### PR TITLE
add cache to github actions

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -21,5 +21,8 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           components: clippy
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: rust-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
       - name: Check formatting
         run: cargo clippy

--- a/.github/workflows/rust_tests.yml
+++ b/.github/workflows/rust_tests.yml
@@ -19,5 +19,8 @@ jobs:
           sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
       - uses: actions/checkout@v4
       - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: rust-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
       - name: Run tests
         run: cargo test --release


### PR DESCRIPTION
The current Github test action has become quite slow (~30 minutes). Based on the logs most of the time is spent in compiling the Rust crates. This PR adds a cache system so the previous build can be re-used. The cache is broken when a crate is added/modified/deleted.

Uses [https://github.com/Swatinem/rust-cache](https://github.com/Swatinem/rust-cache)