### PR TITLE
[draft] handle reorgs

### DIFF
--- a/synchronizer/src/db.rs
+++ b/synchronizer/src/db.rs
@@ -150,6 +150,7 @@ impl Db {
     pub fn rollback_to_slot(&self, keep_slot: Option<u32>) -> Result<()> {
         let mut batch = WriteBatch::default();
 
+        // Remove any derived records written after the retained canonical slot.
         for entry in self.db.iterator(IteratorMode::Start) {
             let (key, value) = entry?;
             if key.starts_with(TX_PREFIX) || key.starts_with(NULLIFIER_PREFIX) {
@@ -174,6 +175,7 @@ impl Db {
             }
         }
 
+        // Move sync cursor back to the retained slot (or reset completely).
         match keep_slot {
             Some(keep) => {
                 batch.put(SYNC_SLOT_KEY, keep.to_be_bytes());

--- a/synchronizer/src/db.rs
+++ b/synchronizer/src/db.rs
@@ -1,11 +1,13 @@
 use std::{collections::HashSet, sync::Arc};
 
+use alloy::primitives::B256;
 use anyhow::{Context, Result};
 use rocksdb::{IteratorMode, Options, WriteBatch, DB};
 use serde::{Deserialize, Serialize};
 
 const SYNC_SLOT_KEY: &[u8] = b"sync:last_processed_slot";
 const SYNC_BLOCK_KEY: &[u8] = b"sync:last_processed_block_number";
+const SLOT_ROOT_PREFIX: &[u8] = b"slot_root:";
 const TX_PREFIX: &[u8] = b"tx:";
 const NULLIFIER_PREFIX: &[u8] = b"nullifier:";
 
@@ -101,6 +103,26 @@ impl Db {
         Ok(())
     }
 
+    pub fn set_slot_root(&self, slot: u32, root: Option<B256>) -> Result<()> {
+        let key = slot_root_key(slot);
+        match root {
+            Some(root) => self.db.put(key, root.as_slice())?,
+            None => self.db.delete(key)?,
+        }
+        Ok(())
+    }
+
+    pub fn slot_root(&self, slot: u32) -> Result<Option<B256>> {
+        let Some(bytes) = self.db.get(slot_root_key(slot))? else {
+            return Ok(None);
+        };
+        let raw: &[u8] = bytes.as_ref();
+        let arr: [u8; 32] = raw
+            .try_into()
+            .map_err(|_| anyhow::anyhow!("invalid stored slot root bytes"))?;
+        Ok(Some(B256::from(arr)))
+    }
+
     pub fn persist_transaction(
         &self,
         object_id: &str,
@@ -124,6 +146,48 @@ impl Db {
         self.db.put(key, value)?;
         Ok(())
     }
+
+    pub fn rollback_to_slot(&self, keep_slot: Option<u32>) -> Result<()> {
+        let mut batch = WriteBatch::default();
+
+        for entry in self.db.iterator(IteratorMode::Start) {
+            let (key, value) = entry?;
+            if key.starts_with(TX_PREFIX) || key.starts_with(NULLIFIER_PREFIX) {
+                let should_delete = match keep_slot {
+                    Some(keep) => match serde_json::from_slice::<SeenAt>(&value) {
+                        Ok(seen_at) => seen_at.slot > keep,
+                        Err(_) => true,
+                    },
+                    None => true,
+                };
+                if should_delete {
+                    batch.delete(key);
+                }
+            } else if key.starts_with(SLOT_ROOT_PREFIX) {
+                let should_delete = match keep_slot {
+                    Some(keep) => slot_root_key_slot(&key).is_none_or(|slot| slot > keep),
+                    None => true,
+                };
+                if should_delete {
+                    batch.delete(key);
+                }
+            }
+        }
+
+        match keep_slot {
+            Some(keep) => {
+                batch.put(SYNC_SLOT_KEY, keep.to_be_bytes());
+                batch.delete(SYNC_BLOCK_KEY);
+            }
+            None => {
+                batch.delete(SYNC_SLOT_KEY);
+                batch.delete(SYNC_BLOCK_KEY);
+            }
+        }
+
+        self.db.write(batch)?;
+        Ok(())
+    }
 }
 
 fn tx_key(id: &str) -> Vec<u8> {
@@ -132,6 +196,16 @@ fn tx_key(id: &str) -> Vec<u8> {
 
 fn nullifier_key(id: &str) -> Vec<u8> {
     [NULLIFIER_PREFIX, id.as_bytes()].concat()
+}
+
+fn slot_root_key(slot: u32) -> Vec<u8> {
+    [SLOT_ROOT_PREFIX, &slot.to_be_bytes()].concat()
+}
+
+fn slot_root_key_slot(key: &[u8]) -> Option<u32> {
+    let raw = key.strip_prefix(SLOT_ROOT_PREFIX)?;
+    let arr: [u8; 4] = raw.try_into().ok()?;
+    Some(u32::from_be_bytes(arr))
 }
 
 fn decode_u32(bytes: &[u8]) -> Result<u32> {

--- a/synchronizer/src/node.rs
+++ b/synchronizer/src/node.rs
@@ -95,6 +95,26 @@ impl Node {
         self.db.mark_slot_processed(slot, block_number)
     }
 
+    pub fn set_slot_root(&self, slot: u32, root: Option<B256>) -> Result<()> {
+        self.db.set_slot_root(slot, root)
+    }
+
+    pub fn slot_root(&self, slot: u32) -> Result<Option<B256>> {
+        self.db.slot_root(slot)
+    }
+
+    pub fn rollback_to_slot(&self, keep_slot: Option<u32>) -> Result<()> {
+        self.db.rollback_to_slot(keep_slot)?;
+        let DerivedState {
+            transactions,
+            nullifiers,
+        } = self.db.load_state()?;
+        let mut state = self.write_state()?;
+        state.transactions = transactions;
+        state.nullifiers = nullifiers;
+        Ok(())
+    }
+
     async fn get_blobs(&self, slot: u32, versioned_hashes: &[B256]) -> Result<HashMap<B256, Blob>> {
         let blobs = self.beacon_cli.get_blobs(slot.into()).await?;
         debug!(slot, blob_count = blobs.len(), "Fetched blobs from beacon");

--- a/synchronizer/src/state.rs
+++ b/synchronizer/src/state.rs
@@ -1,4 +1,7 @@
-use std::{collections::HashSet, sync::RwLockReadGuard};
+use std::{
+    collections::HashSet,
+    sync::{RwLockReadGuard, RwLockWriteGuard},
+};
 
 use alloy::eips::eip4844::FIELD_ELEMENT_BYTES_USIZE;
 use anyhow::{anyhow, Context, Result};
@@ -18,6 +21,12 @@ impl Node {
         self.state
             .read()
             .map_err(|e| anyhow!("state read lock poisoned: {e}"))
+    }
+
+    pub(super) fn write_state(&self) -> Result<RwLockWriteGuard<'_, State>> {
+        self.state
+            .write()
+            .map_err(|e| anyhow!("state write lock poisoned: {e}"))
     }
 
     pub fn state_snapshot(&self) -> Result<(Vec<String>, Vec<String>)> {

--- a/synchronizer/src/sync_loop.rs
+++ b/synchronizer/src/sync_loop.rs
@@ -10,7 +10,6 @@ use tracing::{debug, info, warn};
 use crate::node::Node;
 
 const HEAD_CHECK_INTERVAL: Duration = Duration::from_secs(12);
-const REORG_REWIND_SLOTS: u32 = 32;
 
 enum SlotHeaderState {
     Shutdown,
@@ -71,7 +70,7 @@ pub async fn run_sync_loop(
                         slot = next_slot,
                         "Detected reorg: slot was previously canonical but is now missing; rewinding"
                     );
-                    next_slot = rewind_for_reorg(&node, next_slot)?;
+                    next_slot = rewind_for_reorg(&node, next_slot).await?;
                     continue;
                 }
                 info!(slot = next_slot, "No block produced for slot");
@@ -91,7 +90,7 @@ pub async fn run_sync_loop(
                     fetched_root = ?beacon_block_header.root,
                     "Detected reorg: canonical root changed for slot; rewinding"
                 );
-                next_slot = rewind_for_reorg(&node, next_slot)?;
+                next_slot = rewind_for_reorg(&node, next_slot).await?;
                 continue;
             }
         }
@@ -104,7 +103,7 @@ pub async fn run_sync_loop(
                         actual_parent = ?beacon_block_header.parent_root,
                         "Detected reorg: parent linkage mismatch; rewinding"
                     );
-                    next_slot = rewind_for_reorg(&node, next_slot)?;
+                    next_slot = rewind_for_reorg(&node, next_slot).await?;
                     continue;
                 }
             }
@@ -126,15 +125,32 @@ pub async fn run_sync_loop(
     }
 }
 
-fn rewind_for_reorg(node: &Node, current_slot: u32) -> Result<u32> {
-    let rewind_start = current_slot.saturating_sub(REORG_REWIND_SLOTS);
+async fn rewind_for_reorg(node: &Node, current_slot: u32) -> Result<u32> {
+    let rewind_start = find_divergence_slot(node, current_slot).await?;
     let keep_slot = rewind_start.checked_sub(1);
     node.rollback_to_slot(keep_slot)?;
     info!(
         current_slot,
-        rewind_start, keep_slot, "Rewound state to recover from reorg"
+        rewind_start, keep_slot, "Rewound state to divergence boundary"
     );
     Ok(rewind_start)
+}
+
+async fn find_divergence_slot(node: &Node, current_slot: u32) -> Result<u32> {
+    let mut slot = current_slot;
+    while let Some(prev_slot) = slot.checked_sub(1) {
+        let stored_root = node.slot_root(prev_slot)?;
+        let live_root = node
+            .beacon_cli
+            .get_block_header(BlockId::Slot(prev_slot))
+            .await?
+            .map(|header| header.root);
+        if stored_root == live_root {
+            return Ok(prev_slot + 1);
+        }
+        slot = prev_slot;
+    }
+    Ok(0)
 }
 
 async fn initialize_sync(node: &Node, initial_start_slot: Option<u32>) -> Result<SyncStart> {

--- a/synchronizer/src/sync_loop.rs
+++ b/synchronizer/src/sync_loop.rs
@@ -10,6 +10,7 @@ use tracing::{debug, info, warn};
 use crate::node::Node;
 
 const HEAD_CHECK_INTERVAL: Duration = Duration::from_secs(12);
+const REORG_REWIND_SLOTS: u32 = 32;
 
 enum SlotHeaderState {
     Shutdown,
@@ -65,8 +66,16 @@ pub async fn run_sync_loop(
                 return Ok(());
             }
             SlotHeaderState::Missing => {
-                // Empty slots are valid on beacon; persist progress so sync stays in-order.
+                if node.slot_root(next_slot)?.is_some() {
+                    warn!(
+                        slot = next_slot,
+                        "Detected reorg: slot was previously canonical but is now missing; rewinding"
+                    );
+                    next_slot = rewind_for_reorg(&node, next_slot)?;
+                    continue;
+                }
                 info!(slot = next_slot, "No block produced for slot");
+                node.set_slot_root(next_slot, None)?;
                 node.mark_slot_processed(next_slot, None)?;
                 next_slot += 1;
                 continue;
@@ -74,10 +83,38 @@ pub async fn run_sync_loop(
             SlotHeaderState::Present(header) => header,
         };
 
+        if let Some(stored_root) = node.slot_root(next_slot)? {
+            if stored_root != beacon_block_header.root {
+                warn!(
+                    slot = next_slot,
+                    stored_root = ?stored_root,
+                    fetched_root = ?beacon_block_header.root,
+                    "Detected reorg: canonical root changed for slot; rewinding"
+                );
+                next_slot = rewind_for_reorg(&node, next_slot)?;
+                continue;
+            }
+        }
+        if let Some(prev_slot) = next_slot.checked_sub(1) {
+            if let Some(prev_root) = node.slot_root(prev_slot)? {
+                if beacon_block_header.parent_root != prev_root {
+                    warn!(
+                        slot = next_slot,
+                        expected_parent = ?prev_root,
+                        actual_parent = ?beacon_block_header.parent_root,
+                        "Detected reorg: parent linkage mismatch; rewinding"
+                    );
+                    next_slot = rewind_for_reorg(&node, next_slot)?;
+                    continue;
+                }
+            }
+        }
+
         let block_number = node
             .process_beacon_block_header(&beacon_block_header)
             .await?;
 
+        node.set_slot_root(next_slot, Some(beacon_block_header.root))?;
         node.mark_slot_processed(next_slot, block_number)?;
 
         if wait_or_shutdown(sync_delay, &mut shutdown_rx).await {
@@ -87,6 +124,17 @@ pub async fn run_sync_loop(
 
         next_slot += 1;
     }
+}
+
+fn rewind_for_reorg(node: &Node, current_slot: u32) -> Result<u32> {
+    let rewind_start = current_slot.saturating_sub(REORG_REWIND_SLOTS);
+    let keep_slot = rewind_start.checked_sub(1);
+    node.rollback_to_slot(keep_slot)?;
+    info!(
+        current_slot,
+        rewind_start, keep_slot, "Rewound state to recover from reorg"
+    );
+    Ok(rewind_start)
 }
 
 async fn initialize_sync(node: &Node, initial_start_slot: Option<u32>) -> Result<SyncStart> {
@@ -198,14 +246,21 @@ impl HeadTracker {
                     }
                 }
                 Some(Err(err)) => {
-                    warn!(?err, target_slot = slot, "Beacon event stream error; reconnecting");
+                    warn!(
+                        ?err,
+                        target_slot = slot,
+                        "Beacon event stream error; reconnecting"
+                    );
                     self.events = None;
                     if wait_or_shutdown(Duration::from_secs(1), shutdown_rx).await {
                         return Ok(SlotHeaderState::Shutdown);
                     }
                 }
                 None => {
-                    warn!(target_slot = slot, "Beacon event stream ended; reconnecting");
+                    warn!(
+                        target_slot = slot,
+                        "Beacon event stream ended; reconnecting"
+                    );
                     self.events = None;
                     if wait_or_shutdown(Duration::from_secs(1), shutdown_rx).await {
                         return Ok(SlotHeaderState::Shutdown);
@@ -230,7 +285,11 @@ impl HeadTracker {
         }
 
         // Head passed target: explicit target lookup distinguishes produced vs skipped slot.
-        debug!(head_slot = self.head.slot, target_slot = slot, "Target slot behind head; fetching explicit slot header");
+        debug!(
+            head_slot = self.head.slot,
+            target_slot = slot,
+            "Target slot behind head; fetching explicit slot header"
+        );
         Ok(
             match node
                 .beacon_cli

--- a/synchronizer/src/sync_loop.rs
+++ b/synchronizer/src/sync_loop.rs
@@ -65,6 +65,7 @@ pub async fn run_sync_loop(
                 return Ok(());
             }
             SlotHeaderState::Missing => {
+                // A previously canonical slot becoming empty implies canonical history changed.
                 if node.slot_root(next_slot)?.is_some() {
                     warn!(
                         slot = next_slot,
@@ -84,6 +85,7 @@ pub async fn run_sync_loop(
         };
 
         if let Some(stored_root) = node.slot_root(next_slot)? {
+            // Same slot number with a different block root is a canonical reorg.
             if stored_root != beacon_block_header.root {
                 warn!(
                     slot = next_slot,
@@ -97,6 +99,7 @@ pub async fn run_sync_loop(
         }
         if let Some(prev_slot) = next_slot.checked_sub(1) {
             if let Some(prev_root) = node.slot_root(prev_slot)? {
+                // Parent mismatch means our local chain view diverged from current canonical chain.
                 if beacon_block_header.parent_root != prev_root {
                     warn!(
                         slot = next_slot,
@@ -127,6 +130,7 @@ pub async fn run_sync_loop(
 }
 
 async fn rewind_for_reorg(node: &Node, current_slot: u32) -> Result<u32> {
+    // Rewind to the first slot after the last matching ancestor, then replay forward.
     let rewind_start = find_divergence_slot(node, current_slot).await?;
     let keep_slot = rewind_start.checked_sub(1);
     node.rollback_to_slot(keep_slot)?;
@@ -140,6 +144,7 @@ async fn rewind_for_reorg(node: &Node, current_slot: u32) -> Result<u32> {
 async fn find_divergence_slot(node: &Node, current_slot: u32) -> Result<u32> {
     let mut slot = current_slot;
     while let Some(prev_slot) = slot.checked_sub(1) {
+        // Walk backward until stored and live roots match (last common ancestor).
         let stored_root = node.slot_root(prev_slot)?;
         let live_root = node
             .beacon_cli

--- a/synchronizer/src/sync_loop.rs
+++ b/synchronizer/src/sync_loop.rs
@@ -73,6 +73,7 @@ pub async fn run_sync_loop(
                     next_slot = rewind_for_reorg(&node, next_slot).await?;
                     continue;
                 }
+                // Empty slots are valid on beacon; persist progress so sync stays in-order.
                 info!(slot = next_slot, "No block produced for slot");
                 node.set_slot_root(next_slot, None)?;
                 node.mark_slot_processed(next_slot, None)?;


### PR DESCRIPTION
## Reorg Handling

The synchronizer tracks canonical beacon roots per slot (`slot_root:<slot>`) and checks them while syncing.

Reorg is detected when any of these happen:

- a slot that previously had a root is now missing
- stored root for a slot differs from newly fetched root
- fetched header `parent_root` does not match stored root of the previous slot

When detected, it:

1. walks backward to find the last slot where stored root matches live root
2. rewinds DB state to just before divergence
3. replays forward from the divergence slot

Rollback removes:

- tx/nullifier entries seen after the retained slot
- stored slot-root entries after the retained slot
- sync progress after the retained slot