### PR TITLE
Port sdk from 10 objects

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1943,7 +1943,7 @@ dependencies = [
  "itertools 0.14.0",
  "log",
  "plonky2",
- "pod2 0.1.0 (git+https://github.com/0xPARC/pod2?rev=cdf227e3530247e07e375daed007cae7d443b4ae)",
+ "pod2 0.1.0 (git+https://github.com/0xPARC/pod2?rev=9993799c08e6e95b11eb016763fcc13f5030293e)",
  "pod2_onchain",
  "time 0.3.47",
  "tracing",
@@ -2105,6 +2105,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "craft_sdk"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "env_logger",
+ "hex",
+ "log",
+ "lt_eq_u256_pod",
+ "plonky2",
+ "pod2 0.1.0 (git+https://github.com/0xPARC/pod2?rev=9993799c08e6e95b11eb016763fcc13f5030293e)",
+ "pod2utils",
+ "rand 0.9.2",
+ "serde",
+ "serde_json",
+ "time 0.3.47",
+ "tinytemplate",
+ "txlib",
+ "vdfpod",
 ]
 
 [[package]]
@@ -4325,6 +4346,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "lt_eq_u256_pod"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "hex",
+ "itertools 0.14.0",
+ "log",
+ "plonky2",
+ "pod2 0.1.0 (git+https://github.com/0xPARC/pod2?rev=9993799c08e6e95b11eb016763fcc13f5030293e)",
+ "pod2utils",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "lz4-sys"
 version = "1.11.1+lz4-1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5507,7 +5543,7 @@ dependencies = [
 [[package]]
 name = "pod2"
 version = "0.1.0"
-source = "git+https://github.com/0xPARC/pod2?rev=cdf227e3530247e07e375daed007cae7d443b4ae#cdf227e3530247e07e375daed007cae7d443b4ae"
+source = "git+https://github.com/0xPARC/pod2?rev=9993799c08e6e95b11eb016763fcc13f5030293e#9993799c08e6e95b11eb016763fcc13f5030293e"
 dependencies = [
  "annotate-snippets",
  "anyhow",
@@ -5607,7 +5643,9 @@ dependencies = [
  "anyhow",
  "itertools 0.14.0",
  "log",
- "pod2 0.1.0 (git+https://github.com/0xPARC/pod2?rev=cdf227e3530247e07e375daed007cae7d443b4ae)",
+ "plonky2",
+ "pod2 0.1.0 (git+https://github.com/0xPARC/pod2?rev=9993799c08e6e95b11eb016763fcc13f5030293e)",
+ "rand 0.9.2",
  "serde",
  "serde_json",
 ]
@@ -7172,7 +7210,7 @@ dependencies = [
  "hex",
  "minicbor-serde 0.6.2",
  "plonky2",
- "pod2 0.1.0 (git+https://github.com/0xPARC/pod2?rev=cdf227e3530247e07e375daed007cae7d443b4ae)",
+ "pod2 0.1.0 (git+https://github.com/0xPARC/pod2?rev=9993799c08e6e95b11eb016763fcc13f5030293e)",
  "pod2utils",
  "rand 0.8.5",
  "reqwest 0.12.28",
@@ -7698,6 +7736,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8060,7 +8108,7 @@ dependencies = [
  "hex",
  "log",
  "plonky2",
- "pod2 0.1.0 (git+https://github.com/0xPARC/pod2?rev=cdf227e3530247e07e375daed007cae7d443b4ae)",
+ "pod2 0.1.0 (git+https://github.com/0xPARC/pod2?rev=9993799c08e6e95b11eb016763fcc13f5030293e)",
  "pod2utils",
  "rand 0.9.2",
  "serde",
@@ -8283,6 +8331,21 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "vdfpod"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "hex",
+ "itertools 0.14.0",
+ "log",
+ "plonky2",
+ "pod2 0.1.0 (git+https://github.com/0xPARC/pod2?rev=9993799c08e6e95b11eb016763fcc13f5030293e)",
+ "pod2utils",
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "vergen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,10 @@
 [workspace]
-members = ["app-gui/src-tauri", "common", "pod2utils", "synchronizer", "txlib"]
+members = ["app-gui/src-tauri", "common", "pod2utils", "synchronizer", "txlib", "craft_sdk", "intro_pods/vdfpod", "intro_pods/lt_eq_u256_pod"]
 resolver = "2"
 
 [workspace.dependencies]
-pod2 = { git = "https://github.com/0xPARC/pod2", rev = "cdf227e3530247e07e375daed007cae7d443b4ae", default-features = false, features = [
+# Branch `tmp/more-wildcards`
+pod2 = { git = "https://github.com/0xPARC/pod2", rev = "9993799c08e6e95b11eb016763fcc13f5030293e", default-features = false, features = [
     "backend_plonky2",
     "disk_cache",
     "zk",

--- a/craft_sdk/Cargo.toml
+++ b/craft_sdk/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "craft_sdk"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+anyhow = { workspace = true }
+log = { workspace = true }
+pod2 = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+hex = { workspace = true }
+rand = { workspace = true }
+plonky2 = { workspace = true }
+env_logger = { workspace = true }
+time = "0.3.46"
+tinytemplate = "1.2.1"
+pod2utils = { path = "../pod2utils" }
+txlib = { path = "../txlib" }
+vdfpod = { path = "../intro_pods/vdfpod" }
+lt_eq_u256_pod = { path = "../intro_pods/lt_eq_u256_pod" }

--- a/craft_sdk/src/lib.rs
+++ b/craft_sdk/src/lib.rs
@@ -6,10 +6,10 @@ use log::info;
 use pod2::{
     backends::plonky2::{basetypes::DEFAULT_VD_SET, mainpod::Prover, mock::mainpod::MockProver},
     frontend::{MainPod, MultiPodBuilder, Operation},
-    lang::{load_module, Module},
+    lang::{Module, load_module},
     middleware::{
-        containers::Dictionary, Key, MainPodProver, Params, Statement, TypedValue, VDSet, Value,
-        EMPTY_VALUE,
+        EMPTY_VALUE, Key, MainPodProver, Params, Statement, TypedValue, VDSet, Value,
+        containers::Dictionary,
     },
 };
 use pod2utils::{dict, macros::BuildContext, rand_raw_value};
@@ -1029,13 +1029,13 @@ mod tests {
     use lt_eq_u256_pod::LtEqU256Pod;
     use pod2::{
         frontend::{MainPod, Operation},
-        middleware::{containers::Array, Hash, Key, Pod, RawValue, Statement, Value, F},
+        middleware::{F, Hash, Key, Pod, RawValue, Statement, Value, containers::Array},
     };
     use pod2utils::{rand_raw_value, set};
     use txlib::{StateRoot, Tx};
     use vdfpod::VdfPod;
 
-    use super::{api::*, Context, Helper};
+    use super::{Context, Helper, api::*};
 
     const WOOD_POW_DIFFICULTY: u64 = 0x0020_0000_0000_0000;
 
@@ -1090,29 +1090,31 @@ mod tests {
 
         let find_log = Action {
             name: "FindLog",
-            steps: vec![Step::output("log", "Log")
-                .set("blueprint", Arg::literal("Log"))
-                .var(
-                    "work",
-                    Box::new(|ctx| {
-                        let log = ctx.vars.get("log");
-                        let log_raw = RawValue::from(log);
-                        let (vdf_pod, st_vdf, work) = vdf(ctx, 3, log_raw);
-                        ctx.store("vdf_pod", Box::new(vdf_pod));
-                        ctx.store("st_vdf", Box::new(st_vdf));
-                        work
-                    }),
-                )
-                .condition(
-                    "Vdf(3, {state}, work)",
-                    Box::new(|ctx| {
-                        let vdf_pod: Box<MainPod> = ctx.take("vdf_pod");
-                        let st_vdf: Box<Statement> = ctx.take("st_vdf");
-                        ctx.bld.builder.add_pod(*vdf_pod).unwrap();
-                        *st_vdf
-                    }),
-                )
-                .update("work", Arg::var("work"))],
+            steps: vec![
+                Step::output("log", "Log")
+                    .set("blueprint", Arg::literal("Log"))
+                    .var(
+                        "work",
+                        Box::new(|ctx| {
+                            let log = ctx.vars.get("log");
+                            let log_raw = RawValue::from(log);
+                            let (vdf_pod, st_vdf, work) = vdf(ctx, 3, log_raw);
+                            ctx.store("vdf_pod", Box::new(vdf_pod));
+                            ctx.store("st_vdf", Box::new(st_vdf));
+                            work
+                        }),
+                    )
+                    .condition(
+                        "Vdf(3, {state}, work)",
+                        Box::new(|ctx| {
+                            let vdf_pod: Box<MainPod> = ctx.take("vdf_pod");
+                            let st_vdf: Box<Statement> = ctx.take("st_vdf");
+                            ctx.bld.builder.add_pod(*vdf_pod).unwrap();
+                            *st_vdf
+                        }),
+                    )
+                    .update("work", Arg::var("work")),
+            ],
         };
 
         let craft_wood = Action {
@@ -1248,8 +1250,10 @@ mod tests {
 
         let use_wood_pick = Action {
             name: "UseWoodPick",
-            steps: vec![Step::mutate("wood_pick", "WoodPick")
-                .snippet(|step| use_pick_details(step, "wood_pick", 10))],
+            steps: vec![
+                Step::mutate("wood_pick", "WoodPick")
+                    .snippet(|step| use_pick_details(step, "wood_pick", 10)),
+            ],
         };
 
         let mine_stone_with_wood_pick = Action {
@@ -1262,8 +1266,10 @@ mod tests {
 
         let use_stone_pick = Action {
             name: "UseStonePick",
-            steps: vec![Step::mutate("stone_pick", "StonePick")
-                .snippet(|step| use_pick_details(step, "stone_pick", 5))],
+            steps: vec![
+                Step::mutate("stone_pick", "StonePick")
+                    .snippet(|step| use_pick_details(step, "stone_pick", 5)),
+            ],
         };
 
         let mine_stone_with_stone_pick = Action {

--- a/craft_sdk/src/lib.rs
+++ b/craft_sdk/src/lib.rs
@@ -1,0 +1,1369 @@
+use std::{any::Any, collections::HashMap, fmt, mem, slice, sync::Arc};
+
+use anyhow::Result;
+use fmt::Write;
+use log::info;
+use pod2::{
+    backends::plonky2::{basetypes::DEFAULT_VD_SET, mainpod::Prover, mock::mainpod::MockProver},
+    frontend::{MainPod, MultiPodBuilder, Operation},
+    lang::{load_module, Module},
+    middleware::{
+        containers::Dictionary, Key, MainPodProver, Params, Statement, TypedValue, VDSet, Value,
+        EMPTY_VALUE,
+    },
+};
+use pod2utils::{dict, macros::BuildContext, rand_raw_value};
+use serde::Serialize;
+use tinytemplate::TinyTemplate;
+use txlib::{StateRoot, Tx, TxBuilder};
+
+pub mod api {
+    use std::fmt;
+
+    use pod2::middleware::{Hash, Statement, Value};
+
+    /// Argument to an Update/Set detail
+    pub enum Arg {
+        /// A literal Value embedded in the statement template
+        Literal(Value),
+        /// Pick up the value from a variable in the predicate context (a wildcard)
+        Var(String),
+    }
+
+    impl Arg {
+        pub fn literal(v: impl Into<Value>) -> Self {
+            Self::Literal(v.into())
+        }
+        pub fn var(name: impl Into<String>) -> Self {
+            Self::Var(name.into())
+        }
+    }
+
+    impl fmt::Display for Arg {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            match self {
+                Arg::Literal(v) => v.fmt(f),
+                Arg::Var(v) => v.fmt(f),
+            }
+        }
+    }
+
+    /// Details about the object
+    pub enum Detail {
+        /// Introduce a variable in the context
+        Var {
+            name: String,
+            f: Box<dyn Fn(&mut super::Context) -> Value>,
+        },
+        /// Define a condition that the object must fulfill via a predicate and the function that
+        /// generates such predicate.
+        Condition {
+            pred: String,
+            f: Box<dyn Fn(&mut super::Context) -> Statement>,
+        },
+        /// Update a key of the object
+        Update { key: String, value: Arg },
+        /// Set a key of the object (doesn't modify the object)
+        Set { key: String, value: Arg },
+    }
+
+    #[derive(Default)]
+    pub enum StepKind {
+        #[default]
+        Depends,
+        Input,
+        Mutate,
+        Output,
+    }
+
+    #[derive(Default)]
+    pub struct Step {
+        pub(crate) kind: StepKind,
+        pub(crate) name: String,
+        pub(crate) class: String,
+        pub(crate) action: String,
+        pub(crate) details: Vec<Detail>,
+    }
+
+    impl Step {
+        /// The action consumes an object as input
+        pub fn input(name: impl Into<String>, class: impl Into<String>) -> Self {
+            Self {
+                kind: StepKind::Input,
+                name: name.into(),
+                class: class.into(),
+                ..Default::default()
+            }
+        }
+        /// The action produces an object as output
+        pub fn output(name: impl Into<String>, class: impl Into<String>) -> Self {
+            Self {
+                kind: StepKind::Output,
+                name: name.into(),
+                class: class.into(),
+                ..Default::default()
+            }
+        }
+        /// The action mutates an object, which is considered both input and output
+        pub fn mutate(name: impl Into<String>, class: impl Into<String>) -> Self {
+            Self {
+                kind: StepKind::Mutate,
+                name: name.into(),
+                class: class.into(),
+                ..Default::default()
+            }
+        }
+        /// The action depends on another action that affects an object
+        pub fn depends(name: impl Into<String>, action: impl Into<String>) -> Self {
+            Self {
+                kind: StepKind::Depends,
+                name: name.into(),
+                action: action.into(),
+                ..Default::default()
+            }
+        }
+        /// Introduce a variable in the context
+        pub fn var(
+            mut self,
+            name: impl Into<String>,
+            f: Box<dyn Fn(&mut super::Context) -> Value>,
+        ) -> Self {
+            self.details.push(Detail::Var {
+                name: name.into(),
+                f,
+            });
+            self
+        }
+        /// Define a condition that the object must fulfill via a predicate and the function that
+        /// generates such predicate.
+        pub fn condition(
+            mut self,
+            pred: impl Into<String>,
+            f: Box<dyn Fn(&mut super::Context) -> Statement>,
+        ) -> Self {
+            self.details.push(Detail::Condition {
+                pred: pred.into(),
+                f,
+            });
+            self
+        }
+        /// Update a key of the object
+        pub fn update(mut self, key: impl Into<String>, arg: Arg) -> Self {
+            if matches!(self.kind, StepKind::Depends) {
+                panic!("kind doesn't allow \"update\"");
+            }
+            self.details.push(Detail::Update {
+                key: key.into(),
+                value: arg,
+            });
+            self
+        }
+        /// Set a key of the object (doesn't modify the object)
+        pub fn set(mut self, key: impl Into<String>, arg: Arg) -> Self {
+            if matches!(
+                self.kind,
+                StepKind::Input | StepKind::Mutate | StepKind::Depends
+            ) {
+                panic!("kind doesn't allow \"set\"");
+            }
+            self.details.push(Detail::Set {
+                key: key.into(),
+                value: arg,
+            });
+            self
+        }
+        /// Apply a snippet function to the Step
+        pub fn snippet(self, f: impl Fn(Step) -> Self) -> Self {
+            f(self)
+        }
+    }
+
+    /// An action consumes objects and produces objects via a list of steps
+    pub struct Action {
+        pub name: &'static str,
+        pub steps: Vec<Step>,
+    }
+
+    /// Dependency towards another pod module or introduction pod
+    pub enum Dependency {
+        Module { name: &'static str, hash: Hash },
+        Intro { pred: &'static str, hash: Hash },
+    }
+}
+
+struct Class {
+    name: String,
+    // Actions that define the class with the index within the Action arguments that correspond to
+    // the class.
+    actions: Vec<(String, usize)>,
+}
+
+pub struct Helper {
+    params: Params,
+    data: Data,
+    pub podlang_src: String,
+    modules: Vec<Arc<Module>>,
+    pub module: Arc<Module>,
+}
+
+impl Helper {
+    pub fn new(mut dependencies: Vec<api::Dependency>, api_actions: Vec<api::Action>) -> Self {
+        let params = Params::default();
+        let txlib_mod = Arc::new(txlib::predicates::module());
+        dependencies.push(api::Dependency::Module {
+            name: "tx",
+            hash: txlib_mod.id(),
+        });
+
+        let mut actions = Vec::new();
+        for api_action in api_actions {
+            actions.push(Data::new_action(api_action));
+        }
+        let classes = Data::classes(&actions);
+        let output_index_class_st_index = Data::output_index_class_st_index(&actions);
+        let data = Data {
+            dependencies,
+            actions,
+            classes,
+            output_index_class_st_index,
+        };
+
+        let mut podlang_src = String::new();
+        data.format_podlang(&mut podlang_src).unwrap();
+        let module = Arc::new(
+            load_module(
+                podlang_src.as_str(),
+                "root",
+                &params,
+                slice::from_ref(&txlib_mod),
+            )
+            .expect("compiles"),
+        );
+        let modules = vec![txlib_mod, module.clone()];
+        Self {
+            params,
+            data,
+            podlang_src,
+            modules,
+            module,
+        }
+    }
+    pub fn builder(&self, mock: bool, state_root: Arc<StateRoot>) -> ObjectBuilder<'_> {
+        let mock_prover = MockProver {};
+        let real_prover = Prover {};
+        let (vd_set, prover): (_, Box<dyn MainPodProver>) = if mock {
+            (VDSet::new(&[]), Box::new(mock_prover))
+        } else {
+            let vd_set = &*DEFAULT_VD_SET;
+            (vd_set.clone(), Box::new(real_prover))
+        };
+
+        ObjectBuilder {
+            mock,
+            params: self.params.clone(),
+            vd_set,
+            state_root,
+            prover,
+            modules: self.modules.clone(),
+            data: &self.data,
+        }
+    }
+}
+
+fn prove(builder: MultiPodBuilder, prover: &dyn MainPodProver) -> MainPod {
+    let solution = builder.solve().unwrap();
+    log::debug!("solution needs {} pods", solution.solution().pod_count);
+    solution.prove(prover).unwrap().pods.pop().unwrap()
+}
+
+#[derive(Debug)]
+pub struct SpendableObject {
+    pub pod: MainPod,
+    pub obj: Dictionary,
+    pub tx: Tx,
+}
+
+impl SpendableObject {
+    pub fn tx_input(&self) -> (Dictionary, Tx) {
+        (self.obj.clone(), self.tx.clone())
+    }
+}
+
+pub struct SpendableObjects {
+    pub tx_pod: MainPod,
+    pub obj_pods: Vec<MainPod>,
+    pub objs: Vec<Dictionary>,
+    pub tx: Tx,
+}
+
+impl SpendableObjects {
+    pub fn obj(&self, index: usize) -> SpendableObject {
+        SpendableObject {
+            pod: self.obj_pods[index].clone(),
+            obj: self.objs[index].clone(),
+            tx: self.tx.clone(),
+        }
+    }
+    pub fn objs<const N: usize>(&self) -> [SpendableObject; N] {
+        let objs: Vec<_> = (0..N).map(|i| self.obj(i)).collect();
+        objs.try_into().unwrap()
+    }
+}
+
+pub struct ObjectBuilder<'a> {
+    mock: bool,
+    params: Params,
+    vd_set: VDSet,
+    state_root: Arc<StateRoot>,
+    prover: Box<dyn MainPodProver>,
+    modules: Vec<Arc<Module>>,
+    data: &'a Data,
+}
+
+pub struct Context<'a> {
+    pub vars: Vars<'a>,
+    storage: HashMap<&'static str, Box<dyn Any>>,
+    pub mock: bool,
+    pub params: Params,
+    pub vd_set: VDSet,
+    pub bld: BuildContext,
+}
+
+impl<'a> Context<'a> {
+    pub fn store(&mut self, key: &'static str, value: Box<dyn Any>) {
+        self.storage.insert(key, value);
+    }
+    pub fn load<T: 'static>(&self, key: &'static str) -> &T {
+        let value = self.storage.get(key).unwrap();
+        value.downcast_ref::<T>().unwrap()
+    }
+    pub fn take<T: 'static>(&mut self, key: &'static str) -> Box<T> {
+        let value = self.storage.remove(key).unwrap();
+        value.downcast::<T>().unwrap()
+    }
+}
+
+struct OutputData<'a> {
+    class: &'a str,
+    obj: Dictionary,
+}
+
+impl<'a> ObjectBuilder<'a> {
+    fn new_builder(&self) -> MultiPodBuilder {
+        MultiPodBuilder::new(&self.params, &self.vd_set)
+    }
+
+    fn new_tx_builder(&self, ctx: &mut BuildContext, inputs: &[(Dictionary, Tx)]) -> TxBuilder {
+        TxBuilder::new(ctx, inputs, self.state_root.clone())
+    }
+
+    // Returns Action statement, Output objects and data required to make the object class
+    // statement for each output from that Action
+    #[allow(clippy::type_complexity)]
+    fn _action(
+        &'a self,
+        ctx: &mut Context<'a>,
+        tx_builder: &mut TxBuilder,
+        action: &'a Action,
+        inputs: &[SpendableObject],
+    ) -> (Statement, Vec<Dictionary>, Vec<(String, Vec<Statement>)>) {
+        let mut io_info = String::new();
+        for (class, name) in action.inputs() {
+            write!(io_info, "Is{class}({name}) ").unwrap();
+        }
+        write!(io_info, "-> ").unwrap();
+        for (class, name) in action.outputs() {
+            write!(io_info, "Is{class}({name}) ").unwrap();
+        }
+        info!("action {}: {io_info}", action.name);
+
+        // Statements used to build the Action custom statement
+        let mut sts = Vec::new();
+        // Copies of objects before Updates for Mutate cases
+        let mut objs0: HashMap<&str, Dictionary> = HashMap::new();
+        // Object OutputData's to be returned by this Action
+        let mut outputs = Vec::new();
+        // Object to be returned by this Action (including dependent actions)
+        let mut output_objs = Vec::new();
+        // Data necessary to make each output object' class statement
+        let mut output_objs_st_class_data = Vec::new();
+        // Counter of the input object we're processing
+        let mut input_index = 0;
+        // Offset for dependency inputs
+        let mut input_offset = 0;
+        for step in action.steps() {
+            match step.kind {
+                StepKind::Output => {
+                    ctx.vars.insert(
+                        step.name.as_str(),
+                        dict!({"work" => EMPTY_VALUE, "key" => Value::from(rand_raw_value())}),
+                    );
+                }
+                StepKind::Input | StepKind::Mutate => {
+                    let input = &inputs[input_index];
+                    let input_pod_sts = input.pod.pod.pub_statements();
+                    let st_class = input_pod_sts[0].clone();
+                    sts.push(st_class);
+                    input_index += 1;
+                }
+                StepKind::Depends => {
+                    let (_name, action) = (step.name.as_str(), step.action.as_str());
+                    let action = self.data.action_by_name(action);
+                    let current_vars = mem::take(&mut ctx.vars);
+
+                    let mut input_count = 0;
+                    for (input_index, (_class, name)) in action.inputs().enumerate() {
+                        let input = &inputs[input_offset + input_index];
+                        ctx.vars.insert(name, input.obj.clone());
+                        input_count += 1;
+                    }
+                    input_offset += input_count;
+
+                    let (st_action, objs, objs_st_class_data) =
+                        self._action(ctx, tx_builder, action, inputs);
+                    ctx.vars = current_vars;
+                    output_objs.extend(objs.into_iter());
+                    output_objs_st_class_data.extend(objs_st_class_data.into_iter());
+                    sts.push(st_action);
+                }
+            }
+            // On Mutate we save a copy of the initial object because it's required by the mutate
+            // transaction
+            if matches!(step.kind, StepKind::Mutate) {
+                let obj = ctx.vars.get_dict(&step.name).unwrap();
+                objs0.insert(&step.name, obj.clone());
+            }
+
+            let details_set_len = details_set_len(&step.details);
+            let mut details_set_kv = Vec::new();
+            let mut details_set_done = details_set_len == 0;
+            for detail in &step.details {
+                match detail {
+                    api::Detail::Set { key, value } => {
+                        let value = ctx.vars.value(value);
+                        let obj = ctx.vars.get_dict_mut(&step.name).unwrap();
+                        obj.insert(&Key::from(key.clone()), &value).unwrap();
+                        details_set_kv.push((key.clone(), value));
+                    }
+                    api::Detail::Update { key, value } => {
+                        if !details_set_done {
+                            panic!("Update before last Set in the Step");
+                        }
+                        let value = ctx.vars.value(value);
+                        let obj = ctx.vars.get_dict_mut(&step.name).unwrap();
+                        let obj0 = obj.clone();
+                        obj.update(&Key::from(key.clone()), &value).unwrap();
+                        sts.push(
+                            ctx.bld
+                                .builder
+                                .priv_op(Operation::dict_update(
+                                    obj.clone(),
+                                    obj0,
+                                    key.clone(),
+                                    value,
+                                ))
+                                .unwrap(),
+                        );
+                    }
+                    api::Detail::Var { name, f } => {
+                        let value = f(ctx);
+                        ctx.vars.insert(name, value.take_typed());
+                    }
+                    api::Detail::Condition { pred: _, f } => {
+                        if !details_set_done {
+                            panic!("Condition before last Set in the Step");
+                        }
+                        let st = f(ctx);
+                        sts.push(st);
+                    }
+                }
+                // add Detail::Set statements just after they have been processed so that they all
+                // refer to the same object state.
+                if !details_set_done && details_set_kv.len() == details_set_len {
+                    for (key, value) in mem::take(&mut details_set_kv).into_iter() {
+                        let obj = ctx.vars.get_dict_mut(&step.name).unwrap();
+                        sts.push(
+                            ctx.bld
+                                .builder
+                                .priv_op(Operation::dict_contains(obj.clone(), key, value))
+                                .unwrap(),
+                        );
+                    }
+                    details_set_done = true;
+                }
+            }
+
+            match step.kind {
+                StepKind::Output => {
+                    let obj = ctx.vars.get_dict(step.name.as_str()).unwrap().clone();
+                    outputs.push(OutputData {
+                        class: &step.class,
+                        obj: obj.clone(),
+                    });
+                    sts.push(tx_builder.insert(&mut ctx.bld, obj));
+                }
+                StepKind::Input => {
+                    let obj = ctx.vars.get_dict(step.name.as_str()).unwrap().clone();
+                    sts.push(tx_builder.delete(&mut ctx.bld, obj));
+                }
+                StepKind::Mutate => {
+                    let obj0 = objs0.get(step.name.as_str()).unwrap();
+                    let obj = ctx.vars.get_dict(step.name.as_str()).unwrap().clone();
+                    outputs.push(OutputData {
+                        class: &step.class,
+                        obj: obj.clone(),
+                    });
+                    sts.push(tx_builder.mutate(&mut ctx.bld, obj, obj0.clone()));
+                }
+                StepKind::Depends => {}
+            }
+        }
+
+        // Action statement
+        let st_action = ctx
+            .bld
+            .apply_custom_pred(false, &action.name, HashMap::new(), sts)
+            .unwrap();
+        ctx.bld.builder.reveal(&st_action).unwrap();
+
+        // Output (includes Output & Mutate) Class(obj) statements
+        for (index, output) in outputs.iter().enumerate() {
+            let class = self.data.class_by_name(output.class);
+            let mut sts = vec![Statement::None; class.actions.len()];
+            let class_st_index =
+                self.data.output_index_class_st_index[&(action.name.clone(), index)];
+            sts[class_st_index] = st_action.clone();
+            let pred = format!("Is{}", class.name);
+            // We delay the creation of the class statement until we have created all actions
+            // because the class statements go to different pods.
+            output_objs_st_class_data.push((pred, sts));
+        }
+
+        output_objs.extend(outputs.into_iter().map(|out| out.obj));
+        (st_action, output_objs, output_objs_st_class_data)
+    }
+
+    pub fn action(self, action: &str, inputs: Vec<SpendableObject>) -> SpendableObjects {
+        let action = self.data.action_by_name(action);
+
+        let builder = self.new_builder();
+        let mut ctx = Context {
+            vars: Vars::default(),
+            storage: HashMap::new(),
+            mock: self.mock,
+            params: self.params.clone(),
+            vd_set: self.vd_set.clone(),
+            bld: BuildContext {
+                builder,
+                modules: self.modules.clone(),
+            },
+        };
+
+        let mut tx_inputs = Vec::new();
+        for (input_index, (_class, name)) in action.inputs().enumerate() {
+            let input = &inputs[input_index];
+            ctx.vars.insert(name, input.obj.clone());
+            tx_inputs.push(input.tx_input());
+            ctx.bld.builder.add_pod(input.pod.clone()).unwrap();
+        }
+
+        let mut tx_builder = self.new_tx_builder(&mut ctx.bld, &tx_inputs);
+
+        let (_st_action, objs, objs_st_class_data) =
+            self._action(&mut ctx, &mut tx_builder, action, &inputs);
+
+        // Prove a pod with the class statements and the last tx statement
+        ctx.bld.builder.reveal(tx_builder.st_tx()).unwrap();
+        let pod = prove(ctx.bld.builder, &*self.prover);
+        pod.pod.verify().unwrap();
+
+        // Finalize tx and prove it in another pod
+        let tx = tx_builder.tx;
+        ctx.bld.builder = self.new_builder();
+        ctx.bld.builder.add_pod(pod.clone()).unwrap();
+        let tx_builder = TxBuilder::new_from_tx(&ctx.bld, tx);
+        let (st_tx_finalize, tx) = tx_builder.finalize(&mut ctx.bld);
+        ctx.bld.builder.reveal(&st_tx_finalize).unwrap();
+
+        let tx_pod = prove(ctx.bld.builder, &*self.prover);
+        tx_pod.pod.verify().unwrap();
+
+        // Make one pod for each object with just the corresponding class statement.
+        let mut obj_pods = Vec::new();
+        for (pred, sts) in objs_st_class_data {
+            ctx.bld.builder = self.new_builder();
+            ctx.bld.builder.add_pod(pod.clone()).unwrap();
+            let st_class = ctx
+                .bld
+                .apply_custom_pred(false, &pred, HashMap::new(), sts)
+                .unwrap();
+            ctx.bld.builder.reveal(&st_class).unwrap();
+
+            let obj_pod = prove(ctx.bld.builder, &*self.prover);
+            obj_pod.pod.verify().unwrap();
+            obj_pods.push(obj_pod);
+        }
+
+        SpendableObjects {
+            tx_pod,
+            obj_pods,
+            objs,
+            tx,
+        }
+    }
+}
+
+#[derive(Default)]
+pub struct Vars<'a> {
+    vars: HashMap<&'a str, TypedValue>,
+}
+
+impl<'a> Vars<'a> {
+    pub fn insert(&mut self, name: &'a str, value: impl Into<TypedValue>) {
+        self.vars.insert(name, value.into());
+    }
+    pub fn get(&self, name: &'a str) -> &TypedValue {
+        self.vars.get(name).unwrap()
+    }
+    pub fn get_dict_mut(&mut self, name: &'a str) -> Option<&mut Dictionary> {
+        let v = self.vars.get_mut(name).unwrap();
+        match v {
+            TypedValue::Dictionary(v) => Some(v),
+            _ => None,
+        }
+    }
+    pub fn get_dict(&self, name: &'a str) -> Option<&Dictionary> {
+        let v = self.vars.get(name).unwrap();
+        match v {
+            TypedValue::Dictionary(v) => Some(v),
+            _ => None,
+        }
+    }
+    // Resolve a Arg::Var or return its Literal value
+    pub fn value(&self, arg: &api::Arg) -> Value {
+        match arg {
+            api::Arg::Literal(v) => v.clone(),
+            api::Arg::Var(name) => Value::new(self.vars[name.as_str()].clone()),
+        }
+    }
+}
+
+struct Action {
+    name: String,
+    depends: Vec<Step>,
+    inputs: Vec<Step>,
+    mutates: Vec<Step>,
+    outputs: Vec<Step>,
+}
+
+impl Action {
+    fn steps(&self) -> impl Iterator<Item = &Step> {
+        self.depends
+            .iter()
+            .chain(self.inputs.iter())
+            .chain(self.mutates.iter())
+            .chain(self.outputs.iter())
+    }
+    // List of (class, object name) that the action takes as input.  Includes Input and Mutate.
+    fn inputs(&self) -> impl Iterator<Item = (&str, &str)> {
+        self.steps()
+            .filter(|s| {
+                matches!(
+                    s.kind,
+                    StepKind::Input | StepKind::Mutate | StepKind::Depends
+                )
+            })
+            .map(|s| (s.class.as_str(), s.name.as_str()))
+    }
+    // List of (class, object name) that the action returns as output.  Includes Output and Mutate.
+    fn outputs(&self) -> impl Iterator<Item = (&str, &str)> {
+        self.steps()
+            .filter(|s| matches!(s.kind, StepKind::Output | StepKind::Mutate))
+            .map(|s| (s.class.as_str(), s.name.as_str()))
+    }
+    fn steps_len(&self) -> usize {
+        self.depends.len() + self.inputs.len() + self.mutates.len() + self.outputs.len()
+    }
+    fn public_vars(&self) -> Vec<&str> {
+        let mut vars = Vec::new();
+        for step in self.steps() {
+            match step.kind {
+                StepKind::Mutate | StepKind::Output => vars.push(step.name.as_str()),
+                _ => {}
+            }
+        }
+        vars
+    }
+    fn public_vars_len(&self) -> usize {
+        self.outputs.len() + self.mutates.len()
+    }
+    fn private_vars(&self) -> Vec<String> {
+        let mut vars: Vec<String> = Vec::new();
+        // Intermediate transactions
+        for i in 1..self.steps_len() {
+            vars.push(format!("tx{}", i));
+        }
+        for step in self.steps() {
+            // Non-output/mutate item states
+            if !matches!(step.kind, StepKind::Output | StepKind::Mutate) {
+                vars.push(step.name.to_string());
+            }
+            // Intermediate item states
+            for i in 0..step.details_update_len() {
+                vars.push(format!("{}{}", step.name, i));
+            }
+            // Details variables
+            for detail in &step.details {
+                if let api::Detail::Var { name, .. } = detail {
+                    vars.push(name.to_string());
+                }
+            }
+        }
+        vars
+    }
+}
+
+use api::{Step, StepKind};
+
+impl Step {
+    fn details_update_len(&self) -> usize {
+        self.details
+            .iter()
+            .filter(|d| matches!(*d, api::Detail::Update { .. }))
+            .count()
+    }
+}
+
+#[derive(Serialize)]
+struct TmplContext {
+    state: String,
+}
+
+struct StateVar<'a> {
+    name: &'a str,
+    ts: usize,
+    max_ts: usize,
+}
+
+impl<'a> StateVar<'a> {
+    fn inc(&mut self) {
+        self.ts += 1;
+    }
+    fn next(&'a self) -> Self {
+        Self {
+            name: self.name,
+            ts: self.ts + 1,
+            max_ts: self.max_ts,
+        }
+    }
+}
+
+impl<'a> fmt::Display for StateVar<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.name)?;
+        if self.ts != self.max_ts {
+            write!(f, "{}", self.ts)?;
+        }
+        Ok(())
+    }
+}
+
+struct Data {
+    actions: Vec<Action>,
+    classes: Vec<Class>,
+    dependencies: Vec<api::Dependency>,
+    // Maps from output index in the Action to statement index in the Class predicate
+    output_index_class_st_index: HashMap<(String, usize), usize>,
+}
+
+fn details_set_len(details: &[api::Detail]) -> usize {
+    details
+        .iter()
+        .filter(|d| matches!(d, api::Detail::Set { .. }))
+        .count()
+}
+
+impl Data {
+    fn new_action(api_action: api::Action) -> Action {
+        let mut depends = Vec::new();
+        let mut inputs = Vec::new();
+        let mut mutates = Vec::new();
+        let mut outputs = Vec::new();
+        for api_step in api_action.steps {
+            use api::StepKind::*;
+            match api_step.kind {
+                Depends => depends.push(api_step),
+                Input => inputs.push(api_step),
+                Mutate => mutates.push(api_step),
+                Output => outputs.push(api_step),
+            }
+        }
+
+        Action {
+            name: api_action.name.to_string(),
+            depends,
+            inputs,
+            mutates,
+            outputs,
+        }
+    }
+
+    fn action_by_name(&self, name: &str) -> &Action {
+        self.actions.iter().find(|a| a.name == name).unwrap()
+    }
+
+    fn class_by_name(&self, name: &str) -> &Class {
+        self.classes.iter().find(|c| c.name == name).unwrap()
+    }
+
+    fn classes(actions: &[Action]) -> Vec<Class> {
+        let mut class_to_actions: HashMap<&str, Vec<(String, usize)>> = HashMap::new();
+        let mut classes_ordered = Vec::new();
+        for action in actions {
+            let mut classes = Vec::new();
+            for step in action.steps() {
+                let class_name = step.class.as_str();
+                match step.kind {
+                    StepKind::Mutate | StepKind::Output => {
+                        classes.push(class_name);
+                        if !classes_ordered.contains(&class_name) {
+                            classes_ordered.push(class_name);
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            for (i, class) in classes.iter().enumerate() {
+                let actions = class_to_actions.entry(class).or_default();
+                actions.push((action.name.clone(), i));
+            }
+        }
+        let mut classes = Vec::new();
+        for class in classes_ordered {
+            classes.push(Class {
+                name: class.to_string(),
+                actions: class_to_actions[class].clone(),
+            });
+        }
+        classes
+    }
+
+    fn output_index_class_st_index(actions: &[Action]) -> HashMap<(String, usize), usize> {
+        let mut output_index_class_st_index = HashMap::new();
+        let mut class_action_count = HashMap::new();
+        for action in actions {
+            for (output_index, (class, _name)) in action.outputs().enumerate() {
+                let class_st_index = class_action_count.entry(class).or_insert(0);
+                output_index_class_st_index
+                    .insert((action.name.clone(), output_index), *class_st_index);
+                *class_st_index += 1;
+            }
+        }
+        output_index_class_st_index
+    }
+
+    fn format_podlang(&self, w: &mut dyn fmt::Write) -> Result<()> {
+        for dependency in &self.dependencies {
+            Self::format_dependency(w, dependency)?;
+        }
+        writeln!(w)?;
+        writeln!(w, "// Actions\n")?;
+        for action in &self.actions {
+            Self::format_action(w, action)?;
+        }
+        writeln!(w, "// Classes\n")?;
+        for class in &self.classes {
+            self.format_class(w, class)?;
+        }
+        Ok(())
+    }
+
+    fn format_dependency(w: &mut dyn fmt::Write, dependency: &api::Dependency) -> Result<()> {
+        match dependency {
+            api::Dependency::Module { name, hash } => {
+                writeln!(w, "use module {:#} as {name}", hash)?;
+            }
+            api::Dependency::Intro { pred, hash } => {
+                writeln!(w, "use intro {pred} from {:#}", hash)?;
+            }
+        }
+        Ok(())
+    }
+
+    fn format_action(w: &mut dyn fmt::Write, action: &Action) -> Result<()> {
+        write!(w, "{}(", action.name)?;
+        for public_var in &action.public_vars() {
+            write!(w, "{}, ", public_var)?;
+        }
+        write!(w, "tx, tx0, private: ")?;
+        let private_vars = action.private_vars();
+        for (i, var) in private_vars.iter().enumerate() {
+            if i != 0 {
+                write!(w, ", ")?;
+            }
+            write!(w, "{var}")?;
+        }
+
+        writeln!(w, ") = AND (")?;
+        let steps_len = action.steps_len();
+        for (step_idx, step) in action.steps().enumerate() {
+            let mut state = StateVar {
+                name: step.name.as_str(),
+                ts: 0,
+                max_ts: step.details_update_len(),
+            };
+            let tx = format!("tx{}", step_idx);
+            let tx_next = if step_idx == steps_len - 1 {
+                "tx".to_string()
+            } else {
+                format!("tx{}", step_idx + 1)
+            };
+            match step.kind {
+                StepKind::Input => {
+                    writeln!(w, "  // Input")?;
+                    writeln!(w, "  Is{}({})", step.class, state)?
+                }
+                StepKind::Mutate => {
+                    writeln!(w, "  // Mutate")?;
+                    writeln!(w, "  Is{}({})", step.class, state)?
+                }
+                StepKind::Output => {
+                    writeln!(w, "  // Output")?;
+                }
+                StepKind::Depends => {
+                    writeln!(w, "  // Action dependency")?;
+                }
+            }
+            for detail in &step.details {
+                match detail {
+                    api::Detail::Condition { pred, .. } => {
+                        let mut tt = TinyTemplate::new();
+                        tt.add_template("pred", pred)?;
+                        let ctx = TmplContext {
+                            state: format!("{}", state),
+                        };
+                        writeln!(w, "  {}", tt.render("pred", &ctx)?)?;
+                    }
+                    api::Detail::Update { key, value } => {
+                        writeln!(
+                            w,
+                            r#"  DictUpdate({state_next}, {state}, "{key}", {value})"#,
+                            state_next = state.next()
+                        )?;
+                        state.inc();
+                    }
+                    api::Detail::Set { key, value } => {
+                        writeln!(w, r#"  DictContains({state}, "{key}", {value})"#,)?;
+                    }
+                    api::Detail::Var { .. } => {}
+                }
+            }
+            match step.kind {
+                StepKind::Depends => writeln!(
+                    w,
+                    "  {action}({state}, {tx_next}, {tx})",
+                    action = step.action
+                )?,
+                StepKind::Input => writeln!(w, "  tx::TxDeleted({tx_next}, {tx}, {state})")?,
+                StepKind::Mutate => {
+                    writeln!(w, "  tx::TxMutated({tx_next}, {tx}, {state}, {state}0)",)?
+                }
+                StepKind::Output => writeln!(w, "  tx::TxInserted({tx_next}, {tx}, {state})")?,
+            }
+        }
+        writeln!(w, ")")?;
+        writeln!(w)?;
+        Ok(())
+    }
+
+    fn format_class(&self, w: &mut dyn fmt::Write, class: &Class) -> Result<()> {
+        let name = &class.name;
+        write!(w, "Is{name}(state, private: tx, tx0")?;
+
+        let other_len = class
+            .actions
+            .iter()
+            .map(|(action_name, _)| self.action_by_name(action_name).public_vars_len())
+            .max()
+            .unwrap()
+            - 1;
+        if other_len != 0 {
+            write!(w, ", ")?;
+        }
+        for i in 0..other_len {
+            if i != 0 {
+                write!(w, ", ")?;
+            }
+            write!(w, "_other_{i}")?;
+        }
+        writeln!(w, ") = OR(")?;
+        for (action_name, index) in &class.actions {
+            write!(w, "  {action_name}(")?;
+            let action = self.action_by_name(action_name);
+            let mut count = 0;
+            for i in 0..action.public_vars_len() {
+                if i != 0 {
+                    write!(w, ", ")?;
+                }
+                if i == *index {
+                    write!(w, "state")?;
+                } else {
+                    write!(w, "_other_{count}")?;
+                    count += 1;
+                }
+            }
+            writeln!(w, ", tx, tx0)")?;
+        }
+        writeln!(w, ")")?;
+        writeln!(w)?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use std::sync::Arc;
+
+    use hex::FromHex;
+    use lt_eq_u256_pod::LtEqU256Pod;
+    use pod2::{
+        frontend::{MainPod, Operation},
+        middleware::{containers::Array, Hash, Key, Pod, RawValue, Statement, Value, F},
+    };
+    use pod2utils::{rand_raw_value, set};
+    use txlib::{StateRoot, Tx};
+    use vdfpod::VdfPod;
+
+    use super::{api::*, Context, Helper};
+
+    const WOOD_POW_DIFFICULTY: u64 = 0x0020_0000_0000_0000;
+
+    fn update_state_root(state_root: &mut StateRoot, tx: &Tx) {
+        state_root
+            .transactions
+            .insert(&Value::from(tx.dict()))
+            .unwrap();
+        for nullifier in tx.nullifiers.set() {
+            state_root.nullifiers.insert(nullifier).unwrap();
+        }
+        state_root.block_number += 1;
+    }
+
+    fn main_pod(ctx: &Context, pod: Box<dyn Pod>) -> MainPod {
+        let pub_statements = pod.pub_statements();
+        MainPod {
+            pod,
+            public_statements: pub_statements,
+            params: ctx.params.clone(),
+        }
+    }
+
+    // Returns VdfPod, Vdf statement, work
+    fn vdf(ctx: &mut Context, n_iters: usize, input: RawValue) -> (MainPod, Statement, Value) {
+        let vdf_pod = if ctx.mock {
+            VdfPod::new_boxed_mock(&ctx.params, ctx.vd_set.clone(), n_iters, input)
+        } else {
+            VdfPod::new_boxed(&ctx.params, ctx.vd_set.clone(), n_iters, input)
+        }
+        .unwrap();
+        let st_vdf = vdf_pod.pub_statements()[0].clone();
+        let work = st_vdf.args()[2].literal().unwrap();
+        (main_pod(ctx, vdf_pod), st_vdf, work)
+    }
+
+    // Returns LtEqU256Pod and LtEqU256 statement used to verify PoW.
+    fn lt_eq_u256(ctx: &mut Context, lhs: RawValue, rhs: RawValue) -> (MainPod, Statement) {
+        let lt_eq_u256_pod = if ctx.mock {
+            LtEqU256Pod::new_boxed_mock(&ctx.params, ctx.vd_set.clone(), lhs, rhs)
+        } else {
+            LtEqU256Pod::new_boxed(&ctx.params, ctx.vd_set.clone(), lhs, rhs)
+        }
+        .unwrap();
+        let st_lt_eq_u256 = lt_eq_u256_pod.pub_statements()[0].clone();
+        (main_pod(ctx, lt_eq_u256_pod), st_lt_eq_u256)
+    }
+
+    #[test]
+    fn test_sdk() {
+        let _ = env_logger::builder().try_init();
+
+        let find_log = Action {
+            name: "FindLog",
+            steps: vec![Step::output("log", "Log")
+                .set("blueprint", Arg::literal("Log"))
+                .var(
+                    "work",
+                    Box::new(|ctx| {
+                        let log = ctx.vars.get("log");
+                        let log_raw = RawValue::from(log);
+                        let (vdf_pod, st_vdf, work) = vdf(ctx, 3, log_raw);
+                        ctx.store("vdf_pod", Box::new(vdf_pod));
+                        ctx.store("st_vdf", Box::new(st_vdf));
+                        work
+                    }),
+                )
+                .condition(
+                    "Vdf(3, {state}, work)",
+                    Box::new(|ctx| {
+                        let vdf_pod: Box<MainPod> = ctx.take("vdf_pod");
+                        let st_vdf: Box<Statement> = ctx.take("st_vdf");
+                        ctx.bld.builder.add_pod(*vdf_pod).unwrap();
+                        *st_vdf
+                    }),
+                )
+                .update("work", Arg::var("work"))],
+        };
+
+        let craft_wood = Action {
+            name: "CraftWood",
+            steps: vec![
+                Step::input("log", "Log"),
+                Step::output("wood", "Wood")
+                    .set("blueprint", Arg::literal("Wood"))
+                    .var(
+                        "key",
+                        Box::new(|ctx| {
+                            let mut wood = ctx.vars.get_dict("wood").unwrap().clone();
+                            let mut key = Value::from(rand_raw_value());
+                            if !ctx.mock {
+                                while RawValue::from(wood.commitment()).0[3].0
+                                    > WOOD_POW_DIFFICULTY
+                                {
+                                    key = Value::from(rand_raw_value());
+
+                                    wood.update(&Key::from("key"), &key).unwrap();
+                                }
+                            }
+                            key
+                        }),
+                    )
+                    .update("key", Arg::var("key"))
+                    .condition(
+                        "LtEqU256({state}, Raw(0x0020000000000000000000000000000000000000000000000000000000000000))",
+                        Box::new(|ctx| {
+                            let wood = ctx.vars.get("wood");
+                            let wood_raw = RawValue::from(wood);
+                            let (lt_eq_u256_pod, st_lt_eq_u256) = lt_eq_u256(
+                                ctx,
+                                wood_raw,
+                                RawValue([F(0), F(0), F(0), F(WOOD_POW_DIFFICULTY)]),
+                            );
+                            ctx.bld.builder.add_pod(lt_eq_u256_pod).unwrap();
+                            st_lt_eq_u256
+                        }),
+                    )
+                ]
+        };
+
+        let craft_sticks = Action {
+            name: "CraftSticks",
+            steps: vec![
+                Step::input("wood", "Wood"),
+                Step::output("stick_a", "Stick").set("blueprint", Arg::literal("Stick")),
+                Step::output("stick_b", "Stick").set("blueprint", Arg::literal("Stick")),
+            ],
+        };
+
+        let craft_wood_pick = Action {
+            name: "CraftWoodPick",
+            steps: vec![
+                Step::input("wood", "Wood"),
+                Step::input("stick", "Stick"),
+                Step::output("wood_pick", "WoodPick")
+                    .set("blueprint", Arg::literal("WoodPick"))
+                    .set("durability", Arg::literal(100i64)),
+            ],
+        };
+
+        let craft_stone_pick = Action {
+            name: "CraftStonePick",
+            steps: vec![
+                Step::input("stone", "Stone"),
+                Step::input("stick", "Stick"),
+                Step::output("stone_pick", "StonePick")
+                    .set("blueprint", Arg::literal("StonePick"))
+                    .set("durability", Arg::literal(200i64)),
+            ],
+        };
+
+        fn use_pick_details(step: Step, name: &'static str, vdf_iters: usize) -> Step {
+            step.condition(
+                "Gt({state}.durability, 0)",
+                Box::new(|ctx| {
+                    let obj = ctx.vars.get_dict(name).unwrap();
+                    ctx.bld
+                        .builder
+                        .priv_op(Operation::gt((obj, "durability"), 0))
+                        .unwrap()
+                }),
+            )
+            .var(
+                "durability",
+                Box::new(|ctx| {
+                    let obj = ctx.vars.get_dict(name).unwrap();
+                    let mut durability =
+                        i64::try_from(obj.get(&Key::from("durability")).unwrap().typed()).unwrap();
+                    durability -= 1;
+                    ctx.store("durability", Box::new(durability));
+                    Value::from(durability)
+                }),
+            )
+            .condition(
+                "SumOf({state}.durability, durability, 1)",
+                Box::new(|ctx| {
+                    let durability: Box<i64> = ctx.take("durability");
+                    let obj = ctx.vars.get_dict(name).unwrap();
+                    ctx.bld
+                        .builder
+                        .priv_op(Operation::sum_of((obj, "durability"), *durability, 1))
+                        .unwrap()
+                }),
+            )
+            .update("durability", Arg::var("durability"))
+            .var("key", Box::new(|_ctx| Value::from(rand_raw_value())))
+            .update("key", Arg::var("key"))
+            .var(
+                "work",
+                Box::new(move |ctx| {
+                    let obj = ctx.vars.get(name);
+                    let obj_raw = RawValue::from(obj);
+                    let (vdf_pod, st_vdf, work) = vdf(ctx, vdf_iters, obj_raw);
+                    ctx.store("vdf_pod", Box::new(vdf_pod));
+                    ctx.store("st_vdf", Box::new(st_vdf));
+                    work
+                }),
+            )
+            .condition(
+                format!("Vdf({vdf_iters}, {{state}}, work)").leak(),
+                Box::new(|ctx| {
+                    let vdf_pod: Box<MainPod> = ctx.take("vdf_pod");
+                    let st_vdf: Box<Statement> = ctx.take("st_vdf");
+                    ctx.bld.builder.add_pod(*vdf_pod).unwrap();
+                    *st_vdf
+                }),
+            )
+            .update("work", Arg::var("work"))
+        }
+
+        let use_wood_pick = Action {
+            name: "UseWoodPick",
+            steps: vec![Step::mutate("wood_pick", "WoodPick")
+                .snippet(|step| use_pick_details(step, "wood_pick", 10))],
+        };
+
+        let mine_stone_with_wood_pick = Action {
+            name: "MineStoneWithWoodPick",
+            steps: vec![
+                Step::depends("pick", "UseWoodPick"),
+                Step::output("stone", "Stone").set("blueprint", Arg::literal("Stone")),
+            ],
+        };
+
+        let use_stone_pick = Action {
+            name: "UseStonePick",
+            steps: vec![Step::mutate("stone_pick", "StonePick")
+                .snippet(|step| use_pick_details(step, "stone_pick", 5))],
+        };
+
+        let mine_stone_with_stone_pick = Action {
+            name: "MineStoneWithStonePick",
+            steps: vec![
+                Step::depends("pick", "UseStonePick"),
+                Step::output("stone", "Stone").set("blueprint", Arg::literal("Stone")),
+            ],
+        };
+
+        let dependencies = vec![
+            Dependency::Intro {
+                pred: "Vdf(count, input, output)",
+                hash: Hash::from_hex(
+                    "b77a964de74c8569e6c6172692bb50147df9334fd9b572abc8d4d9c688a40e06",
+                )
+                .unwrap(),
+            },
+            Dependency::Intro {
+                pred: "LtEqU256(lhs, rhs)",
+                hash: Hash::from_hex(
+                    "2e79114ee823f4783ab5b6eb93b49abba87fb69b4d14de4cf1d78648ade73529",
+                )
+                .unwrap(),
+            },
+        ];
+
+        let helper = Helper::new(
+            dependencies,
+            vec![
+                find_log,
+                craft_wood,
+                craft_sticks,
+                craft_wood_pick,
+                craft_stone_pick,
+                use_wood_pick,
+                mine_stone_with_wood_pick,
+                use_stone_pick,
+                mine_stone_with_stone_pick,
+            ],
+        );
+        println!("{}", helper.podlang_src);
+
+        let mut state_root = StateRoot {
+            transactions: set!(),
+            nullifiers: set!(),
+            block_number: 0,
+            gsrs: Array::new(vec![]),
+        };
+
+        let mock = true;
+
+        let builder = helper.builder(mock, Arc::new(state_root.clone()));
+        let [log_a] = builder.action("FindLog", vec![]).objs();
+        update_state_root(&mut state_root, &log_a.tx);
+
+        let builder = helper.builder(mock, Arc::new(state_root.clone()));
+        let [wood_a] = builder.action("CraftWood", vec![log_a]).objs();
+        update_state_root(&mut state_root, &wood_a.tx);
+
+        let builder = helper.builder(mock, Arc::new(state_root.clone()));
+        let [stick_a, stick_b] = builder.action("CraftSticks", vec![wood_a]).objs();
+        update_state_root(&mut state_root, &stick_a.tx);
+
+        let builder = helper.builder(mock, Arc::new(state_root.clone()));
+        let [log_b] = builder.action("FindLog", vec![]).objs();
+        update_state_root(&mut state_root, &log_b.tx);
+
+        let builder = helper.builder(mock, Arc::new(state_root.clone()));
+        let [wood_b] = builder.action("CraftWood", vec![log_b]).objs();
+        update_state_root(&mut state_root, &wood_b.tx);
+
+        let builder = helper.builder(mock, Arc::new(state_root.clone()));
+        let [wood_pick] = builder
+            .action("CraftWoodPick", vec![wood_b, stick_a])
+            .objs();
+        update_state_root(&mut state_root, &wood_pick.tx);
+
+        let builder = helper.builder(mock, Arc::new(state_root.clone()));
+        let [wood_pick, stone_a] = builder
+            .action("MineStoneWithWoodPick", vec![wood_pick])
+            .objs();
+        update_state_root(&mut state_root, &wood_pick.tx);
+
+        let builder = helper.builder(mock, Arc::new(state_root.clone()));
+        let [stone_pick] = builder
+            .action("CraftStonePick", vec![stone_a, stick_b])
+            .objs();
+        update_state_root(&mut state_root, &stone_pick.tx);
+
+        let builder = helper.builder(mock, Arc::new(state_root.clone()));
+        let [stone_pick, _stone_b] = builder
+            .action("MineStoneWithStonePick", vec![stone_pick])
+            .objs();
+        update_state_root(&mut state_root, &stone_pick.tx);
+
+        let builder = helper.builder(mock, Arc::new(state_root.clone()));
+        let [stone_pick, _stone_c] = builder
+            .action("MineStoneWithStonePick", vec![stone_pick])
+            .objs();
+        update_state_root(&mut state_root, &stone_pick.tx);
+    }
+}

--- a/intro_pods/lt_eq_u256_pod/Cargo.toml
+++ b/intro_pods/lt_eq_u256_pod/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "lt_eq_u256_pod"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+anyhow = { workspace = true }
+log = { workspace = true }
+itertools.workspace = true
+pod2 = { workspace = true }
+plonky2 = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+hex = { workspace = true }
+
+pod2utils = { path = "../../pod2utils" }

--- a/intro_pods/lt_eq_u256_pod/src/lib.rs
+++ b/intro_pods/lt_eq_u256_pod/src/lib.rs
@@ -1,0 +1,607 @@
+//! LtEqU256Pod: Introduction Pod that proves lower than for U256 values.
+//! - takes as input two RawValues (lhs and rhs) that represent a U256 split into 4 limbs each
+//! - proves that lhs <= rhs
+//!
+//! This can be used to prove that mining work was done to find a valid nonce/seed.
+//!
+//! Circuit structure:
+//! 1. LtEqU256Circuit:
+//!     - lhs: RawValue (4 field elements interpreted as 4 limbs of U256.  For PoW this is a hash/commitment)
+//!     - rhs: RawValue (4 field elements interpreted as 4 limbs of U256.  For PoW this is the
+//!       inverse of the difficulty)
+//!     - proves: lhs <= rhs
+//!
+//! 2. LtEqU256Pod:
+//!     - satisfies the pod2's Pod trait interface
+//!     - verifies the proof from LtEqU256Circuit
+//!
+//! Usage:
+//! ```rust,no_run
+//!   use pod2::{backends::plonky2::basetypes::DEFAULT_VD_SET, middleware::{Params, RawValue, hash_str, F}};
+//!   use lt_eq_u256_pod::LtEqU256Pod;
+//!
+//!   let params = Params::default();
+//!   let vd_set = &*DEFAULT_VD_SET;
+//!   let candidate_hash = RawValue::from(hash_str("block header + nonce"));
+//!   let max_value = RawValue([F(0), F(0), F(0), F(0x0020_0000_0000_0000u64)]);
+//!   let lt_eq_u256_pod = LtEqU256Pod::new(&params, vd_set.clone(), candidate_hash, max_value).unwrap();
+//! ```
+
+use anyhow::Result;
+use hex::FromHex;
+use itertools::Itertools;
+use plonky2::{
+    field::types::{Field, PrimeField64},
+    hash::hash_types::{HashOut, HashOutTarget},
+    iop::{
+        target::Target,
+        witness::{PartialWitness, WitnessWrite},
+    },
+    plonk::{
+        circuit_builder::CircuitBuilder,
+        circuit_data::{CircuitData, VerifierOnlyCircuitData},
+        proof::ProofWithPublicInputs,
+    },
+};
+use pod2::{
+    backends::plonky2::{
+        Error, Result as BResult,
+        circuits::{
+            common::{
+                CircuitBuilderPod, PredicateTarget, StatementArgTarget, StatementTarget,
+                ValueTarget,
+            },
+            mainpod::calculate_statements_hash_circuit,
+        },
+        deserialize_proof, mainpod,
+        mainpod::calculate_statements_hash,
+        serialize_proof,
+    },
+    measure_gates_begin, measure_gates_end, middleware,
+    middleware::{
+        C, D, EMPTY_HASH, F, Hash, IntroPredicateRef, Params, Pod, Proof, RawValue, ToFields,
+        VDSet, Value,
+    },
+    timed,
+};
+use pod2utils::mockintro::MockIntroPod;
+use serde::{Deserialize, Serialize};
+
+const LT_EQ_U256_POD_TYPE: (usize, &str) = (2002, "LtEqU256");
+
+pub static STANDARD_LT_EQ_U256_VD_HASH: std::sync::LazyLock<Hash> =
+    std::sync::LazyLock::new(|| {
+        Hash::from_hex("2e79114ee823f4783ab5b6eb93b49abba87fb69b4d14de4cf1d78648ade73529").unwrap()
+    });
+
+static STANDARD_LT_EQ_U256_POD_DATA: std::sync::LazyLock<(
+    LtEqU256PodTarget,
+    CircuitData<F, C, D>,
+)> = std::sync::LazyLock::new(|| build().expect("successful build"));
+fn build() -> Result<(LtEqU256PodTarget, CircuitData<F, C, D>)> {
+    let params = Params::default();
+
+    // use pod2's recursion config as config for the introduction pod; which if
+    // the zk feature enabled, it will have the zk property enabled
+    let rec_circuit_data =
+        &*pod2::backends::plonky2::cache_get_standard_rec_main_pod_common_circuit_data();
+
+    let common_data = rec_circuit_data.0.clone();
+    let config = common_data.config.clone();
+
+    let mut builder = CircuitBuilder::<F, D>::new(config);
+    let lt_eq_u256_pod_target = LtEqU256PodTarget::add_targets(&mut builder, &params)?;
+    pod2::backends::plonky2::recursion::pad_circuit(&mut builder, &common_data);
+
+    let data = timed!("LtEqU256Pod build", builder.build::<C>());
+    assert_eq!(common_data, data.common);
+    Ok((lt_eq_u256_pod_target, data))
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct LtEqU256Pod {
+    pub params: Params,
+    // verify lhs <= rhs
+    pub lhs: RawValue,
+    pub rhs: RawValue,
+
+    pub vd_set: VDSet,
+    pub statements_hash: Hash,
+    pub proof: Proof,
+
+    pub common_hash: String,
+}
+
+#[allow(dead_code)]
+impl LtEqU256Pod {
+    pub fn new_boxed_mock(
+        params: &Params,
+        vd_set: VDSet,
+        lhs: RawValue,
+        rhs: RawValue,
+    ) -> Result<Box<dyn Pod>> {
+        assert_eq!(params, &Params::default());
+        let vd_hash = *STANDARD_LT_EQ_U256_VD_HASH;
+        let args = vec![Value::from(lhs), Value::from(rhs)];
+        let name = LT_EQ_U256_POD_TYPE.1.to_string();
+        Ok(Box::new(MockIntroPod::new(
+            params, vd_set, name, vd_hash, args,
+        )))
+    }
+
+    pub fn new_boxed(
+        params: &Params,
+        vd_set: VDSet,
+        lhs: RawValue,
+        rhs: RawValue,
+    ) -> Result<Box<dyn Pod>> {
+        Ok(Box::new(Self::new(params, vd_set, lhs, rhs)?))
+    }
+
+    /// Creates a LtEqU256Pod proving that hash[0] <= difficulty
+    pub fn new(
+        params: &Params,
+        vd_set: VDSet,
+        lhs: RawValue,
+        rhs: RawValue,
+    ) -> Result<LtEqU256Pod> {
+        assert_eq!(params, &Params::default());
+
+        // Pre-check difficulty
+        for (lhs_limb, rhs_limb) in lhs.0.iter().zip(rhs.0.iter()).rev() {
+            if lhs_limb.0 > rhs_limb.0 {
+                anyhow::bail!("lhs > rhs in LtEqU256");
+            } else if lhs_limb.0 < rhs_limb.0 {
+                break;
+            }
+        }
+
+        // Build the proof
+        let (lt_eq_u256_pod_target, circuit_data) = &*STANDARD_LT_EQ_U256_POD_DATA;
+        let statements = pub_self_statements(lhs, rhs)
+            .into_iter()
+            .map(mainpod::Statement::from)
+            .collect_vec();
+        let statements_hash: Hash = calculate_statements_hash(&statements);
+
+        // set targets
+        let lt_eq_u256_input = LtEqU256PodInput {
+            vd_root: vd_set.root(),
+            lhs,
+            rhs,
+        };
+
+        let mut pw = PartialWitness::<F>::new();
+        lt_eq_u256_pod_target.set_targets(&mut pw, &lt_eq_u256_input)?;
+
+        let proof_with_pis = timed!(
+            "prove LtEqU256 (LtEqU256Pod proof)",
+            circuit_data.prove(pw)?
+        );
+
+        // sanity check
+        circuit_data
+            .verifier_data()
+            .verify(proof_with_pis.clone())?;
+
+        let common_hash: String =
+            pod2::backends::plonky2::mainpod::cache_get_rec_main_pod_common_hash(params).clone();
+
+        Ok(LtEqU256Pod {
+            params: params.clone(),
+            statements_hash,
+            lhs,
+            rhs,
+            proof: proof_with_pis.proof,
+            vd_set: vd_set.clone(),
+            common_hash,
+        })
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+struct Data {
+    lhs: RawValue,
+    rhs: RawValue,
+    proof: String,
+    common_hash: String,
+}
+
+impl Pod for LtEqU256Pod {
+    fn params(&self) -> &Params {
+        &self.params
+    }
+
+    fn verify(&self) -> pod2::backends::plonky2::Result<()> {
+        let statements = pub_self_statements(self.lhs, self.rhs)
+            .into_iter()
+            .map(mainpod::Statement::from)
+            .collect_vec();
+        let statements_hash: Hash = calculate_statements_hash(&statements);
+        if statements_hash != self.statements_hash {
+            return Err(Error::statements_hash_not_equal(
+                self.statements_hash,
+                statements_hash,
+            ));
+        }
+
+        let (_, circuit_data) = &*STANDARD_LT_EQ_U256_POD_DATA;
+
+        let public_inputs = statements_hash
+            .to_fields()
+            .iter()
+            .chain(self.vd_set().root().0.iter())
+            .cloned()
+            .collect_vec();
+
+        circuit_data
+            .verify(ProofWithPublicInputs {
+                proof: self.proof.clone(),
+                public_inputs,
+            })
+            .map_err(|e| Error::custom(format!("LtEqU256Pod proof verification failure: {e:?}")))
+    }
+
+    fn statements_hash(&self) -> Hash {
+        self.statements_hash
+    }
+
+    fn pod_type(&self) -> (usize, &'static str) {
+        LT_EQ_U256_POD_TYPE
+    }
+
+    fn pub_self_statements(&self) -> Vec<middleware::Statement> {
+        pub_self_statements(self.lhs, self.rhs)
+    }
+
+    fn serialize_data(&self) -> serde_json::Value {
+        serde_json::to_value(Data {
+            lhs: self.lhs,
+            rhs: self.rhs,
+            proof: serialize_proof(&self.proof),
+            common_hash: self.common_hash.clone(),
+        })
+        .expect("serialization to json")
+    }
+
+    fn deserialize_data(
+        params: Params,
+        data: serde_json::Value,
+        vd_set: VDSet,
+        statements_hash: Hash,
+    ) -> BResult<Self> {
+        let data: Data = serde_json::from_value(data)?;
+        let common =
+            &*pod2::backends::plonky2::cache_get_standard_rec_main_pod_common_circuit_data();
+        let proof = deserialize_proof(common, &data.proof)?;
+        Ok(Self {
+            params,
+            lhs: data.lhs,
+            rhs: data.rhs,
+            vd_set,
+            statements_hash,
+            proof,
+            common_hash: data.common_hash,
+        })
+    }
+
+    fn verifier_data(&self) -> VerifierOnlyCircuitData<C, D> {
+        STANDARD_LT_EQ_U256_POD_DATA
+            .1
+            .verifier_data()
+            .verifier_only
+            .clone()
+    }
+
+    fn common_hash(&self) -> String {
+        self.common_hash.clone()
+    }
+
+    fn proof(&self) -> Proof {
+        self.proof.clone()
+    }
+
+    fn vd_set(&self) -> &VDSet {
+        &self.vd_set
+    }
+}
+
+fn pub_self_statements(lhs: RawValue, rhs: RawValue) -> Vec<middleware::Statement> {
+    vec![middleware::Statement::Intro(
+        IntroPredicateRef {
+            name: LT_EQ_U256_POD_TYPE.1.to_string(),
+            args_len: 2,
+            verifier_data_hash: EMPTY_HASH,
+        },
+        vec![lhs.into(), rhs.into()],
+    )]
+}
+
+fn pub_self_statements_target(
+    builder: &mut CircuitBuilder<F, D>,
+    params: &Params,
+    lhs: &[Target],
+    rhs: &[Target],
+) -> Vec<StatementTarget> {
+    let st_arg_0 = StatementArgTarget::literal(builder, &ValueTarget::from_slice(lhs));
+    let st_arg_1 = StatementArgTarget::literal(builder, &ValueTarget::from_slice(rhs));
+
+    let args = [st_arg_0, st_arg_1]
+        .into_iter()
+        .chain(core::iter::repeat_with(|| {
+            StatementArgTarget::none(builder)
+        }))
+        .take(Params::max_statement_args())
+        .collect_vec();
+
+    let verifier_data_hash = builder.constant_hash(HashOut {
+        elements: EMPTY_HASH.0,
+    });
+    let predicate = PredicateTarget::new_intro(builder, verifier_data_hash);
+    vec![StatementTarget::new_with_pred(
+        builder, params, predicate, &args,
+    )]
+}
+
+#[derive(Clone, Debug)]
+struct LtEqU256PodTarget {
+    vd_root: HashOutTarget,
+    lhs: ValueTarget,
+    rhs: ValueTarget,
+}
+
+struct LtEqU256PodInput {
+    vd_root: Hash,
+    lhs: RawValue,
+    rhs: RawValue,
+}
+
+// assert lhs <= rhs for little endian encoded values with 32 bit limbs
+fn assert_lt_eq<const N: usize>(
+    builder: &mut CircuitBuilder<F, D>,
+    lhs: &[Target; N],
+    rhs: &[Target; N],
+) {
+    // Find the highest limb pair that is not equal and store the limb diff for that pair.
+    // We then make sure that the diff fits within 32 bits, which means there's no underflow and
+    // thus limb_lhs <= limb_rhs.
+    let mut diff = builder.constant(F::ZERO);
+    let mut diff_found = builder.constant_bool(false);
+    for (lhs_limb, rhs_limb) in lhs.iter().zip(rhs.iter()).rev() {
+        let limbs_eq = builder.is_equal(*lhs_limb, *rhs_limb);
+        let limbs_neq = builder.not(limbs_eq);
+        let diff_not_found = builder.not(diff_found);
+        let is_first_neq = builder.and(limbs_neq, diff_not_found);
+        diff_found = builder.or(diff_found, is_first_neq);
+        let limbs_diff = builder.sub(*rhs_limb, *lhs_limb);
+        diff = builder.select(is_first_neq, limbs_diff, diff);
+    }
+    builder.range_check(diff, 32);
+}
+
+fn value_to_32b_limbs(builder: &mut CircuitBuilder<F, D>, v: ValueTarget) -> [Target; 8] {
+    let field_max = [
+        builder.constant(F(F::NEG_ONE.to_canonical_u64() & 0xffffffff)),
+        builder.constant(F(F::NEG_ONE.to_canonical_u64() >> 32)),
+    ];
+    let v_64b_limbs = v.elements.map(|t| builder.split_le(t, 64));
+    let v_32b_limbs = v_64b_limbs.map(|bits| {
+        let pair = [
+            builder.le_sum(bits[..32].iter()),
+            builder.le_sum(bits[32..].iter()),
+        ];
+        // Assert that the 64 bit representation is canonical
+        assert_lt_eq(builder, &pair, &field_max);
+        pair
+    });
+    std::array::from_fn(|i| v_32b_limbs[i / 2][i % 2])
+}
+
+impl LtEqU256PodTarget {
+    fn add_targets(builder: &mut CircuitBuilder<F, D>, params: &Params) -> Result<Self> {
+        let measure = measure_gates_begin!(builder, "LtEqU256PodTarget");
+
+        // Add virtual inputs
+        let lhs = builder.add_virtual_value();
+        let rhs = builder.add_virtual_value();
+
+        let lhs_bits = value_to_32b_limbs(builder, lhs);
+        let rhs_bits = value_to_32b_limbs(builder, rhs);
+        assert_lt_eq(builder, &lhs_bits, &rhs_bits);
+
+        // Calculate statements_hash
+        let statements = pub_self_statements_target(builder, params, &lhs.elements, &rhs.elements);
+        let statements_hash = calculate_statements_hash_circuit(builder, &statements);
+
+        // Register public inputs
+        let vd_root = builder.add_virtual_hash();
+        builder.register_public_inputs(&statements_hash.elements);
+        builder.register_public_inputs(&vd_root.elements);
+
+        measure_gates_end!(builder, measure);
+
+        Ok(LtEqU256PodTarget { vd_root, lhs, rhs })
+    }
+
+    fn set_targets(&self, pw: &mut PartialWitness<F>, input: &LtEqU256PodInput) -> Result<()> {
+        pw.set_target_arr(&self.lhs.elements, &input.lhs.0)?;
+        pw.set_target_arr(&self.rhs.elements, &input.rhs.0)?;
+        pw.set_target_arr(&self.vd_root.elements, &input.vd_root.0)?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use plonky2::{
+        hash::hash_types::HashOut,
+        plonk::{
+            circuit_builder::CircuitBuilder, circuit_data::CircuitConfig,
+            config::PoseidonGoldilocksConfig,
+        },
+    };
+    use pod2::{
+        backends::plonky2::{basetypes::DEFAULT_VD_SET, recursion::circuit::hash_verifier_data},
+        middleware::hash_str,
+    };
+
+    use super::*;
+
+    fn test_lt_eq_circuit(lhs: RawValue, rhs: RawValue) -> Result<()> {
+        let config = CircuitConfig::standard_recursion_config();
+        let mut builder = CircuitBuilder::<F, D>::new(config);
+
+        let lhs_target = builder.add_virtual_value();
+        let rhs_target = builder.add_virtual_value();
+
+        let lhs_bits = value_to_32b_limbs(&mut builder, lhs_target);
+        let rhs_bits = value_to_32b_limbs(&mut builder, rhs_target);
+        assert_lt_eq(&mut builder, &lhs_bits, &rhs_bits);
+
+        let mut pw = PartialWitness::<F>::new();
+        pw.set_target_arr(&lhs_target.elements, &lhs.0)?;
+        pw.set_target_arr(&rhs_target.elements, &rhs.0)?;
+
+        let circuit_data = builder.build::<PoseidonGoldilocksConfig>();
+        let proof = circuit_data.prove(pw)?;
+        circuit_data.verify(proof)?;
+        Ok(())
+    }
+
+    #[test]
+    fn test_lt_eq_pass() {
+        test_lt_eq_circuit(
+            RawValue([F(0), F(0), F(0), F(0)]),
+            RawValue([F(0), F(0), F(0), F(0)]),
+        )
+        .unwrap();
+
+        test_lt_eq_circuit(
+            RawValue([F(0), F(0), F(0), F(0)]),
+            RawValue([F(1), F(0), F(0), F(0)]),
+        )
+        .unwrap();
+        test_lt_eq_circuit(
+            RawValue([F(0), F(0), F(0), F(0)]),
+            RawValue([F(0), F(1), F(0), F(0)]),
+        )
+        .unwrap();
+        test_lt_eq_circuit(
+            RawValue([F(1), F(0), F(8), F(0)]),
+            RawValue([F(0), F(1), F(8), F(0)]),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn test_lt_eq_fail() {
+        assert!(
+            test_lt_eq_circuit(
+                RawValue([F(1), F(0), F(0), F(0)]),
+                RawValue([F(0), F(0), F(0), F(0)]),
+            )
+            .is_err()
+        );
+        assert!(
+            test_lt_eq_circuit(
+                RawValue([F(0), F(1), F(0), F(0)]),
+                RawValue([F(0), F(0), F(0), F(0)]),
+            )
+            .is_err()
+        );
+        assert!(
+            test_lt_eq_circuit(
+                RawValue([F(0), F(1), F(8), F(0)]),
+                RawValue([F(1), F(0), F(8), F(0)]),
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn test_lteq256_pod() -> Result<()> {
+        let params = Params::default();
+        let vd_set = &*DEFAULT_VD_SET;
+
+        // Find a valid input by brute force (for testing)
+        let rhs_3 = 0x0020_0000_0000_0000u64;
+        let mut found_input = None;
+
+        for i in 0..10000 {
+            let test_input = RawValue::from(i as i64);
+            let hash_output = RawValue::from(pod2::middleware::hash_value(&test_input));
+            if hash_output.0[3].0 <= rhs_3 {
+                found_input = Some(test_input);
+                println!("Found valid input at i={}: hash={:#}", i, hash_output);
+                break;
+            }
+        }
+
+        let hash_output = RawValue::from(pod2::middleware::hash_value(
+            &found_input.expect("Should find valid input"),
+        ));
+
+        // This should succeed
+        let lt_eq_u256_pod = LtEqU256Pod::new(
+            &params,
+            vd_set.clone(),
+            hash_output,
+            RawValue([F::ZERO, F::ZERO, F::ZERO, F(rhs_3)]),
+        )?;
+        lt_eq_u256_pod.verify()?;
+
+        println!(
+            "lt_eq_u256_pod.verifier_data_hash(): {:#} . To be used in predicates.",
+            lt_eq_u256_pod.verifier_data_hash()
+        );
+
+        // Verify that hash_output meets difficulty
+        assert!(hash_output.0[3].0 <= rhs_3);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_mock_ltequ256() -> Result<()> {
+        let params = Params::default();
+        let vd_set = &*DEFAULT_VD_SET;
+        let rhs = RawValue([F::ZERO, F::ZERO, F::ZERO, F(0x0020_0000_0000_0000u64)]);
+        let hash = RawValue::from(0i64);
+
+        let pod = LtEqU256Pod::new_boxed(&params, vd_set.clone(), hash, rhs)?;
+        pod.verify()?;
+        let mock_pod = LtEqU256Pod::new_boxed_mock(&params, vd_set.clone(), hash, rhs)?;
+        mock_pod.verify()?;
+
+        assert!(mock_pod.is_mock());
+        assert_eq!(pod.verifier_data_hash(), mock_pod.verifier_data_hash());
+        assert_eq!(pod.pub_statements(), mock_pod.pub_statements());
+        Ok(())
+    }
+
+    #[test]
+    fn test_ltequ256_vd_hash() {
+        let expected_vd_hash =
+            hash_verifier_data(&STANDARD_LT_EQ_U256_POD_DATA.1.verifier_data().verifier_only);
+        assert_eq!(
+            expected_vd_hash,
+            HashOut::from(*STANDARD_LT_EQ_U256_VD_HASH)
+        );
+    }
+
+    #[test]
+    fn test_ltequ256_pod_fails_above_difficulty() -> Result<()> {
+        let params = Params::default();
+        let vd_set = &*DEFAULT_VD_SET;
+
+        let input = RawValue::from(hash_str("definitely above difficulty"));
+        let rhs = RawValue([F::ZERO, F::ZERO, F::ZERO, F(0x0000_0000_0000_1000u64)]);
+
+        // This should fail
+        let result = LtEqU256Pod::new(&params, vd_set.clone(), input, rhs);
+        assert!(result.is_err());
+
+        Ok(())
+    }
+}

--- a/intro_pods/vdfpod/Cargo.toml
+++ b/intro_pods/vdfpod/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "vdfpod"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+anyhow = { workspace = true }
+log = { workspace = true }
+itertools.workspace = true
+pod2 = { workspace = true }
+plonky2 = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+hex = { workspace = true }
+
+pod2utils = { path = "../../pod2utils" }

--- a/intro_pods/vdfpod/src/lib.rs
+++ b/intro_pods/vdfpod/src/lib.rs
@@ -1,0 +1,902 @@
+//! VdfPod: Introduction Pod that used as a "Verifiable Delay Function".
+//! - takes as input a custom value, which will be bounded into the recursive chain
+//! - counts how many recursions have been performed
+//!
+//! The 'delay' comes from the proof computation cost at the each recursive step.
+//!
+//! An other option would be to prove the traditional Vdf (hash output within a
+//! range / certain amount of zeroes) inside a circuit, which is easier to
+//! parallelize to gain advantatge.
+//!
+//! Circuits structure:
+//! 1. RecursiveCircuit<VdfInneCircuit>, where for each recursive step:
+//!
+//!   VdfInnerCircuit contains the logic of:
+//!     - output = hash(input)
+//!     - count+1
+//!
+//!   And the RecursiveCircuit does the logic of:
+//!     - verify previous proof of itself
+//!
+//! 2. VdfPod:
+//!     - satisfies in the pod2's Pod trait interface
+//!     - verifies the proof from RecursiveCircuit<VdfInnerCircuit>
+//!
+//!
+//! Usage:
+//! ```rust,no_run
+//!   use pod2::{backends::plonky2::basetypes::DEFAULT_VD_SET, middleware::{Params, RawValue, hash_str}};
+//!   use vdfpod::VdfPod;
+//!
+//!   let params = Params::default();
+//!   let vd_set = &*DEFAULT_VD_SET;
+//!   let n_iters: usize = 2;
+//!   let input = RawValue::from(hash_str("starting input"));
+//!   let vdf_pod = VdfPod::new(&params, vd_set.clone(), n_iters, input).unwrap();
+//! ```
+//! An complete example of usage can be found at the test `test_vdf_pod` (bottom
+//! of this file).
+
+use anyhow::{Result, anyhow};
+use hex::FromHex;
+use itertools::Itertools;
+use plonky2::{
+    field::types::Field,
+    hash::{
+        hash_types::{HashOut, HashOutTarget},
+        poseidon::PoseidonHash,
+    },
+    iop::{
+        target::Target,
+        witness::{PartialWitness, WitnessWrite},
+    },
+    plonk::{
+        circuit_builder::CircuitBuilder,
+        circuit_data::{CircuitData, VerifierOnlyCircuitData},
+        proof::{ProofWithPublicInputs, ProofWithPublicInputsTarget},
+    },
+};
+use pod2::{
+    backends::plonky2::{
+        Error, Result as BResult,
+        circuits::{
+            common::{
+                CircuitBuilderPod, PredicateTarget, StatementArgTarget, StatementTarget,
+                ValueTarget,
+            },
+            mainpod::calculate_statements_hash_circuit,
+        },
+        deserialize_proof, mainpod,
+        mainpod::calculate_statements_hash,
+        recursion::{
+            InnerCircuit, RecursiveCircuit, RecursiveParams, VerifiedProofTarget,
+            circuit::{dummy as dummy_recursive, hash_verifier_data_gadget},
+            new_params as new_recursive_params,
+        },
+        serialize_proof,
+    },
+    measure_gates_begin, measure_gates_end, middleware,
+    middleware::{
+        C, D, EMPTY_HASH, F, HASH_SIZE, Hash, IntroPredicateRef, Params, Pod, Proof, RawValue,
+        ToFields, VDSet, Value,
+    },
+    timed,
+};
+use pod2utils::mockintro::MockIntroPod;
+use serde::{Deserialize, Serialize};
+
+// ARITY is assumed to be one, this also assumed at the VdfInnerCircuit.
+const ARITY: usize = 1;
+const NUM_PUBLIC_INPUTS: usize = 13; // 13: count + input + output + verified_data_hash
+const VDF_POD_TYPE: (usize, &str) = (2001, "Vdf");
+
+pub static STANDARD_VDF_VD_HASH: std::sync::LazyLock<Hash> = std::sync::LazyLock::new(|| {
+    Hash::from_hex("b77a964de74c8569e6c6172692bb50147df9334fd9b572abc8d4d9c688a40e06").unwrap()
+});
+
+static STANDARD_VDF_POD_DATA: std::sync::LazyLock<(VdfPodTarget, CircuitData<F, C, D>)> =
+    std::sync::LazyLock::new(|| build().expect("successful build"));
+fn build() -> Result<(VdfPodTarget, CircuitData<F, C, D>)> {
+    let params = Params::default();
+
+    // use pod2's recursion config as config for the introduction pod; which if
+    // the zk feature enabled, it will have the zk property enabled
+    let rec_circuit_data =
+        &*pod2::backends::plonky2::cache_get_standard_rec_main_pod_common_circuit_data();
+
+    let common_data = rec_circuit_data.0.clone();
+    let config = common_data.config.clone();
+
+    let mut builder = CircuitBuilder::<F, D>::new(config);
+    let vdf_pod_verify_target = VdfPodTarget::add_targets(&mut builder, &params)?;
+    pod2::backends::plonky2::recursion::pad_circuit(&mut builder, &common_data);
+
+    let data = timed!("VdfPod build", builder.build::<C>());
+    assert_eq!(common_data, data.common);
+    Ok((vdf_pod_verify_target, data))
+}
+static VDF_RECURSIVE_CIRCUIT: std::sync::LazyLock<(
+    RecursiveCircuit<VdfInnerCircuit>,
+    RecursiveParams,
+)> = std::sync::LazyLock::new(|| build_vdf_recursive_circuit().expect("successful build"));
+fn build_vdf_recursive_circuit() -> Result<(RecursiveCircuit<VdfInnerCircuit>, RecursiveParams)> {
+    let recursive_params: RecursiveParams =
+        new_recursive_params::<VdfInnerCircuit>(ARITY, NUM_PUBLIC_INPUTS, &())?;
+
+    let recursive_circuit = RecursiveCircuit::<VdfInnerCircuit>::build(&recursive_params, &())?;
+
+    Ok((recursive_circuit, recursive_params))
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct VdfPod {
+    pub params: Params,
+    pub count: F,
+    pub input: RawValue,
+    pub output: RawValue, // output = H(H(H( ...H(input) ))) (count times)
+
+    pub vd_set: VDSet,
+    pub statements_hash: Hash,
+    pub proof: Proof,
+
+    pub common_hash: String,
+}
+
+#[allow(dead_code)]
+impl VdfPod {
+    pub fn new_boxed_mock(
+        params: &Params,
+        vd_set: VDSet,
+        n_iters: usize,
+        input: RawValue,
+    ) -> Result<Box<dyn Pod>> {
+        assert_eq!(params, &Params::default());
+        let vd_hash = *STANDARD_VDF_VD_HASH;
+        let mut output: Hash = Hash::from(input);
+        for _ in 0..n_iters {
+            output = pod2::middleware::hash_value(&RawValue::from(output))
+        }
+        let args = vec![
+            Value::from(n_iters as i64),
+            Value::from(input),
+            Value::from(output),
+        ];
+        let name = VDF_POD_TYPE.1.to_string();
+        Ok(Box::new(MockIntroPod::new(
+            params, vd_set, name, vd_hash, args,
+        )))
+    }
+
+    /// returns a VdfPod for the given n_iters and input.
+    pub fn new(params: &Params, vd_set: VDSet, n_iters: usize, input: RawValue) -> Result<VdfPod> {
+        assert_eq!(params, &Params::default());
+        let (last_iteration_values, proof_with_pis): (
+            VdfInnerCircuitInput,
+            ProofWithPublicInputs<F, C, D>,
+        ) = timed!(
+            "VdfPod::gen_vdf_recursive_circuit_proof",
+            VdfPod::get_vdf_recursive_circuit_proof(n_iters, input)?
+        );
+
+        // generate a new VdfPod from the given count, input, output
+        let (count, input, output) = (
+            last_iteration_values.count,
+            last_iteration_values.input,
+            last_iteration_values.output,
+        );
+        let vdf_pod = timed!(
+            "VdfPod::construct",
+            VdfPod::construct(params, vd_set, count, input, output, proof_with_pis)?
+        );
+
+        #[cfg(test)] // sanity check
+        vdf_pod.verify()?;
+
+        Ok(vdf_pod)
+    }
+
+    pub fn new_boxed(
+        params: &Params,
+        vd_set: VDSet,
+        n_iters: usize,
+        input: RawValue,
+    ) -> Result<Box<dyn Pod>> {
+        Ok(Box::new(Self::new(params, vd_set, n_iters, input)?))
+    }
+
+    /// given the proof from RecursiveCircuit<VdfInnerCircuit>, constructs the
+    /// VdfPod which verifies it.
+    fn construct(
+        params: &Params,
+        vd_set: VDSet,
+        count: F,
+        input: RawValue,
+        output: RawValue,
+        proof: ProofWithPublicInputs<F, C, D>,
+    ) -> Result<VdfPod> {
+        // verify the given proof in a VdfPodTarget circuit
+        let (vdf_pod_target, circuit_data) = &*STANDARD_VDF_POD_DATA;
+        let statements = pub_self_statements(count, input, output)
+            .into_iter()
+            .map(mainpod::Statement::from)
+            .collect_vec();
+        let statements_hash: Hash = calculate_statements_hash(&statements);
+        // set targets
+        let pod_vdf_input = VdfPodVerifyInput {
+            vd_root: vd_set.root(),
+            statements_hash,
+            proof,
+        };
+        let mut pw = PartialWitness::<F>::new();
+        vdf_pod_target.set_targets(&mut pw, &pod_vdf_input)?;
+        let proof_with_pis = timed!(
+            "prove the vdf-verification proof verification (VdfPod proof)",
+            circuit_data.prove(pw)?
+        );
+        // sanity check
+        circuit_data
+            .verifier_data()
+            .verify(proof_with_pis.clone())?;
+
+        let common_hash: String =
+            pod2::backends::plonky2::mainpod::cache_get_rec_main_pod_common_hash(params).clone();
+
+        Ok(VdfPod {
+            params: params.clone(),
+            statements_hash,
+            count,
+            input,
+            output,
+            proof: proof_with_pis.proof,
+            vd_set: vd_set.clone(),
+            common_hash,
+        })
+    }
+
+    /// computes the Vdf proof out of the RecursiveCircuit<VdfInnerCircuit> circuit.
+    fn get_vdf_recursive_circuit_proof(
+        n_iters: usize,
+        starting_input: RawValue,
+    ) -> Result<(VdfInnerCircuitInput, ProofWithPublicInputs<F, C, D>)> {
+        if n_iters < 2 {
+            // this check is due the verifier_data_hash behaving differently for
+            // the first 2 iterations:
+            // - if n_iters=0, is [0,0,0,0]
+            // - if n_iters=1, is the one of the dummy_verifier_data
+            // in both cases, when verifying the proof out of the recursive
+            // chain in the VdfPod circuit, the verifier_data_hash would not
+            // match the one expected (hardcoded as constant) at the VdfPod
+            // circuit.
+            return Err(anyhow!("n_iters must be equal or greater than 2"));
+        }
+
+        let mut inner_inputs = VdfInnerCircuitInput {
+            prev_count: F::ZERO,
+            count: F::ONE,
+            input: starting_input,
+            midput: starting_input, // base case: midput==input
+            output: RawValue::from(pod2::middleware::hash_value(&starting_input)),
+        };
+
+        let (recursive_circuit, recursive_params) = &*VDF_RECURSIVE_CIRCUIT;
+
+        let (dummy_verifier_only_data, dummy_proof) =
+            dummy_recursive(recursive_params.common_data(), NUM_PUBLIC_INPUTS)?;
+        let mut recursive_proof = dummy_proof;
+        let mut recursive_verifier_only_data = dummy_verifier_only_data;
+        for i in 0..n_iters {
+            if i > 0 {
+                inner_inputs.prev_count = inner_inputs.count;
+                inner_inputs.count += F::ONE;
+                inner_inputs.midput = inner_inputs.output;
+                inner_inputs.output =
+                    RawValue::from(pod2::middleware::hash_value(&inner_inputs.midput));
+
+                recursive_verifier_only_data =
+                    recursive_params.verifier_data().verifier_only.clone();
+            }
+            log::debug!("{inner_inputs:?}");
+            log::debug!("{:?}", recursive_proof.public_inputs);
+
+            recursive_proof = recursive_circuit.prove(
+                &inner_inputs,
+                vec![recursive_proof.clone()],
+                vec![recursive_verifier_only_data.clone()],
+            )?;
+            recursive_params
+                .verifier_data()
+                .verify(recursive_proof.clone())?;
+        }
+        Ok((inner_inputs, recursive_proof))
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+struct Data {
+    count: F,
+    input: RawValue,
+    output: RawValue,
+    proof: String,
+    common_hash: String,
+}
+
+impl Pod for VdfPod {
+    fn params(&self) -> &Params {
+        &self.params
+    }
+    fn verify(&self) -> pod2::backends::plonky2::Result<()> {
+        let statements = pub_self_statements(self.count, self.input, self.output)
+            .into_iter()
+            .map(mainpod::Statement::from)
+            .collect_vec();
+        let statements_hash: Hash = calculate_statements_hash(&statements);
+        if statements_hash != self.statements_hash {
+            return Err(Error::statements_hash_not_equal(
+                self.statements_hash,
+                statements_hash,
+            ));
+        }
+
+        let (_, circuit_data) = &*STANDARD_VDF_POD_DATA;
+
+        let public_inputs = statements_hash
+            .to_fields()
+            .iter()
+            .chain(self.vd_set().root().0.iter())
+            .cloned()
+            .collect_vec();
+
+        circuit_data
+            .verify(ProofWithPublicInputs {
+                proof: self.proof.clone(),
+                public_inputs,
+            })
+            .map_err(|e| Error::custom(format!("VdfPod proof verification failure: {e:?}")))
+    }
+
+    fn statements_hash(&self) -> Hash {
+        self.statements_hash
+    }
+
+    fn pod_type(&self) -> (usize, &'static str) {
+        VDF_POD_TYPE
+    }
+
+    fn pub_self_statements(&self) -> Vec<middleware::Statement> {
+        // exposed as a separate function for easier isolated testing
+        pub_self_statements(self.count, self.input, self.output)
+    }
+
+    fn serialize_data(&self) -> serde_json::Value {
+        serde_json::to_value(Data {
+            count: self.count,
+            input: self.input,
+            output: self.output,
+            proof: serialize_proof(&self.proof),
+            common_hash: self.common_hash.clone(),
+        })
+        .expect("serialization to json")
+    }
+    fn deserialize_data(
+        params: Params,
+        data: serde_json::Value,
+        vd_set: VDSet,
+        statements_hash: Hash,
+    ) -> BResult<Self> {
+        let data: Data = serde_json::from_value(data)?;
+        let common =
+            &*pod2::backends::plonky2::cache_get_standard_rec_main_pod_common_circuit_data();
+        let proof = deserialize_proof(common, &data.proof)?;
+        Ok(Self {
+            params,
+            count: data.count,
+            input: data.input,
+            output: data.output,
+            vd_set,
+            statements_hash,
+            proof,
+            common_hash: data.common_hash,
+        })
+    }
+
+    fn verifier_data(&self) -> VerifierOnlyCircuitData<C, D> {
+        STANDARD_VDF_POD_DATA
+            .1
+            .verifier_data()
+            .verifier_only
+            .clone()
+    }
+
+    fn common_hash(&self) -> String {
+        self.common_hash.clone()
+    }
+    fn proof(&self) -> Proof {
+        self.proof.clone()
+    }
+    fn vd_set(&self) -> &VDSet {
+        &self.vd_set
+    }
+}
+
+fn pub_self_statements(count: F, input: RawValue, output: RawValue) -> Vec<middleware::Statement> {
+    vec![middleware::Statement::Intro(
+        IntroPredicateRef {
+            name: VDF_POD_TYPE.1.to_string(),
+            args_len: 3,
+            verifier_data_hash: EMPTY_HASH,
+        },
+        vec![
+            RawValue([count, F::ZERO, F::ZERO, F::ZERO]).into(),
+            input.into(),
+            output.into(),
+        ],
+    )]
+}
+fn pub_self_statements_target(
+    builder: &mut CircuitBuilder<F, D>,
+    params: &Params,
+    count: Target,
+    input: &[Target],
+    output: &[Target],
+) -> Vec<StatementTarget> {
+    let zero = builder.zero();
+    let st_arg_0 = StatementArgTarget::literal(
+        builder,
+        &ValueTarget::from_slice(&[count, zero, zero, zero]),
+    );
+    let st_arg_1 = StatementArgTarget::literal(builder, &ValueTarget::from_slice(input));
+    let st_arg_2 = StatementArgTarget::literal(builder, &ValueTarget::from_slice(output));
+    let args = [st_arg_0, st_arg_1, st_arg_2]
+        .into_iter()
+        .chain(core::iter::repeat_with(|| {
+            StatementArgTarget::none(builder)
+        }))
+        .take(Params::max_statement_args())
+        .collect_vec();
+
+    let verifier_data_hash = builder.constant_hash(HashOut {
+        elements: EMPTY_HASH.0,
+    });
+    let predicate = PredicateTarget::new_intro(builder, verifier_data_hash);
+    vec![StatementTarget::new_with_pred(
+        builder, params, predicate, &args,
+    )]
+}
+
+#[derive(Clone, Debug)]
+struct VdfPodTarget {
+    vd_root: HashOutTarget,
+    statements_hash: HashOutTarget,
+    proof: ProofWithPublicInputsTarget<D>,
+}
+struct VdfPodVerifyInput {
+    vd_root: Hash,
+    statements_hash: Hash,
+    proof: ProofWithPublicInputs<F, C, D>,
+}
+impl VdfPodTarget {
+    fn add_targets(builder: &mut CircuitBuilder<F, D>, params: &Params) -> Result<Self> {
+        let measure = measure_gates_begin!(builder, "VdfPodTarget");
+
+        // Verify RecursiveCircuit<VdfInnerCircuit>'s proof (with verifier_data hardcoded as constant)
+        let (_, recursive_params) = &*VDF_RECURSIVE_CIRCUIT;
+        let verifier_data_targ =
+            builder.constant_verifier_data(&recursive_params.verifier_data().verifier_only);
+        let proof = builder.add_virtual_proof_with_pis(recursive_params.common_data());
+        builder.verify_proof::<C>(&proof, &verifier_data_targ, recursive_params.common_data());
+
+        // ensure that the verifier_data_hash that appears at the public inputs
+        // of the proof being verified matches the one that is constant
+        let pi_verifier_data_hash = &proof.public_inputs[9..13];
+        let constant_verifier_data_hash = hash_verifier_data_gadget(builder, &verifier_data_targ);
+        #[allow(clippy::needless_range_loop)] // to use same syntax as in other similar circuits
+        for i in 0..HASH_SIZE {
+            builder.connect(
+                pi_verifier_data_hash[i],
+                constant_verifier_data_hash.elements[i],
+            );
+        }
+
+        // calculate statements_hash
+        let count = proof.public_inputs[0];
+        let input = &proof.public_inputs[1..5];
+        let output = &proof.public_inputs[5..9];
+        let statements = pub_self_statements_target(builder, params, count, input, output);
+        let statements_hash = calculate_statements_hash_circuit(builder, &statements);
+
+        // register the public inputs
+        let vd_root = builder.add_virtual_hash();
+        builder.register_public_inputs(&statements_hash.elements);
+        builder.register_public_inputs(&vd_root.elements);
+
+        measure_gates_end!(builder, measure);
+        Ok(VdfPodTarget {
+            vd_root,
+            statements_hash,
+            proof,
+        })
+    }
+
+    fn set_targets(&self, pw: &mut PartialWitness<F>, input: &VdfPodVerifyInput) -> Result<()> {
+        pw.set_proof_with_pis_target(&self.proof, &input.proof)?;
+        pw.set_hash_target(
+            self.statements_hash,
+            HashOut::from_vec(input.statements_hash.0.to_vec()),
+        )?;
+        pw.set_target_arr(&self.vd_root.elements, &input.vd_root.0)?;
+
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug)]
+struct VdfInnerCircuit {
+    prev_count: Target,
+    count: Target,       // count contains the amount of recursive steps done
+    input: ValueTarget,  // input that is bounded into the recursive chain
+    midput: ValueTarget, // midput is the 'input' used for the last step of the recursion
+    output: ValueTarget, // output of the recursive chain
+}
+#[derive(Debug)]
+struct VdfInnerCircuitInput {
+    prev_count: F,
+    count: F,
+    input: RawValue,
+    midput: RawValue,
+    output: RawValue,
+}
+impl InnerCircuit for VdfInnerCircuit {
+    type Input = VdfInnerCircuitInput;
+    type Params = ();
+    fn build(
+        builder: &mut CircuitBuilder<F, D>,
+        _params: &Self::Params,
+        verified_proofs: &[VerifiedProofTarget],
+    ) -> BResult<Self> {
+        let prev_count = builder.add_virtual_target();
+        let input = builder.add_virtual_value();
+        let midput = builder.add_virtual_value();
+
+        let output_h = builder.hash_n_to_hash_no_pad::<PoseidonHash>(midput.elements.to_vec());
+        let output = ValueTarget::from_slice(output_h.elements.as_ref());
+
+        let zero = builder.zero();
+        let one = builder.one();
+
+        let is_basecase = builder.is_equal(prev_count, zero); // case 0
+        let is_not_basecase = builder.not(is_basecase);
+        let is_case_1 = builder.is_equal(prev_count, one); // case 1
+        let case_0_or_1 = builder.or(is_basecase, is_case_1);
+        let after_case_1 = builder.not(case_0_or_1);
+
+        // if we're at the prev_count==0, ensure that
+        // input==midput
+        for i in 0..HASH_SIZE {
+            builder.conditional_assert_eq(
+                is_basecase.target,
+                input.elements[i],
+                midput.elements[i],
+            );
+        }
+
+        // if we're at case prev_count>0, assert that the public_inputs of the
+        // proof being verified match with the prev_count, input and midput.
+        // For prev_count>1, we also check that the verifier_data_hash being
+        // used matches the one at the public_inputs of the previous proof.
+        builder.connect(verified_proofs[0].public_inputs[0], prev_count);
+        for i in 0..HASH_SIZE {
+            // if prev_count>0:
+            builder.conditional_assert_eq(
+                is_not_basecase.target,
+                verified_proofs[0].public_inputs[1 + i],
+                input.elements[i],
+            );
+            builder.conditional_assert_eq(
+                is_not_basecase.target,
+                verified_proofs[0].public_inputs[5 + i],
+                midput.elements[i],
+            );
+
+            // if we're at case prev_count>1:
+            // check that the verifier_data's hash used to verify the current
+            // proof is the same as in the public_inputs. Notice that at case 0,
+            // this verifier_data_hash is [0,0,0,0], and at case 1 is the hash
+            // of the dummy_verifier_data; hence we do this check when
+            // prev_count>1.
+            builder.conditional_assert_eq(
+                after_case_1.target,
+                verified_proofs[0].public_inputs[9 + i],
+                verified_proofs[0].verifier_data_hash.elements[i],
+            );
+        }
+
+        // increment count
+        let count = builder.add(prev_count, one);
+
+        // register public inputs: count, input, output
+        builder.register_public_input(count);
+        builder.register_public_inputs(&input.elements);
+        builder.register_public_inputs(&output.elements);
+        builder.register_public_inputs(&verified_proofs[0].verifier_data_hash.elements);
+
+        Ok(Self {
+            prev_count,
+            count,
+            input,
+            midput,
+            output,
+        })
+    }
+    fn set_targets(&self, pw: &mut PartialWitness<F>, input: &Self::Input) -> BResult<()> {
+        pw.set_target(self.prev_count, input.prev_count)?;
+        pw.set_target(self.count, input.count)?;
+        pw.set_target_arr(&self.input.elements, &input.input.0)?;
+        pw.set_target_arr(&self.midput.elements, &input.midput.0)?;
+        pw.set_target_arr(&self.output.elements, &input.output.0)?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use plonky2::plonk::circuit_data::CircuitConfig;
+    use pod2::{
+        backends::plonky2::{basetypes::DEFAULT_VD_SET, recursion::circuit::hash_verifier_data},
+        frontend, measure_gates_print,
+        middleware::{Value, hash_str},
+    };
+
+    use super::*;
+
+    // For tests only. Returns a valid VerifiedProofTarget filled with the
+    // public_inputs from the given VdfInnerCircuitInput, in order to run some
+    // tests.
+    fn empty_verified_proof_target(
+        builder: &mut CircuitBuilder<F, D>,
+        inp: &VdfInnerCircuitInput,
+    ) -> VerifiedProofTarget {
+        let count = builder.constant(inp.prev_count);
+        let input = builder.constants(&inp.input.0);
+        let midput = if inp.prev_count.is_zero() {
+            builder.constants(&inp.output.0)
+        } else {
+            builder.constants(&inp.midput.0)
+        };
+        let verifier_data_hash = HashOutTarget::from_partial(&[builder.zero()], builder.zero());
+        VerifiedProofTarget {
+            public_inputs: [
+                vec![count],
+                input,
+                midput,
+                verifier_data_hash.elements.to_vec(),
+            ]
+            .concat(),
+            verifier_data_hash,
+        }
+    }
+
+    #[ignore]
+    #[test]
+    fn test_inner_circuit() -> Result<()> {
+        let inner_params = ();
+
+        let starting_input = RawValue::from(hash_str("starting input"));
+
+        // circuit
+        let config = CircuitConfig::standard_recursion_zk_config();
+        let mut builder = CircuitBuilder::<F, D>::new(config.clone());
+
+        let inner_inputs = VdfInnerCircuitInput {
+            prev_count: F::ZERO,
+            count: F::ONE,
+            input: starting_input,
+            midput: starting_input, // base case: midput==input
+            output: RawValue::from(pod2::middleware::hash_value(&starting_input)),
+        };
+
+        // build circuit
+        let measure = measure_gates_begin!(&builder, format!("VdfInnerCircuit gates"));
+        let verified_proof_target = empty_verified_proof_target(&mut builder, &inner_inputs);
+        let targets =
+            VdfInnerCircuit::build(&mut builder, &inner_params, &[verified_proof_target])?;
+        measure_gates_end!(&builder, measure);
+        measure_gates_print!();
+        let data = builder.build::<C>();
+
+        // set witness
+        let mut pw = PartialWitness::<F>::new();
+        targets.set_targets(&mut pw, &inner_inputs)?;
+
+        // generate & verify proof
+        let proof = data.prove(pw)?;
+        data.verify(proof.clone())?;
+
+        // Second iteration
+        let inner_inputs = VdfInnerCircuitInput {
+            prev_count: F::ONE,
+            count: F::from_canonical_u64(2u64),
+            input: starting_input,
+            midput: inner_inputs.output, // base case: midput==input
+            output: RawValue::from(pod2::middleware::hash_value(&inner_inputs.output)),
+        };
+        let mut builder = CircuitBuilder::<F, D>::new(config);
+        let mut pw = PartialWitness::<F>::new();
+        let verified_proof_target = empty_verified_proof_target(&mut builder, &inner_inputs);
+        let targets =
+            VdfInnerCircuit::build(&mut builder, &inner_params, &[verified_proof_target])?;
+        targets.set_targets(&mut pw, &inner_inputs)?;
+        let data = builder.build::<C>();
+        let proof = data.prove(pw)?;
+        data.verify(proof.clone())?;
+
+        Ok(())
+    }
+
+    #[ignore]
+    #[test]
+    fn test_recursion_on_inner_circuit() -> Result<()> {
+        let starting_input = RawValue::from(hash_str("starting input"));
+        let _ = VdfPod::get_vdf_recursive_circuit_proof(3, starting_input)?;
+        Ok(())
+    }
+
+    /// test to ensure that the pub_self_statements methods match between the
+    /// in-circuit and the out-circuit implementations
+    #[ignore]
+    #[test]
+    fn test_pub_self_statements_target() -> Result<()> {
+        // first generate all the circuits data so that it does not need to be
+        // computed at further stages of the test (affecting the time reports)
+        timed!(
+            "generate VDF_RECURSIVE_CIRCUIT, STANDARD_VDF_POD_DATA, STANDARD_REC_MAIN_POD_CIRCUIT",
+            {
+                let (_, _) = &*VDF_RECURSIVE_CIRCUIT;
+                let (_, _) = &*STANDARD_VDF_POD_DATA;
+                let _ =
+                    &*pod2::backends::plonky2::cache_get_standard_rec_main_pod_common_circuit_data(
+                    );
+            }
+        );
+
+        let params = &Default::default();
+
+        let count = F::ONE;
+        let input = RawValue::from(hash_str("starting input"));
+        let output = RawValue::from(pod2::middleware::hash_value(&input));
+
+        let st = pub_self_statements(count, input, output)
+            .into_iter()
+            .map(mainpod::Statement::from)
+            .collect_vec();
+        let statements_hash: HashOut<F> =
+            HashOut::<F>::from_vec(calculate_statements_hash(&st).0.to_vec());
+
+        // circuit
+        let config = CircuitConfig::standard_recursion_config();
+        let mut builder = CircuitBuilder::<F, D>::new(config);
+        let mut pw = PartialWitness::<F>::new();
+
+        // add targets
+        let count_targ = builder.add_virtual_target();
+        let input_targ = builder.add_virtual_value();
+        let output_targ = builder.add_virtual_value();
+        let expected_statements_hash_targ = builder.add_virtual_hash();
+
+        // set values to targets
+        pw.set_target(count_targ, count)?;
+        pw.set_target_arr(&input_targ.elements, &input.0)?;
+        pw.set_target_arr(&output_targ.elements, &output.0)?;
+        pw.set_hash_target(expected_statements_hash_targ, statements_hash)?;
+
+        let st_targ = pub_self_statements_target(
+            &mut builder,
+            params,
+            count_targ,
+            &input_targ.elements,
+            &output_targ.elements,
+        );
+        let statements_hash_targ = calculate_statements_hash_circuit(&mut builder, &st_targ);
+
+        builder.connect_hashes(expected_statements_hash_targ, statements_hash_targ);
+
+        // generate & verify proof
+        let data = builder.build::<C>();
+        let proof = data.prove(pw)?;
+        data.verify(proof.clone())?;
+
+        Ok(())
+    }
+
+    #[ignore]
+    #[test]
+    fn test_vdf_pod() -> Result<()> {
+        // for this test, first generate all the circuits data so that it does
+        // not need to be computed at further stages of the test (affecting the
+        // time reports)
+        timed!(
+            "generate VDF_RECURSIVE_CIRCUIT, STANDARD_VDF_POD_DATA, standard_rec_main_pod_common_circuit_data",
+            {
+                let (_, _) = &*VDF_RECURSIVE_CIRCUIT;
+                let (_, _) = &*STANDARD_VDF_POD_DATA;
+                let _ =
+                    &*pod2::backends::plonky2::cache_get_standard_rec_main_pod_common_circuit_data(
+                    );
+            }
+        );
+
+        let params = Params::default();
+        let n_iters: usize = 2;
+        let input = RawValue::from(hash_str("starting input"));
+
+        let vd_set = &*DEFAULT_VD_SET;
+        let vdf_pod = timed!(
+            "VdfPod::new",
+            VdfPod::new(&params, vd_set.clone(), n_iters, input)?
+        );
+        vdf_pod.verify()?;
+
+        println!(
+            "vdf_pod.verifier_data_hash(): {:#} . To be used when importing the VdfPod as introduction pod to define new predicates.",
+            vdf_pod.verifier_data_hash()
+        );
+
+        // wrap the vdf_pod in a 'MainPod'
+        let main_vdf_pod = frontend::MainPod {
+            pod: Box::new(vdf_pod.clone()),
+            public_statements: vdf_pod.pub_statements(),
+            params: params.clone(),
+        };
+
+        let expected_count = Value::from(n_iters as i64);
+        let expected_input = input;
+
+        // now generate a new MainPod from the vdf_pod
+        let mut main_pod_builder = frontend::MainPodBuilder::new(&params, vd_set);
+        main_pod_builder.add_pod(main_vdf_pod.clone())?;
+
+        main_pod_builder.reveal(&main_vdf_pod.public_statements[0]);
+
+        let prover = pod2::backends::plonky2::mock::mainpod::MockProver {};
+        let pod = main_pod_builder.prove(&prover)?;
+        assert!(pod.pod.verify().is_ok());
+
+        println!("going to prove the main_pod");
+        let prover = mainpod::Prover {};
+        let main_pod = timed!("main_pod_builder.prove", main_pod_builder.prove(&prover)?);
+        let pod: Box<mainpod::MainPod> = (main_pod.pod as Box<dyn std::any::Any>)
+            .downcast::<mainpod::MainPod>()
+            .unwrap();
+        pod.verify()?;
+
+        let st_vdf = pod.pub_statements()[0].clone();
+        let count = st_vdf.args()[0].literal()?;
+        let input = st_vdf.args()[1].literal()?;
+        assert_eq!(count, expected_count);
+        assert_eq!(input, Value::from(expected_input));
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_vdf_vd_hash() {
+        let expected_vd_hash =
+            hash_verifier_data(&STANDARD_VDF_POD_DATA.1.verifier_data().verifier_only);
+        assert_eq!(expected_vd_hash, HashOut::from(*STANDARD_VDF_VD_HASH));
+    }
+
+    #[test]
+    fn test_mock_vdf() {
+        let params = Params::default();
+        let vd_set = &*DEFAULT_VD_SET;
+        let n_iters: usize = 2;
+        let input = RawValue::from(hash_str("starting input"));
+
+        let pod = VdfPod::new_boxed(&params, vd_set.clone(), n_iters, input).unwrap();
+        pod.verify().unwrap();
+        let mock_pod = VdfPod::new_boxed_mock(&params, vd_set.clone(), n_iters, input).unwrap();
+        mock_pod.verify().unwrap();
+
+        assert_eq!(pod.verifier_data_hash(), mock_pod.verifier_data_hash());
+        assert_eq!(pod.pub_statements(), mock_pod.pub_statements());
+    }
+}

--- a/pod2utils/Cargo.toml
+++ b/pod2utils/Cargo.toml
@@ -10,3 +10,5 @@ pod2 = { workspace = true }
 log = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+plonky2 = { workspace = true }
+rand = { workspace = true }

--- a/pod2utils/src/lib.rs
+++ b/pod2utils/src/lib.rs
@@ -2,8 +2,8 @@ pub mod macros;
 pub mod mockintro;
 
 use plonky2::field::types::Field;
-use pod2::middleware::{RawValue, F};
-use rand::{rngs::StdRng, RngCore, SeedableRng};
+use pod2::middleware::{F, RawValue};
+use rand::{RngCore, SeedableRng, rngs::StdRng};
 use std::array;
 
 pub fn rand_raw_value() -> RawValue {

--- a/pod2utils/src/lib.rs
+++ b/pod2utils/src/lib.rs
@@ -1,2 +1,12 @@
 pub mod macros;
 pub mod mockintro;
+
+use plonky2::field::types::Field;
+use pod2::middleware::{RawValue, F};
+use rand::{rngs::StdRng, RngCore, SeedableRng};
+use std::array;
+
+pub fn rand_raw_value() -> RawValue {
+    let mut rng = StdRng::from_os_rng();
+    RawValue(array::from_fn(|_| F::from_noncanonical_u64(rng.next_u64())))
+}

--- a/pod2utils/src/macros.rs
+++ b/pod2utils/src/macros.rs
@@ -4,8 +4,8 @@ use pod2::{
     frontend::MultiPodBuilder,
     lang::Module,
     middleware::{
-        containers::{Dictionary, Set},
         CustomPredicateRef, Key, Statement, Value,
+        containers::{Dictionary, Set},
     },
 };
 

--- a/pod2utils/src/macros.rs
+++ b/pod2utils/src/macros.rs
@@ -4,8 +4,8 @@ use pod2::{
     frontend::MultiPodBuilder,
     lang::Module,
     middleware::{
-        CustomPredicateRef, Key, Statement, Value,
         containers::{Dictionary, Set},
+        CustomPredicateRef, Key, Statement, Value,
     },
 };
 
@@ -300,14 +300,40 @@ macro_rules! _st_custom {
     }};
 }
 
-pub struct BuildContext<'a> {
-    pub builder: &'a mut MultiPodBuilder,
-    pub modules: &'a [Arc<Module>],
+pub struct BuildContext {
+    pub builder: MultiPodBuilder,
+    pub modules: Vec<Arc<Module>>,
 }
 
-impl<'a> BuildContext<'a> {
-    pub fn new(builder: &'a mut MultiPodBuilder, modules: &'a [Arc<Module>]) -> Self {
+impl BuildContext {
+    pub fn new(builder: MultiPodBuilder, modules: Vec<Arc<Module>>) -> Self {
         Self { builder, modules }
+    }
+}
+
+impl BuildContext {
+    pub fn apply_custom_pred(
+        &mut self,
+        public: bool,
+        name: &str,
+        wildcard_map: HashMap<String, Value>,
+        statements: Vec<Statement>,
+    ) -> anyhow::Result<Statement> {
+        for module in &self.modules {
+            if let Some(cpr) = module.predicate_ref_by_name(name) {
+                return module.apply_predicate_with(name, statements, public, |is_public, op| {
+                    let mut wildcard_values: Vec<(usize, Value)> = Vec::new();
+                    for (i, name) in cpr.predicate().wildcard_names().iter().enumerate() {
+                        if let Some(value) = wildcard_map.get(name) {
+                            wildcard_values.push((i, value.clone()));
+                        }
+                    }
+                    let st = self.builder.op(is_public, wildcard_values, op).unwrap();
+                    Ok(st)
+                });
+            }
+        }
+        panic!("predicate not found");
     }
 }
 
@@ -317,7 +343,7 @@ impl<'a> BuildContext<'a> {
 #[rustfmt::skip]
 macro_rules! pub_st_custom {
     ($ctx:expr, $pred:ident($($wc_name:ident=$wc_value:expr),*) = ($($sts:tt)*)) => {{
-        $crate::_st_custom!($ctx.builder, $ctx.modules, true, $pred($($wc_name=$wc_value),*) = ($($sts)*))
+        $crate::_st_custom!(&mut $ctx.builder, &$ctx.modules, true, $pred($($wc_name=$wc_value),*) = ($($sts)*))
     }};
 }
 
@@ -331,6 +357,6 @@ macro_rules! pub_st_custom {
 #[rustfmt::skip]
 macro_rules! st_custom {
     ($ctx:expr, $pred:ident($($wc_name:ident=$wc_value:expr),*) = ($($sts:tt)*)) => {{
-        $crate::_st_custom!($ctx.builder, $ctx.modules, false, $pred($($wc_name=$wc_value),*) = ($($sts)*))
+        $crate::_st_custom!(&mut $ctx.builder, &$ctx.modules, false, $pred($($wc_name=$wc_value),*) = ($($sts)*))
     }};
 }

--- a/synchronizer/src/state_machine.rs
+++ b/synchronizer/src/state_machine.rs
@@ -234,6 +234,7 @@ mod tests {
     use hex::ToHex;
     use pod2::middleware::{hash_values, Value};
     use tempfile::TempDir;
+    use txlib::new_obj;
 
     fn make_sm() -> (StateMachine, TempDir) {
         let dir = TempDir::new().unwrap();
@@ -477,7 +478,7 @@ mod tests {
         };
         use pod2utils::macros::BuildContext;
         use std::collections::HashSet;
-        use txlib::{Object, TxBuilder};
+        use txlib::TxBuilder;
 
         let params = Params::default();
         let vd_set = &*DEFAULT_VD_SET;
@@ -508,19 +509,19 @@ mod tests {
 
         // Prove a transaction using txlib's TxBuilder.
         let txlib_modules = vec![Arc::new(txlib::predicates::module())];
-        let mut builder = MultiPodBuilder::new(&params, vd_set);
+        let builder = MultiPodBuilder::new(&params, vd_set);
         let mut ctx = BuildContext {
-            builder: &mut builder,
-            modules: &txlib_modules,
+            builder,
+            modules: txlib_modules,
         };
 
-        let obj = Object::new(std::collections::HashMap::new());
+        let obj = new_obj();
         let mut tx_builder = TxBuilder::new(&mut ctx, &[], state_root);
         tx_builder.insert(&mut ctx, obj);
         let (st_finalized, tx) = tx_builder.finalize(&mut ctx);
         ctx.builder.reveal(&st_finalized).unwrap();
 
-        let solution = builder.solve().unwrap();
+        let solution = ctx.builder.solve().unwrap();
         let pod = solution.prove(&Prover {}).unwrap().pods.pop().unwrap();
         pod.pod.verify().unwrap();
 

--- a/timelib/src/predicates/mod.rs
+++ b/timelib/src/predicates/mod.rs
@@ -18,7 +18,7 @@ mod tests {
     use pod2::{
         backends::plonky2::mock::mainpod::MockProver,
         frontend::MultiPodBuilder,
-        middleware::{containers::Array, Key, Params, VDSet, Value},
+        middleware::{Key, Params, VDSet, Value, containers::Array},
     };
     use pod2utils::{macros::BuildContext, op, set};
 
@@ -61,7 +61,7 @@ mod tests {
     /// GSR₂ (when the lock was established). The transaction is finalized.
     #[test]
     fn prove_lock_and_unlock() {
-        use txlib::{new_obj, StateRoot as TxStateRoot, TxBuilder};
+        use txlib::{StateRoot as TxStateRoot, TxBuilder, new_obj};
 
         let txlib_module = Arc::new(txlib::predicates::module());
         let time_module = Arc::new(module().unwrap());
@@ -179,7 +179,7 @@ mod tests {
     /// takes the expiry-bearing object as an input and proves `NotExpired`.
     #[test]
     fn prove_set_expiry_and_not_expired() {
-        use txlib::{new_obj, StateRoot as TxStateRoot, TxBuilder};
+        use txlib::{StateRoot as TxStateRoot, TxBuilder, new_obj};
 
         let txlib_module = Arc::new(txlib::predicates::module());
         let time_module = Arc::new(module().unwrap());

--- a/timelib/src/tx_utils.rs
+++ b/timelib/src/tx_utils.rs
@@ -18,7 +18,7 @@ use anyhow::ensure;
 use pod2::{
     frontend::MultiPodError,
     lang::{Module, MultiOperationError},
-    middleware::{containers::Dictionary, hash_values, Key, Statement, Value},
+    middleware::{Key, Statement, Value, containers::Dictionary, hash_values},
 };
 use pod2utils::{macros::BuildContext, op, st_custom};
 use txlib::{StateRoot, Tx};

--- a/txlib/src/lib.rs
+++ b/txlib/src/lib.rs
@@ -228,7 +228,7 @@ impl TxBuilder {
 
     fn st_tx_obj_nullified(&mut self, ctx: &mut BuildContext, obj: &Dictionary) -> Statement {
         let key = obj.get(&Key::from("key")).unwrap().clone();
-        let obj_key_hash = hash_values(&[Value::from(obj.commitment()), Value::from(key)]);
+        let obj_key_hash = hash_values(&[Value::from(obj.commitment()), key]);
         let obj_nullifier =
             hash_values(&[Value::from(obj_key_hash), Value::from("txlib-nullifier-v1")]);
         let tx_before = self.tx.dict();
@@ -337,7 +337,7 @@ mod tests {
             basetypes::DEFAULT_VD_SET, mainpod::Prover, mock::mainpod::MockProver,
         },
         frontend::{MainPod, MultiPodBuilder},
-        middleware::{MainPodProver, Params, VDSet},
+        middleware::{MainPodProver, Params, VDSet, EMPTY_VALUE},
     };
     use pod2utils::{macros::BuildContext, set};
 
@@ -380,10 +380,10 @@ mod tests {
         let params = Params::default();
 
         // Insert
-        let mut builder = MultiPodBuilder::new(&params, vd_set);
+        let builder = MultiPodBuilder::new(&params, vd_set);
         let mut ctx = BuildContext {
-            builder: &mut builder,
-            modules: &modules,
+            builder,
+            modules: modules.clone(),
         };
 
         let mut tx_builder = TxBuilder::new(&mut ctx, &[], Arc::new(state_root.clone()));
@@ -392,7 +392,7 @@ mod tests {
         let (st, tx0) = tx_builder.finalize(&mut ctx);
         ctx.builder.reveal(&st).unwrap();
 
-        let tx_pod = prove(builder, prover);
+        let tx_pod = prove(ctx.builder, prover);
         tx_pod.pod.verify().unwrap();
 
         state_root
@@ -404,10 +404,10 @@ mod tests {
         }
 
         // Mutate
-        let mut builder = MultiPodBuilder::new(&params, vd_set);
+        let builder = MultiPodBuilder::new(&params, vd_set);
         let mut ctx = BuildContext {
-            builder: &mut builder,
-            modules: &modules,
+            builder,
+            modules: modules.clone(),
         };
 
         let inputs = vec![(obj0.clone(), tx0)];
@@ -418,7 +418,7 @@ mod tests {
         let (st, tx1) = tx_builder.finalize(&mut ctx);
         ctx.builder.reveal(&st).unwrap();
 
-        let tx_pod = prove(builder, prover);
+        let tx_pod = prove(ctx.builder, prover);
         tx_pod.pod.verify().unwrap();
 
         state_root
@@ -430,10 +430,10 @@ mod tests {
         }
 
         // Delete
-        let mut builder = MultiPodBuilder::new(&params, vd_set);
+        let builder = MultiPodBuilder::new(&params, vd_set);
         let mut ctx = BuildContext {
-            builder: &mut builder,
-            modules: &modules,
+            builder,
+            modules: modules.clone(),
         };
 
         let inputs = vec![(obj1.clone(), tx1)];
@@ -442,7 +442,7 @@ mod tests {
         let (st, tx2) = tx_builder.finalize(&mut ctx);
         ctx.builder.reveal(&st).unwrap();
 
-        let tx_pod = prove(builder, prover);
+        let tx_pod = prove(ctx.builder, prover);
         tx_pod.pod.verify().unwrap();
 
         state_root

--- a/txlib/src/lib.rs
+++ b/txlib/src/lib.rs
@@ -6,8 +6,9 @@ use std::{
 };
 
 use pod2::middleware::{
+    EMPTY_VALUE, Hash, Key, Statement, Value,
     containers::{Array, Dictionary, Set},
-    hash_values, Hash, Key, Statement, Value, EMPTY_VALUE,
+    hash_values,
 };
 use pod2utils::{dict, dict_define, macros::BuildContext, rand_raw_value, set, st_custom};
 

--- a/txlib/src/lib.rs
+++ b/txlib/src/lib.rs
@@ -1,18 +1,15 @@
 // pub mod examples;
 pub mod predicates;
 use std::{
-    array,
     collections::{HashMap, HashSet},
     sync::Arc,
 };
 
-use plonky2::field::types::Field;
 use pod2::middleware::{
     containers::{Array, Dictionary, Set},
-    hash_values, Hash, Key, RawValue, Statement, Value, EMPTY_VALUE, F,
+    hash_values, Hash, Key, RawValue, Statement, Value,
 };
-use pod2utils::{dict, dict_define, macros::BuildContext, set, st_custom};
-use rand::{rngs::StdRng, RngCore, SeedableRng};
+use pod2utils::{dict, dict_define, macros::BuildContext, rand_raw_value, set, st_custom};
 
 #[derive(Clone, Debug)]
 pub struct StateRoot {
@@ -81,11 +78,6 @@ pub struct Object {
     pub app_layer: HashMap<String, Value>,
 }
 
-fn rand_raw_value() -> RawValue {
-    let mut rng = StdRng::from_os_rng();
-    RawValue(array::from_fn(|_| F::from_noncanonical_u64(rng.next_u64())))
-}
-
 pub fn rekey(obj: &mut Dictionary) {
     obj.update(&Key::from("key"), &Value::from(rand_raw_value()))
         .unwrap();
@@ -135,6 +127,20 @@ impl TxBuilder {
         )
         .unwrap();
         Self { st_tx, tx }
+    }
+
+    pub fn new_from_tx(ctx: &BuildContext, tx: Tx) -> Self {
+        let tx_pred = ctx
+            .modules
+            .iter()
+            .find_map(|module| module.predicate_ref_by_name("Tx"))
+            .unwrap();
+        let st_tx = Statement::Custom(tx_pred, vec![Value::from(tx.dict())]);
+        Self { st_tx, tx }
+    }
+
+    pub fn st_tx(&self) -> &Statement {
+        &self.st_tx
     }
 
     fn st_inputs_grounded(

--- a/txlib/src/lib.rs
+++ b/txlib/src/lib.rs
@@ -7,7 +7,7 @@ use std::{
 
 use pod2::middleware::{
     containers::{Array, Dictionary, Set},
-    hash_values, Hash, Key, RawValue, Statement, Value,
+    hash_values, Hash, Key, RawValue, Statement, Value, EMPTY_VALUE,
 };
 use pod2utils::{dict, dict_define, macros::BuildContext, rand_raw_value, set, st_custom};
 
@@ -329,6 +329,13 @@ impl TxBuilder {
     }
 }
 
+pub fn new_obj() -> Dictionary {
+    let mut map = HashMap::new();
+    map.insert(Key::from("key"), Value::from(rand_raw_value()));
+    map.insert(Key::from("work"), Value::from(EMPTY_VALUE));
+    Dictionary::new(map)
+}
+
 #[cfg(test)]
 mod tests {
 
@@ -337,7 +344,7 @@ mod tests {
             basetypes::DEFAULT_VD_SET, mainpod::Prover, mock::mainpod::MockProver,
         },
         frontend::{MainPod, MultiPodBuilder},
-        middleware::{MainPodProver, Params, VDSet, EMPTY_VALUE},
+        middleware::{MainPodProver, Params, VDSet},
     };
     use pod2utils::{macros::BuildContext, set};
 
@@ -346,13 +353,6 @@ mod tests {
     fn prove(builder: MultiPodBuilder, prover: &dyn MainPodProver) -> MainPod {
         let solution = builder.solve().unwrap();
         solution.prove(prover).unwrap().pods.pop().unwrap()
-    }
-
-    fn new_obj() -> Dictionary {
-        let mut map = HashMap::new();
-        map.insert(Key::from("key"), Value::from(rand_raw_value()));
-        map.insert(Key::from("work"), Value::from(EMPTY_VALUE));
-        Dictionary::new(map)
     }
 
     #[test]

--- a/txlib/src/lib.rs
+++ b/txlib/src/lib.rs
@@ -8,12 +8,11 @@ use std::{
 
 use plonky2::field::types::Field;
 use pod2::middleware::{
-    EMPTY_VALUE, F, Hash, Key, RawValue, Statement, Value,
     containers::{Array, Dictionary, Set},
-    hash_values,
+    hash_values, Hash, Key, RawValue, Statement, Value, EMPTY_VALUE, F,
 };
 use pod2utils::{dict, dict_define, macros::BuildContext, set, st_custom};
-use rand::{RngCore, SeedableRng, rngs::StdRng};
+use rand::{rngs::StdRng, RngCore, SeedableRng};
 
 #[derive(Clone, Debug)]
 pub struct StateRoot {
@@ -87,26 +86,9 @@ fn rand_raw_value() -> RawValue {
     RawValue(array::from_fn(|_| F::from_noncanonical_u64(rng.next_u64())))
 }
 
-impl Object {
-    pub fn new(app_layer: HashMap<String, Value>) -> Self {
-        Self {
-            key: rand_raw_value(),
-            work: EMPTY_VALUE,
-            app_layer,
-        }
-    }
-    pub fn dict(&self) -> Dictionary {
-        let mut map = HashMap::new();
-        map.insert(Key::from("key"), Value::from(self.key));
-        map.insert(Key::from("work"), Value::from(self.work));
-        for (key, value) in &self.app_layer {
-            map.insert(Key::from(key), value.clone());
-        }
-        Dictionary::new(map)
-    }
-    pub fn rekey(&mut self) {
-        self.key = rand_raw_value();
-    }
+pub fn rekey(obj: &mut Dictionary) {
+    obj.update(&Key::from("key"), &Value::from(rand_raw_value()))
+        .unwrap();
 }
 
 pub struct TxBuilder {
@@ -117,7 +99,7 @@ pub struct TxBuilder {
 impl TxBuilder {
     pub fn new(
         ctx: &mut BuildContext,
-        inputs: &[(Object, Tx)],
+        inputs: &[(Dictionary, Tx)],
         state_root: Arc<StateRoot>,
     ) -> Self {
         let (st_inputs_grounded, inputs_set) = Self::st_inputs_grounded(ctx, inputs, &state_root);
@@ -157,7 +139,7 @@ impl TxBuilder {
 
     fn st_inputs_grounded(
         ctx: &mut BuildContext,
-        inputs: &[(Object, Tx)],
+        inputs: &[(Dictionary, Tx)],
         state_root: &StateRoot,
     ) -> (Statement, Set) {
         let state_root_hash = state_root.hash();
@@ -179,9 +161,8 @@ impl TxBuilder {
         .unwrap();
         let mut prev_inputs_set = set!();
         for (obj, source_tx) in inputs {
-            let obj_dict = obj.dict();
             let mut inputs_set = prev_inputs_set.clone();
-            inputs_set.insert(&Value::from(obj_dict.clone())).unwrap();
+            inputs_set.insert(&Value::from(obj.clone())).unwrap();
             let st_state_root = st_custom!(
                 ctx,
                 StateRoot() = (
@@ -200,8 +181,8 @@ impl TxBuilder {
                 ctx,
                 InputsGroundedRecursive() = (
                     st_tx_in_state_root,
-                    SetContains((&source_tx.dict(), "live"), obj_dict),
-                    SetInsert(inputs_set, prev_inputs_set, obj_dict),
+                    SetContains((&source_tx.dict(), "live"), obj),
+                    SetInsert(inputs_set, prev_inputs_set, obj),
                     st
                 )
             )
@@ -213,8 +194,8 @@ impl TxBuilder {
         (st, prev_inputs_set)
     }
 
-    pub fn insert(&mut self, ctx: &mut BuildContext, new: Object) -> Statement {
-        let new = Value::from(new.dict());
+    pub fn insert(&mut self, ctx: &mut BuildContext, new: Dictionary) -> Statement {
+        let new = Value::from(new);
         let tx_before = self.tx.dict();
         self.tx.live.insert(&new).unwrap();
         let st_tx_inserted = st_custom!(
@@ -239,9 +220,9 @@ impl TxBuilder {
         st_tx_inserted
     }
 
-    fn st_tx_obj_nullified(&mut self, ctx: &mut BuildContext, obj: &Object) -> Statement {
-        let obj_dict = obj.dict();
-        let obj_key_hash = hash_values(&[Value::from(obj_dict.commitment()), Value::from(obj.key)]);
+    fn st_tx_obj_nullified(&mut self, ctx: &mut BuildContext, obj: &Dictionary) -> Statement {
+        let key = obj.get(&Key::from("key")).unwrap().clone();
+        let obj_key_hash = hash_values(&[Value::from(obj.commitment()), Value::from(key)]);
         let obj_nullifier =
             hash_values(&[Value::from(obj_key_hash), Value::from("txlib-nullifier-v1")]);
         let tx_before = self.tx.dict();
@@ -252,7 +233,7 @@ impl TxBuilder {
         st_custom!(
             ctx,
             TxObjectStateNullified(tx_before = tx_before) = (
-                HashOf(obj_key_hash, obj_dict, (&obj_dict, "key")),
+                HashOf(obj_key_hash, obj, (obj, "key")),
                 HashOf(obj_nullifier, obj_key_hash, "txlib-nullifier-v1"),
                 SetInsert(
                     self.tx.nullifiers,
@@ -265,20 +246,16 @@ impl TxBuilder {
         .unwrap()
     }
 
-    pub fn delete(&mut self, ctx: &mut BuildContext, obj: Object) -> Statement {
-        let obj_dict = obj.dict();
+    pub fn delete(&mut self, ctx: &mut BuildContext, obj: Dictionary) -> Statement {
         let st_tx_obj_nullified = self.st_tx_obj_nullified(ctx, &obj);
         let tx_after_nullified = self.tx.dict();
-        self.tx
-            .live
-            .delete(&Value::from(obj_dict.commitment()))
-            .unwrap();
+        self.tx.live.delete(&Value::from(obj.commitment())).unwrap();
         let st_tx_deleted = st_custom!(
             ctx,
             TxDeleted() = (
                 self.st_tx.clone(),
                 st_tx_obj_nullified,
-                SetDelete(self.tx.live, (&tx_after_nullified, "live"), obj_dict),
+                SetDelete(self.tx.live, (&tx_after_nullified, "live"), obj),
                 DictUpdate(self.tx.dict(), tx_after_nullified, "live", self.tx.live)
             )
         )
@@ -296,24 +273,24 @@ impl TxBuilder {
         st_tx_deleted
     }
 
-    pub fn mutate(&mut self, ctx: &mut BuildContext, new: Object, old: Object) -> Statement {
-        let old_dict = old.dict();
-        let new_dict = new.dict();
+    pub fn mutate(
+        &mut self,
+        ctx: &mut BuildContext,
+        new: Dictionary,
+        old: Dictionary,
+    ) -> Statement {
         let st_tx_obj_nullified = self.st_tx_obj_nullified(ctx, &old);
         let tx_after_nullified = self.tx.dict();
-        self.tx
-            .live
-            .delete(&Value::from(old_dict.commitment()))
-            .unwrap();
+        self.tx.live.delete(&Value::from(old.commitment())).unwrap();
         let live_mid = self.tx.live.clone();
-        self.tx.live.insert(&Value::from(new_dict.clone())).unwrap();
+        self.tx.live.insert(&Value::from(new.clone())).unwrap();
         let st_tx_mutated = st_custom!(
             ctx,
             TxMutated() = (
                 self.st_tx.clone(),
                 st_tx_obj_nullified,
-                SetDelete(live_mid, (&tx_after_nullified, "live"), old_dict),
-                SetInsert(self.tx.live, live_mid, new_dict),
+                SetDelete(live_mid, (&tx_after_nullified, "live"), old),
+                SetInsert(self.tx.live, live_mid, new),
                 DictUpdate(self.tx.dict(), tx_after_nullified, "live", self.tx.live)
             )
         )
@@ -365,6 +342,13 @@ mod tests {
         solution.prove(prover).unwrap().pods.pop().unwrap()
     }
 
+    fn new_obj() -> Dictionary {
+        let mut map = HashMap::new();
+        map.insert(Key::from("key"), Value::from(rand_raw_value()));
+        map.insert(Key::from("work"), Value::from(EMPTY_VALUE));
+        Dictionary::new(map)
+    }
+
     #[test]
     fn test_tx_builder() {
         let txlib_mod = crate::predicates::module();
@@ -397,7 +381,7 @@ mod tests {
         };
 
         let mut tx_builder = TxBuilder::new(&mut ctx, &[], Arc::new(state_root.clone()));
-        let obj0 = Object::new(HashMap::new());
+        let obj0 = new_obj();
         tx_builder.insert(&mut ctx, obj0.clone());
         let (st, tx0) = tx_builder.finalize(&mut ctx);
         ctx.builder.reveal(&st).unwrap();
@@ -423,7 +407,7 @@ mod tests {
         let inputs = vec![(obj0.clone(), tx0)];
         let mut tx_builder = TxBuilder::new(&mut ctx, &inputs, Arc::new(state_root.clone()));
         let mut obj1 = obj0.clone();
-        obj1.app_layer.insert("foo".to_string(), Value::from("bar"));
+        obj1.insert(&Key::from("foo"), &Value::from("bar")).unwrap();
         tx_builder.mutate(&mut ctx, obj1.clone(), obj0);
         let (st, tx1) = tx_builder.finalize(&mut ctx);
         ctx.builder.reveal(&st).unwrap();

--- a/txlib/src/lib.rs
+++ b/txlib/src/lib.rs
@@ -6,8 +6,9 @@ use std::{
 };
 
 use pod2::middleware::{
+    EMPTY_VALUE, Hash, Key, RawValue, Statement, Value,
     containers::{Array, Dictionary, Set},
-    hash_values, Hash, Key, RawValue, Statement, Value, EMPTY_VALUE,
+    hash_values,
 };
 use pod2utils::{dict, dict_define, macros::BuildContext, rand_raw_value, set, st_custom};
 


### PR DESCRIPTION
This PR ports the sdk from the 10 objects repository (originally reviewed in https://github.com/0xPARC/10object-exploration/pull/14)

I improved the ergonomics of the sdk, you can review that change independently here: https://github.com/0xPARC/10object-exploration/compare/feat/decl-craft?expand=1#diff-823537328d87a0888e29996a5a5b0208d3fb78b294f9090dbcc62358b805e424R1160
Basically instead of using only structs and enum with native constructors I added methods so that the declaration can be made using the builder pattern.  My main motivation was to be able to mix `&'static str` and `String` and a nice way to do that is having a method that receives `impl Into<String>`.

I've also ported:
- vdf pod (no changes)
- pow pod (no changes)
- txlib and pod2utils small changes required by the sdk