### PR TITLE
handle reorgs

### DIFF
--- a/synchronizer/src/config.rs
+++ b/synchronizer/src/config.rs
@@ -19,6 +19,8 @@ pub struct AppConfig {
 }
 
 pub fn load_config() -> Result<AppConfig> {
+    let _ = dotenvy::from_filename("synchronizer/.env");
+
     let db_path = dotenvy::var("DB_PATH").unwrap_or_else(|_| DEFAULT_DB_PATH.to_string());
     let http_bind = dotenvy::var("HTTP_BIND").unwrap_or_else(|_| DEFAULT_HTTP_BIND.to_string());
     let http_bind: SocketAddr = http_bind.parse()?;

--- a/synchronizer/src/db.rs
+++ b/synchronizer/src/db.rs
@@ -1,5 +1,6 @@
 use std::{collections::HashSet, sync::Arc};
 
+use alloy::primitives::B256;
 use anyhow::{Context, Result};
 use hex::{FromHex, ToHex};
 use pod2::middleware::Hash;
@@ -11,6 +12,7 @@ const SYNC_BLOCK_KEY: &[u8] = b"sync:last_processed_block_number";
 const TX_PREFIX: &[u8] = b"tx:";
 const NULLIFIER_PREFIX: &[u8] = b"nullifier:";
 const GSR_PREFIX: &[u8] = b"global_state_root:";
+const SLOT_ROOT_PREFIX: &[u8] = b"slot_root:";
 
 #[derive(Debug)]
 pub struct DerivedState {
@@ -149,6 +151,70 @@ impl Db {
         self.db.put(key, value)?;
         Ok(())
     }
+
+    pub fn set_slot_root(&self, slot: u32, root: Option<B256>) -> Result<()> {
+        let key = slot_root_key(slot);
+        match root {
+            Some(root) => self.db.put(key, root.as_slice())?,
+            None => self.db.delete(key)?,
+        }
+        Ok(())
+    }
+
+    pub fn slot_root(&self, slot: u32) -> Result<Option<B256>> {
+        let Some(bytes) = self.db.get(slot_root_key(slot))? else {
+            return Ok(None);
+        };
+        let raw: &[u8] = bytes.as_ref();
+        let arr: [u8; 32] = raw
+            .try_into()
+            .map_err(|_| anyhow::anyhow!("invalid stored slot root bytes"))?;
+        Ok(Some(B256::from(arr)))
+    }
+
+    pub fn rollback_to_slot(&self, keep_slot: Option<u32>) -> Result<()> {
+        let mut batch = WriteBatch::default();
+
+        // Remove any derived records written after the retained canonical slot.
+        for entry in self.db.iterator(IteratorMode::Start) {
+            let (key, value) = entry?;
+            if key.starts_with(TX_PREFIX) || key.starts_with(NULLIFIER_PREFIX) {
+                let should_delete = match keep_slot {
+                    Some(keep) => match serde_json::from_slice::<SeenAt>(&value) {
+                        Ok(seen_at) => seen_at.slot > keep,
+                        Err(_) => true,
+                    },
+                    None => true,
+                };
+                if should_delete {
+                    batch.delete(key);
+                }
+            } else if key.starts_with(SLOT_ROOT_PREFIX) {
+                let should_delete = match keep_slot {
+                    Some(keep) => slot_root_key_slot(&key).is_none_or(|slot| slot > keep),
+                    None => true,
+                };
+                if should_delete {
+                    batch.delete(key);
+                }
+            }
+        }
+
+        // Move sync cursor back to the retained slot (or reset completely).
+        match keep_slot {
+            Some(keep) => {
+                batch.put(SYNC_SLOT_KEY, keep.to_be_bytes());
+                batch.delete(SYNC_BLOCK_KEY);
+            }
+            None => {
+                batch.delete(SYNC_SLOT_KEY);
+                batch.delete(SYNC_BLOCK_KEY);
+            }
+        }
+
+        self.db.write(batch)?;
+        Ok(())
+    }
 }
 
 fn tx_key(hash: Hash) -> Vec<u8> {
@@ -163,6 +229,16 @@ fn gsr_key(block_number: i64) -> Vec<u8> {
     // Use block_number as u64 big-endian for lexicographic ordering
     let block_u64 = block_number as u64;
     [GSR_PREFIX, &block_u64.to_be_bytes()].concat()
+}
+
+fn slot_root_key(slot: u32) -> Vec<u8> {
+    [SLOT_ROOT_PREFIX, &slot.to_be_bytes()].concat()
+}
+
+fn slot_root_key_slot(key: &[u8]) -> Option<u32> {
+    let raw = key.strip_prefix(SLOT_ROOT_PREFIX)?;
+    let arr: [u8; 4] = raw.try_into().ok()?;
+    Some(u32::from_be_bytes(arr))
 }
 
 /// Serialize a Hash to 32 raw bytes for RocksDB storage.

--- a/synchronizer/src/db.rs
+++ b/synchronizer/src/db.rs
@@ -33,13 +33,6 @@ struct SeenAt {
     block_number: Option<u32>,
 }
 
-#[derive(Debug, Clone, Copy)]
-struct GsrSeenAt {
-    slot: u32,
-    block_number: u32,
-    hash: Hash,
-}
-
 pub struct Db {
     db: Arc<DB>,
 }
@@ -71,10 +64,10 @@ impl Db {
                     nullifiers.insert(hash);
                 }
             } else if key.starts_with(GSR_PREFIX) {
-                if let (Some(block_number), Some(record)) =
+                if let (Some(block_number), Some((_slot, hash))) =
                     (gsr_key_block(&key), decode_gsr_value(&value))
                 {
-                    gsr_entries.push((block_number, record.hash));
+                    gsr_entries.push((block_number, hash));
                 }
             }
         }
@@ -157,11 +150,7 @@ impl Db {
         hash: Hash,
     ) -> Result<()> {
         let key = gsr_key(block_number);
-        let value = encode_gsr_value(GsrSeenAt {
-            slot,
-            block_number,
-            hash,
-        });
+        let value = encode_gsr_value(slot, hash);
         self.db.put(key, value)?;
         Ok(())
     }
@@ -206,7 +195,7 @@ impl Db {
             } else if key.starts_with(GSR_PREFIX) {
                 let should_delete = match keep_slot {
                     Some(keep) => match decode_gsr_value(&value) {
-                        Some(record) => record.slot > keep,
+                        Some((slot, _hash)) => slot > keep,
                         None => true,
                     },
                     None => true,
@@ -270,26 +259,20 @@ fn slot_root_key_slot(key: &[u8]) -> Option<u32> {
     Some(u32::from_be_bytes(arr))
 }
 
-fn encode_gsr_value(record: GsrSeenAt) -> Vec<u8> {
-    let mut out = Vec::with_capacity(40);
-    out.extend_from_slice(&record.slot.to_be_bytes());
-    out.extend_from_slice(&record.block_number.to_be_bytes());
-    out.extend_from_slice(&hash_to_db_bytes(record.hash));
+fn encode_gsr_value(slot: u32, hash: Hash) -> Vec<u8> {
+    let mut out = Vec::with_capacity(36);
+    out.extend_from_slice(&slot.to_be_bytes());
+    out.extend_from_slice(&hash_to_db_bytes(hash));
     out
 }
 
-fn decode_gsr_value(bytes: &[u8]) -> Option<GsrSeenAt> {
-    if bytes.len() != 40 {
+fn decode_gsr_value(bytes: &[u8]) -> Option<(u32, Hash)> {
+    if bytes.len() != 36 {
         return None;
     }
     let slot = u32::from_be_bytes(bytes[0..4].try_into().ok()?);
-    let block_number = u32::from_be_bytes(bytes[4..8].try_into().ok()?);
-    let hash = db_bytes_to_hash(&bytes[8..40]).ok()?;
-    Some(GsrSeenAt {
-        slot,
-        block_number,
-        hash,
-    })
+    let hash = db_bytes_to_hash(&bytes[4..36]).ok()?;
+    Some((slot, hash))
 }
 
 /// Serialize a Hash to 32 raw bytes for RocksDB storage.

--- a/synchronizer/src/db.rs
+++ b/synchronizer/src/db.rs
@@ -301,6 +301,7 @@ fn decode_u32(bytes: &[u8]) -> Result<u32> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloy::primitives::B256;
     use pod2::middleware::{hash_values, Value, EMPTY_HASH};
     use tempfile::TempDir;
 
@@ -360,5 +361,66 @@ mod tests {
 
         let state = db.load_state().unwrap();
         assert_eq!(state.global_state_roots, vec![h1]);
+    }
+
+    #[test]
+    fn test_rollback_to_slot_prunes_all_reorg_sensitive_state() {
+        let (db, _dir) = open_test_db();
+        let tx1 = hash_values(&[Value::from(11)]);
+        let tx2 = hash_values(&[Value::from(12)]);
+        let n1 = hash_values(&[Value::from(21)]);
+        let n2 = hash_values(&[Value::from(22)]);
+        let g1 = hash_values(&[Value::from(31)]);
+        let g2 = hash_values(&[Value::from(32)]);
+        let root1 = B256::from([1u8; 32]);
+        let root2 = B256::from([2u8; 32]);
+
+        db.persist_transaction(tx1, 1, Some(101)).unwrap();
+        db.persist_transaction(tx2, 2, Some(102)).unwrap();
+        db.persist_nullifier(n1, 1, Some(101)).unwrap();
+        db.persist_nullifier(n2, 2, Some(102)).unwrap();
+        db.persist_global_state_root(1, 101, g1).unwrap();
+        db.persist_global_state_root(2, 102, g2).unwrap();
+        db.set_slot_root(1, Some(root1)).unwrap();
+        db.set_slot_root(2, Some(root2)).unwrap();
+        db.mark_slot_processed(2, Some(102)).unwrap();
+
+        db.rollback_to_slot(Some(1)).unwrap();
+
+        let state = db.load_state().unwrap();
+        assert!(state.transactions.contains(&tx1));
+        assert!(!state.transactions.contains(&tx2));
+        assert!(state.nullifiers.contains(&n1));
+        assert!(!state.nullifiers.contains(&n2));
+        assert_eq!(state.global_state_roots, vec![g1]);
+        assert_eq!(db.slot_root(1).unwrap(), Some(root1));
+        assert_eq!(db.slot_root(2).unwrap(), None);
+
+        let progress = db.last_progress().unwrap().expect("progress exists");
+        assert_eq!(progress.last_processed_slot, 1);
+        assert_eq!(progress.last_processed_block_number, None);
+    }
+
+    #[test]
+    fn test_rollback_to_none_resets_all_state() {
+        let (db, _dir) = open_test_db();
+        let tx = hash_values(&[Value::from(11)]);
+        let n = hash_values(&[Value::from(21)]);
+        let g = hash_values(&[Value::from(31)]);
+
+        db.persist_transaction(tx, 1, Some(101)).unwrap();
+        db.persist_nullifier(n, 1, Some(101)).unwrap();
+        db.persist_global_state_root(1, 101, g).unwrap();
+        db.set_slot_root(1, Some(B256::from([1u8; 32]))).unwrap();
+        db.mark_slot_processed(1, Some(101)).unwrap();
+
+        db.rollback_to_slot(None).unwrap();
+
+        let state = db.load_state().unwrap();
+        assert!(state.transactions.is_empty());
+        assert!(state.nullifiers.is_empty());
+        assert!(state.global_state_roots.is_empty());
+        assert_eq!(db.slot_root(1).unwrap(), None);
+        assert!(db.last_progress().unwrap().is_none());
     }
 }

--- a/synchronizer/src/db.rs
+++ b/synchronizer/src/db.rs
@@ -33,6 +33,13 @@ struct SeenAt {
     block_number: Option<u32>,
 }
 
+#[derive(Debug, Clone, Copy)]
+struct GsrSeenAt {
+    slot: u32,
+    block_number: u32,
+    hash: Hash,
+}
+
 pub struct Db {
     db: Arc<DB>,
 }
@@ -49,7 +56,7 @@ impl Db {
     pub fn load_state(&self) -> Result<DerivedState> {
         let mut transactions = HashSet::new();
         let mut nullifiers = HashSet::new();
-        let mut gsr_entries: Vec<(u64, Hash)> = Vec::new();
+        let mut gsr_entries: Vec<(u32, Hash)> = Vec::new();
 
         for entry in self.db.iterator(IteratorMode::Start) {
             let (key, value) = entry?;
@@ -64,12 +71,10 @@ impl Db {
                     nullifiers.insert(hash);
                 }
             } else if key.starts_with(GSR_PREFIX) {
-                let block_bytes = &key[GSR_PREFIX.len()..];
-                if block_bytes.len() == 8 {
-                    let block_number = u64::from_be_bytes(block_bytes.try_into().expect("8 bytes"));
-                    if let Ok(hash) = db_bytes_to_hash(&value) {
-                        gsr_entries.push((block_number, hash));
-                    }
+                if let (Some(block_number), Some(record)) =
+                    (gsr_key_block(&key), decode_gsr_value(&value))
+                {
+                    gsr_entries.push((block_number, record.hash));
                 }
             }
         }
@@ -145,9 +150,18 @@ impl Db {
         Ok(())
     }
 
-    pub fn persist_global_state_root(&self, block_number: i64, hash: Hash) -> Result<()> {
+    pub fn persist_global_state_root(
+        &self,
+        slot: u32,
+        block_number: u32,
+        hash: Hash,
+    ) -> Result<()> {
         let key = gsr_key(block_number);
-        let value = hash_to_db_bytes(hash);
+        let value = encode_gsr_value(GsrSeenAt {
+            slot,
+            block_number,
+            hash,
+        });
         self.db.put(key, value)?;
         Ok(())
     }
@@ -183,6 +197,17 @@ impl Db {
                     Some(keep) => match serde_json::from_slice::<SeenAt>(&value) {
                         Ok(seen_at) => seen_at.slot > keep,
                         Err(_) => true,
+                    },
+                    None => true,
+                };
+                if should_delete {
+                    batch.delete(key);
+                }
+            } else if key.starts_with(GSR_PREFIX) {
+                let should_delete = match keep_slot {
+                    Some(keep) => match decode_gsr_value(&value) {
+                        Some(record) => record.slot > keep,
+                        None => true,
                     },
                     None => true,
                 };
@@ -225,10 +250,14 @@ fn nullifier_key(hash: Hash) -> Vec<u8> {
     [NULLIFIER_PREFIX, &hash_to_db_bytes(hash)].concat()
 }
 
-fn gsr_key(block_number: i64) -> Vec<u8> {
-    // Use block_number as u64 big-endian for lexicographic ordering
-    let block_u64 = block_number as u64;
-    [GSR_PREFIX, &block_u64.to_be_bytes()].concat()
+fn gsr_key(block_number: u32) -> Vec<u8> {
+    [GSR_PREFIX, &block_number.to_be_bytes()].concat()
+}
+
+fn gsr_key_block(key: &[u8]) -> Option<u32> {
+    let raw = key.strip_prefix(GSR_PREFIX)?;
+    let arr: [u8; 4] = raw.try_into().ok()?;
+    Some(u32::from_be_bytes(arr))
 }
 
 fn slot_root_key(slot: u32) -> Vec<u8> {
@@ -239,6 +268,28 @@ fn slot_root_key_slot(key: &[u8]) -> Option<u32> {
     let raw = key.strip_prefix(SLOT_ROOT_PREFIX)?;
     let arr: [u8; 4] = raw.try_into().ok()?;
     Some(u32::from_be_bytes(arr))
+}
+
+fn encode_gsr_value(record: GsrSeenAt) -> Vec<u8> {
+    let mut out = Vec::with_capacity(40);
+    out.extend_from_slice(&record.slot.to_be_bytes());
+    out.extend_from_slice(&record.block_number.to_be_bytes());
+    out.extend_from_slice(&hash_to_db_bytes(record.hash));
+    out
+}
+
+fn decode_gsr_value(bytes: &[u8]) -> Option<GsrSeenAt> {
+    if bytes.len() != 40 {
+        return None;
+    }
+    let slot = u32::from_be_bytes(bytes[0..4].try_into().ok()?);
+    let block_number = u32::from_be_bytes(bytes[4..8].try_into().ok()?);
+    let hash = db_bytes_to_hash(&bytes[8..40]).ok()?;
+    Some(GsrSeenAt {
+        slot,
+        block_number,
+        hash,
+    })
 }
 
 /// Serialize a Hash to 32 raw bytes for RocksDB storage.
@@ -267,7 +318,7 @@ fn decode_u32(bytes: &[u8]) -> Result<u32> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use pod2::middleware::EMPTY_HASH;
+    use pod2::middleware::{hash_values, Value, EMPTY_HASH};
     use tempfile::TempDir;
 
     fn open_test_db() -> (Db, TempDir) {
@@ -301,12 +352,30 @@ mod tests {
         let (db, _dir) = open_test_db();
 
         // Persist out of order to verify ordering
-        let h0 = EMPTY_HASH;
-        db.persist_global_state_root(10, h0).unwrap();
-        db.persist_global_state_root(5, h0).unwrap();
-        db.persist_global_state_root(20, h0).unwrap();
+        let h0 = hash_values(&[Value::from(0)]);
+        let h1 = hash_values(&[Value::from(1)]);
+        let h2 = hash_values(&[Value::from(2)]);
+        db.persist_global_state_root(10, 10, h0).unwrap();
+        db.persist_global_state_root(5, 5, h1).unwrap();
+        db.persist_global_state_root(20, 20, h2).unwrap();
 
         let state = db.load_state().unwrap();
-        assert_eq!(state.global_state_roots.len(), 3);
+        assert_eq!(state.global_state_roots, vec![h1, h0, h2]);
+    }
+
+    #[test]
+    fn test_rollback_removes_gsrs_after_keep_slot() {
+        let (db, _dir) = open_test_db();
+        let h1 = hash_values(&[Value::from(1)]);
+        let h2 = hash_values(&[Value::from(2)]);
+        let h3 = hash_values(&[Value::from(3)]);
+        db.persist_global_state_root(1, 1, h1).unwrap();
+        db.persist_global_state_root(2, 2, h2).unwrap();
+        db.persist_global_state_root(3, 3, h3).unwrap();
+
+        db.rollback_to_slot(Some(1)).unwrap();
+
+        let state = db.load_state().unwrap();
+        assert_eq!(state.global_state_roots, vec![h1]);
     }
 }

--- a/synchronizer/src/node.rs
+++ b/synchronizer/src/node.rs
@@ -185,7 +185,8 @@ impl Node {
 
         if !slot_ctx.has_blob_commitments {
             debug!(slot = slot_ctx.slot, "Slot has no blob commitments");
-            self.state_machine.advance_block(block_number as i64)?;
+            self.state_machine
+                .advance_block(slot_ctx.slot, block_number)?;
             return Ok(Some(block_number));
         }
 
@@ -227,7 +228,8 @@ impl Node {
                 to_address = ?self.config.to_address,
                 "No matching target blob transactions in execution block"
             );
-            self.state_machine.advance_block(block_number as i64)?;
+            self.state_machine
+                .advance_block(slot_ctx.slot, block_number)?;
             return Ok(Some(block_number));
         }
 
@@ -281,7 +283,8 @@ impl Node {
             }
         }
 
-        self.state_machine.advance_block(block_number as i64)?;
+        self.state_machine
+            .advance_block(slot_ctx.slot, block_number)?;
         Ok(Some(block_number))
     }
 }

--- a/synchronizer/src/node.rs
+++ b/synchronizer/src/node.rs
@@ -77,6 +77,18 @@ impl Node {
         self.state_machine.mark_slot_processed(slot, block_number)
     }
 
+    pub fn set_slot_root(&self, slot: u32, root: Option<B256>) -> Result<()> {
+        self.state_machine.set_slot_root(slot, root)
+    }
+
+    pub fn slot_root(&self, slot: u32) -> Result<Option<B256>> {
+        self.state_machine.slot_root(slot)
+    }
+
+    pub fn rollback_to_slot(&self, keep_slot: Option<u32>) -> Result<()> {
+        self.state_machine.rollback_to_slot(keep_slot)
+    }
+
     async fn get_blobs(&self, slot: u32, versioned_hashes: &[B256]) -> Result<HashMap<B256, Blob>> {
         let blobs = self.beacon_cli.get_blobs(slot.into()).await?;
         debug!(slot, blob_count = blobs.len(), "Fetched blobs from beacon");

--- a/synchronizer/src/state_machine.rs
+++ b/synchronizer/src/state_machine.rs
@@ -435,6 +435,35 @@ mod tests {
     }
 
     #[test]
+    fn test_reorg_rollback_restores_in_memory_sets() {
+        let (sm, _dir) = make_sm();
+        sm.advance_block(0, 0).unwrap();
+        let gsr0 = sm.state_snapshot().unwrap().2[0];
+
+        let tx1 = unique_hash(101);
+        let n1 = unique_hash(201);
+        sm.process_blob(&mock_txn_bytes(tx1, &[n1], gsr0), 1, Some(1))
+            .unwrap();
+        sm.advance_block(1, 1).unwrap();
+        let gsr1 = sm.state_snapshot().unwrap().2[1];
+
+        let tx2 = unique_hash(102);
+        let n2 = unique_hash(202);
+        sm.process_blob(&mock_txn_bytes(tx2, &[n2], gsr1), 2, Some(2))
+            .unwrap();
+        sm.advance_block(2, 2).unwrap();
+
+        sm.rollback_to_slot(Some(1)).unwrap();
+
+        let (txns, nullifiers, gsrs) = sm.state_snapshot().unwrap();
+        assert!(txns.contains(&tx1));
+        assert!(!txns.contains(&tx2));
+        assert!(nullifiers.contains(&n1));
+        assert!(!nullifiers.contains(&n2));
+        assert_eq!(gsrs.len(), 2);
+    }
+
+    #[test]
     #[ignore = "slow: requires Plonky2 proving (builds circuit on first run, cached thereafter)"]
     fn test_e2e_real_proof() {
         use common::{

--- a/synchronizer/src/state_machine.rs
+++ b/synchronizer/src/state_machine.rs
@@ -146,20 +146,22 @@ impl StateMachine {
     /// Must be called exactly once per block, **after** all blobs for that block have been
     /// processed. The new GSR commits to the accumulated set of transaction commitments and
     /// nullifiers so far, so subsequent provers can reference it as their `state_root_hash`.
-    pub fn advance_block(&self, block_number: i64) -> Result<()> {
+    pub fn advance_block(&self, slot: u32, block_number: u32) -> Result<()> {
         let mut state = self.write_state()?;
 
         let new_gsr = StateRoot::new(
-            block_number,
+            block_number as i64,
             &state.transactions,
             &state.nullifiers,
             &state.global_state_roots,
         )
         .hash();
         state.global_state_roots.push(new_gsr);
-        self.db.persist_global_state_root(block_number, new_gsr)?;
+        self.db
+            .persist_global_state_root(slot, block_number, new_gsr)?;
 
         info!(
+            slot,
             block_number,
             gsr_count = state.global_state_roots.len(),
             "Computed and persisted new GSR"
@@ -262,7 +264,7 @@ mod tests {
     #[test]
     fn test_happy_path_single_tx() {
         let (sm, _dir) = make_sm();
-        sm.advance_block(0).unwrap();
+        sm.advance_block(0, 0).unwrap();
         let gsr0 = sm.state_snapshot().unwrap().2[0];
 
         let tx_hash = unique_hash(1);
@@ -278,14 +280,14 @@ mod tests {
     #[test]
     fn test_sequence_across_blocks() {
         let (sm, _dir) = make_sm();
-        sm.advance_block(0).unwrap();
+        sm.advance_block(0, 0).unwrap();
         let gsr0 = sm.state_snapshot().unwrap().2[0];
 
         let tx1 = unique_hash(1);
         let null1 = unique_hash(2);
         sm.process_blob(&mock_txn_bytes(tx1, &[null1], gsr0), 1, Some(1))
             .unwrap();
-        sm.advance_block(1).unwrap();
+        sm.advance_block(1, 1).unwrap();
 
         let gsr1 = sm.state_snapshot().unwrap().2[1];
         assert_ne!(gsr0, gsr1);
@@ -294,7 +296,7 @@ mod tests {
         let null2 = unique_hash(4);
         sm.process_blob(&mock_txn_bytes(tx2, &[null2], gsr1), 2, Some(2))
             .unwrap();
-        sm.advance_block(2).unwrap();
+        sm.advance_block(2, 2).unwrap();
 
         let (txns, nullifiers, gsrs) = sm.state_snapshot().unwrap();
         assert!(txns.contains(&tx1));
@@ -307,13 +309,13 @@ mod tests {
     #[test]
     fn test_old_gsr_still_valid() {
         let (sm, _dir) = make_sm();
-        sm.advance_block(0).unwrap();
+        sm.advance_block(0, 0).unwrap();
         let gsr0 = sm.state_snapshot().unwrap().2[0];
 
         let tx1 = unique_hash(1);
         sm.process_blob(&mock_txn_bytes(tx1, &[], gsr0), 1, Some(1))
             .unwrap();
-        sm.advance_block(1).unwrap();
+        sm.advance_block(1, 1).unwrap();
 
         // tx2 is grounded against gsr0, not the newer gsr1 — still valid
         let tx2 = unique_hash(2);
@@ -328,7 +330,7 @@ mod tests {
     #[test]
     fn test_duplicate_tx_rejected() {
         let (sm, _dir) = make_sm();
-        sm.advance_block(0).unwrap();
+        sm.advance_block(0, 0).unwrap();
         let gsr0 = sm.state_snapshot().unwrap().2[0];
 
         let tx_final = unique_hash(1);
@@ -344,7 +346,7 @@ mod tests {
     #[test]
     fn test_duplicate_nullifier_rejected() {
         let (sm, _dir) = make_sm();
-        sm.advance_block(0).unwrap();
+        sm.advance_block(0, 0).unwrap();
         let gsr0 = sm.state_snapshot().unwrap().2[0];
 
         let null = unique_hash(10);
@@ -366,7 +368,7 @@ mod tests {
     #[test]
     fn test_nullifier_collision_is_atomic() {
         let (sm, _dir) = make_sm();
-        sm.advance_block(0).unwrap();
+        sm.advance_block(0, 0).unwrap();
         let gsr0 = sm.state_snapshot().unwrap().2[0];
 
         let spent = unique_hash(10);
@@ -395,7 +397,7 @@ mod tests {
     #[test]
     fn test_unknown_gsr_rejected() {
         let (sm, _dir) = make_sm();
-        sm.advance_block(0).unwrap();
+        sm.advance_block(0, 0).unwrap();
 
         let bogus_gsr = unique_hash(999);
         let tx_final = unique_hash(1);
@@ -409,13 +411,27 @@ mod tests {
     #[test]
     fn test_invalid_blob_skipped() {
         let (sm, _dir) = make_sm();
-        sm.advance_block(0).unwrap();
+        sm.advance_block(0, 0).unwrap();
 
         sm.process_blob(b"not json", 1, Some(1)).unwrap();
 
         let (txns, nullifiers, _) = sm.state_snapshot().unwrap();
         assert!(txns.is_empty());
         assert!(nullifiers.is_empty());
+    }
+
+    #[test]
+    fn test_rollback_reloads_gsrs_from_retained_slot() {
+        let (sm, _dir) = make_sm();
+        sm.advance_block(0, 0).unwrap();
+        sm.advance_block(1, 1).unwrap();
+        sm.advance_block(2, 2).unwrap();
+        assert_eq!(sm.state_snapshot().unwrap().2.len(), 3);
+
+        sm.rollback_to_slot(Some(1)).unwrap();
+
+        let (_, _, gsrs) = sm.state_snapshot().unwrap();
+        assert_eq!(gsrs.len(), 2);
     }
 
     #[test]
@@ -445,7 +461,7 @@ mod tests {
             StateMachine::new(db, Arc::new(crate::proof::ProofParser::new().unwrap())).unwrap();
 
         // Seed GSR0 (empty state).
-        sm.advance_block(0).unwrap();
+        sm.advance_block(0, 0).unwrap();
         let gsr0 = sm.state_snapshot().unwrap().2[0];
 
         // Build a txlib StateRoot matching the empty GSR0 and verify it agrees.

--- a/synchronizer/src/state_machine.rs
+++ b/synchronizer/src/state_machine.rs
@@ -3,6 +3,7 @@ use std::{
     sync::{Arc, RwLock},
 };
 
+use alloy::primitives::B256;
 use anyhow::{anyhow, Result};
 use pod2::middleware::Hash;
 use tracing::{info, warn};
@@ -198,6 +199,28 @@ impl StateMachine {
 
     pub fn mark_slot_processed(&self, slot: u32, block_number: Option<u32>) -> Result<()> {
         self.db.mark_slot_processed(slot, block_number)
+    }
+
+    pub fn set_slot_root(&self, slot: u32, root: Option<B256>) -> Result<()> {
+        self.db.set_slot_root(slot, root)
+    }
+
+    pub fn slot_root(&self, slot: u32) -> Result<Option<B256>> {
+        self.db.slot_root(slot)
+    }
+
+    pub fn rollback_to_slot(&self, keep_slot: Option<u32>) -> Result<()> {
+        self.db.rollback_to_slot(keep_slot)?;
+        let DerivedState {
+            transactions,
+            nullifiers,
+            global_state_roots,
+        } = self.db.load_state()?;
+        let mut state = self.write_state()?;
+        state.transactions = transactions;
+        state.nullifiers = nullifiers;
+        state.global_state_roots = global_state_roots;
+        Ok(())
     }
 }
 

--- a/synchronizer/src/sync_loop.rs
+++ b/synchronizer/src/sync_loop.rs
@@ -85,7 +85,21 @@ pub async fn run_sync_loop(
             SlotHeaderState::Present(header) => header,
         };
 
-        if let Some(stored_root) = node.slot_root(next_slot)? {
+        let last_processed_slot = node.last_processed_slot()?;
+        let stored_root_for_slot = node.slot_root(next_slot)?;
+        if last_processed_slot.is_some_and(|last_slot| last_slot >= next_slot)
+            && stored_root_for_slot.is_none()
+        {
+            // A previously empty canonical slot becoming non-empty implies canonical history changed.
+            warn!(
+                slot = next_slot,
+                "Detected reorg: slot was previously empty but now has a block; rewinding"
+            );
+            next_slot = rewind_for_reorg(&node, next_slot).await?;
+            continue;
+        }
+
+        if let Some(stored_root) = stored_root_for_slot {
             // Same slot number with a different block root is a canonical reorg.
             if stored_root != beacon_block_header.root {
                 warn!(

--- a/synchronizer/src/sync_loop.rs
+++ b/synchronizer/src/sync_loop.rs
@@ -65,8 +65,19 @@ pub async fn run_sync_loop(
                 return Ok(());
             }
             SlotHeaderState::Missing => {
+                // A previously canonical slot becoming empty implies canonical history changed.
+                if node.slot_root(next_slot)?.is_some() {
+                    warn!(
+                        slot = next_slot,
+                        "Detected reorg: slot was previously canonical but is now missing; rewinding"
+                    );
+                    next_slot = rewind_for_reorg(&node, next_slot).await?;
+                    continue;
+                }
+
                 // Empty slots are valid on beacon; persist progress so sync stays in-order.
                 info!(slot = next_slot, "No block produced for slot");
+                node.set_slot_root(next_slot, None)?;
                 node.mark_slot_processed(next_slot, None)?;
                 next_slot += 1;
                 continue;
@@ -74,10 +85,39 @@ pub async fn run_sync_loop(
             SlotHeaderState::Present(header) => header,
         };
 
+        if let Some(stored_root) = node.slot_root(next_slot)? {
+            // Same slot number with a different block root is a canonical reorg.
+            if stored_root != beacon_block_header.root {
+                warn!(
+                    slot = next_slot,
+                    stored_root = ?stored_root,
+                    fetched_root = ?beacon_block_header.root,
+                    "Detected reorg: canonical root changed for slot; rewinding"
+                );
+                next_slot = rewind_for_reorg(&node, next_slot).await?;
+                continue;
+            }
+        }
+        if let Some(prev_slot) = next_slot.checked_sub(1) {
+            if let Some(prev_root) = node.slot_root(prev_slot)? {
+                // Parent mismatch means our local chain view diverged from current canonical chain.
+                if beacon_block_header.parent_root != prev_root {
+                    warn!(
+                        slot = next_slot,
+                        expected_parent = ?prev_root,
+                        actual_parent = ?beacon_block_header.parent_root,
+                        "Detected reorg: parent linkage mismatch; rewinding"
+                    );
+                    next_slot = rewind_for_reorg(&node, next_slot).await?;
+                    continue;
+                }
+            }
+        }
+
         let block_number = node
             .process_beacon_block_header(&beacon_block_header)
             .await?;
-
+        node.set_slot_root(next_slot, Some(beacon_block_header.root))?;
         node.mark_slot_processed(next_slot, block_number)?;
 
         if wait_or_shutdown(sync_delay, &mut shutdown_rx).await {
@@ -87,6 +127,36 @@ pub async fn run_sync_loop(
 
         next_slot += 1;
     }
+}
+
+async fn rewind_for_reorg(node: &Node, current_slot: u32) -> Result<u32> {
+    // Rewind to the first slot after the last matching ancestor, then replay forward.
+    let rewind_start = find_divergence_slot(node, current_slot).await?;
+    let keep_slot = rewind_start.checked_sub(1);
+    node.rollback_to_slot(keep_slot)?;
+    info!(
+        current_slot,
+        rewind_start, keep_slot, "Rewound state to divergence boundary"
+    );
+    Ok(rewind_start)
+}
+
+async fn find_divergence_slot(node: &Node, current_slot: u32) -> Result<u32> {
+    let mut slot = current_slot;
+    while let Some(prev_slot) = slot.checked_sub(1) {
+        // Walk backward until stored and live roots match (last common ancestor).
+        let stored_root = node.slot_root(prev_slot)?;
+        let live_root = node
+            .beacon_cli
+            .get_block_header(BlockId::Slot(prev_slot))
+            .await?
+            .map(|header| header.root);
+        if stored_root == live_root {
+            return Ok(prev_slot + 1);
+        }
+        slot = prev_slot;
+    }
+    Ok(0)
 }
 
 async fn initialize_sync(node: &Node, initial_start_slot: Option<u32>) -> Result<SyncStart> {


### PR DESCRIPTION
## Reorg Handling

The synchronizer tracks canonical beacon roots per slot (`slot_root:<slot>`) and checks them while syncing.

Reorg is detected when any of these happen:

- a slot that previously had a root is now missing
- a slot that was previously processed as empty is now present with a block
- stored root for a slot differs from newly fetched root
- fetched header `parent_root` does not match stored root of the previous slot

When detected, it:

1. walks backward to find the last slot where stored root matches live root
2. rewinds DB state to just before divergence
3. replays forward from the divergence slot

Rollback removes:

- tx/nullifier/gsr entries seen after the retained slot
- stored slot-root entries after the retained slot
- sync progress after the retained slot