### PR TITLE
Add CI

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -1,0 +1,25 @@
+name: Clippy Check
+
+on:
+  pull_request:
+    branches: [main]
+    types: [ready_for_review, opened, synchronize, reopened]
+  push:
+    branches: [main]
+
+jobs:
+  clippy:
+    if: github.event.pull_request.draft == false
+    name: Clippy check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Tauri dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+      - uses: actions/checkout@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          components: clippy
+      - name: Check formatting
+        run: cargo clippy

--- a/.github/workflows/rust_tests.yml
+++ b/.github/workflows/rust_tests.yml
@@ -1,0 +1,23 @@
+name: Rust Tests
+
+on:
+  pull_request:
+    branches: [main]
+    types: [ready_for_review, opened, synchronize, reopened]
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    if: github.event.pull_request.draft == false
+    name: Rust tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Tauri dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+      - uses: actions/checkout@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - name: Run tests
+        run: cargo test --release

--- a/.github/workflows/rustfmt.yml
+++ b/.github/workflows/rustfmt.yml
@@ -1,0 +1,21 @@
+name: Rustfmt Check
+
+on:
+  pull_request:
+    branches: [main]
+    types: [ready_for_review, opened, synchronize, reopened]
+  push:
+    branches: [main]
+
+jobs:
+  rustfmt:
+    if: github.event.pull_request.draft == false
+    name: Rust formatting
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          components: rustfmt
+      - name: Check formatting
+        uses: actions-rust-lang/rustfmt@v1


### PR DESCRIPTION
Closes #19 

These configs are copied from https://github.com/0xPARC/pod2-client. In that repo we also had JavaScript tests for the Tauri UI, and a "release" task which would build the Tauri app for various platforms (Linux, MacOS, Windows). We could copy that across when we want to start automated builds for distribution, but that seems unnecessary at this stage.