### PR TITLE
MCP server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -964,8 +964,10 @@ dependencies = [
  "tauri-build",
  "tauri-plugin-opener",
  "thiserror 2.0.18",
+ "tokio",
  "txlib",
  "vdfpod",
+ "zk-craft-mcp",
 ]
 
 [[package]]
@@ -10757,6 +10759,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "axum",
+ "reqwest 0.12.28",
  "rmcp",
  "schemars 1.2.1",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,7 +27,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -1903,6 +1903,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.0",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2039,7 +2050,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "531185e432bb31db1ecda541e9e7ab21468d4d844ad7505e0546a49b4945d49b"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "proptest",
  "serde_core",
 ]
@@ -2176,6 +2187,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -2367,6 +2387,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
+]
+
+[[package]]
 name = "darling_core"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2396,6 +2426,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2413,6 +2456,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
  "darling_core 0.21.3",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core 0.23.0",
  "quote",
  "syn 2.0.117",
 ]
@@ -3457,6 +3511,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.0",
  "wasip2",
  "wasip3",
 ]
@@ -4375,7 +4430,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -5479,6 +5534,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pastey"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b867cad97c0791bbd3aaa6472142568c6c9e8f71937e98379f584cfb0cf35bec"
+
+[[package]]
 name = "pathdiff"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6378,6 +6439,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.0",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6434,6 +6506,12 @@ dependencies = [
  "getrandom 0.3.4",
  "serde",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
 
 [[package]]
 name = "rand_hc"
@@ -6761,6 +6839,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "rmcp"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba6b9d2f0efe2258b23767f1f9e0054cfbcac9c2d6f81a031214143096d7864f"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "chrono",
+ "futures",
+ "http",
+ "http-body",
+ "http-body-util",
+ "pastey",
+ "pin-project-lite",
+ "rand 0.10.0",
+ "rmcp-macros",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "sse-stream",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tower-service",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "rmcp-macros"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab9d95d7ed26ad8306352b0d5f05b593222b272790564589790d210aa15caa9e"
+dependencies = [
+ "darling 0.23.0",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "rocksdb"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6963,7 +7085,7 @@ checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
 dependencies = [
  "dyn-clone",
  "indexmap 1.9.3",
- "schemars_derive",
+ "schemars_derive 0.8.22",
  "serde",
  "serde_json",
  "url",
@@ -6988,8 +7110,10 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
 dependencies = [
+ "chrono",
  "dyn-clone",
  "ref-cast",
+ "schemars_derive 1.2.1",
  "serde",
  "serde_json",
 ]
@@ -6999,6 +7123,18 @@ name = "schemars_derive"
 version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7383,7 +7519,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.10.7",
 ]
 
@@ -7394,7 +7530,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.10.7",
 ]
 
@@ -7751,6 +7887,19 @@ dependencies = [
  "thiserror 2.0.18",
  "tracing",
  "url",
+]
+
+[[package]]
+name = "sse-stream"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb4dc4d33c68ec1f27d386b5610a351922656e1fdf5c05bbaad930cd1519479a"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http-body",
+ "http-body-util",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -8537,6 +8686,7 @@ dependencies = [
  "bytes",
  "libc",
  "mio 1.1.1",
+ "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
@@ -10599,6 +10749,23 @@ dependencies = [
  "log",
  "thiserror 1.0.69",
  "zip 0.6.6",
+]
+
+[[package]]
+name = "zk-craft-mcp"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "axum",
+ "rmcp",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -947,6 +947,7 @@ dependencies = [
  "anyhow",
  "base64 0.22.1",
  "common",
+ "craft-mcp",
  "craft_sdk",
  "hex",
  "lt_eq_u256_pod",
@@ -967,7 +968,6 @@ dependencies = [
  "tokio",
  "txlib",
  "vdfpod",
- "zk-craft-mcp",
 ]
 
 [[package]]
@@ -2200,6 +2200,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "craft-mcp"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "axum",
+ "reqwest 0.12.28",
+ "rmcp",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -10751,24 +10769,6 @@ dependencies = [
  "log",
  "thiserror 1.0.69",
  "zip 0.6.6",
-]
-
-[[package]]
-name = "zk-craft-mcp"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "axum",
- "reqwest 0.12.28",
- "rmcp",
- "schemars 1.2.1",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
- "tokio",
- "tokio-util",
- "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "craft_sdk",
     "intro_pods/vdfpod",
     "intro_pods/lt_eq_u256_pod",
+    "mcp",
 ]
 resolver = "2"
 

--- a/app-gui/src-tauri/Cargo.toml
+++ b/app-gui/src-tauri/Cargo.toml
@@ -36,7 +36,7 @@ reqwest = { version = "0.12", default-features = false, features = ["json", "blo
 hex = "0.4"
 base64 = "0.22"
 pod2 = { workspace = true }
-zk-craft-mcp = { path = "../../mcp" }
+craft-mcp = { path = "../../mcp" }
 tokio = { version = "1", features = ["net"] }
 notify = "6"
 rfd = "0.14"

--- a/app-gui/src-tauri/Cargo.toml
+++ b/app-gui/src-tauri/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 tauri-build = { version = "2", features = [] }
 
 [dependencies]
-tauri = { version = "2", features = [] }
+tauri = { version = "2", features = ["devtools"] }
 tauri-plugin-opener = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -36,6 +36,8 @@ reqwest = { version = "0.12", default-features = false, features = ["json", "blo
 hex = "0.4"
 base64 = "0.22"
 pod2 = { workspace = true }
+zk-craft-mcp = { path = "../../mcp" }
+tokio = { version = "1", features = ["net"] }
 notify = "6"
 rfd = "0.14"
 anyhow = { workspace = true }

--- a/app-gui/src-tauri/src/lib.rs
+++ b/app-gui/src-tauri/src/lib.rs
@@ -15,7 +15,7 @@ use objects::{
 use sdk::{get_global_state_root, load_gui_inventory, run_sdk_action, ActionRunGate};
 use settings::{build_app_menu, get_app_settings, handle_settings_menu_event, save_app_settings};
 
-const MCP_PORT: u16 = 3001;
+use craft_mcp::DEFAULT_PORT as MCP_PORT;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
@@ -67,8 +67,8 @@ async fn start_mcp_server(app: tauri::AppHandle) -> Result<(), Box<dyn std::erro
     let app_settings = get_app_settings(app.clone())?;
 
     let ops = mcp::AppCraftOps::new(objects_dir, app, app_settings);
-    let config = zk_craft_mcp::McpConfig::default();
-    let server = zk_craft_mcp::McpServer::new(ops, config);
+    let config = craft_mcp::McpConfig::default();
+    let server = craft_mcp::McpServer::new(ops, config);
 
     let listener = tokio::net::TcpListener::bind(format!("127.0.0.1:{MCP_PORT}")).await?;
     eprintln!("zk-craft: MCP server listening on http://127.0.0.1:{MCP_PORT}/mcp");

--- a/app-gui/src-tauri/src/lib.rs
+++ b/app-gui/src-tauri/src/lib.rs
@@ -1,9 +1,12 @@
 mod cpu;
 mod error;
+mod mcp;
 mod objects;
 mod sdk;
 mod settings;
 mod spec;
+
+use std::sync::Arc;
 
 use cpu::{sample_app_cpu, CpuMonitor};
 use objects::{
@@ -12,11 +15,14 @@ use objects::{
 use sdk::{get_global_state_root, load_gui_inventory, run_sdk_action, ActionRunGate};
 use settings::{build_app_menu, get_app_settings, handle_settings_menu_event, save_app_settings};
 
+const MCP_PORT: u16 = 3001;
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     if let Err(err) = common::load_dotenv() {
         eprintln!("zk-craft: failed to load app-gui env: {err}");
     }
+
     tauri::Builder::default()
         .menu(build_app_menu)
         .on_menu_event(|app, event| {
@@ -24,11 +30,20 @@ pub fn run() {
         })
         .plugin(tauri_plugin_opener::init())
         .manage(CpuMonitor::new())
-        .manage(ActionRunGate::new())
+        .manage(Arc::new(ActionRunGate::new()))
         .setup(|app| {
             if let Err(err) = start_objects_watcher(app.handle().clone()) {
                 eprintln!("zk-craft: objects watcher disabled: {err}");
             }
+
+            // Start MCP server
+            let handle = app.handle().clone();
+            tauri::async_runtime::spawn(async move {
+                if let Err(err) = start_mcp_server(handle).await {
+                    eprintln!("zk-craft: MCP server failed: {err}");
+                }
+            });
+
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![
@@ -45,4 +60,19 @@ pub fn run() {
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
+}
+
+async fn start_mcp_server(app: tauri::AppHandle) -> Result<(), Box<dyn std::error::Error>> {
+    let objects_dir = objects::objects_dir(&app)?;
+    let app_settings = get_app_settings(app.clone())?;
+
+    let ops = mcp::AppCraftOps::new(objects_dir, app, app_settings);
+    let config = zk_craft_mcp::McpConfig::default();
+    let server = zk_craft_mcp::McpServer::new(ops, config);
+
+    let listener = tokio::net::TcpListener::bind(format!("127.0.0.1:{MCP_PORT}")).await?;
+    eprintln!("zk-craft: MCP server listening on http://127.0.0.1:{MCP_PORT}/mcp");
+
+    server.serve(listener).await?;
+    Ok(())
 }

--- a/app-gui/src-tauri/src/mcp.rs
+++ b/app-gui/src-tauri/src/mcp.rs
@@ -19,14 +19,20 @@ pub(crate) struct AppCraftOps {
     objects_dir: PathBuf,
     app: tauri::AppHandle,
     settings: AppSettings,
+    /// Generated podlang source from craft_sdk::Helper.
+    /// Contains all action predicates and IsClassName class predicates.
+    podlang_src: String,
 }
 
 impl AppCraftOps {
     pub(crate) fn new(objects_dir: PathBuf, app: tauri::AppHandle, settings: AppSettings) -> Self {
+        let helper = craft_sdk::Helper::new(spec::dependencies(), spec::actions());
+        let podlang_src = helper.podlang_src.clone();
         Self {
             objects_dir,
             app,
             settings,
+            podlang_src,
         }
     }
 
@@ -150,8 +156,8 @@ impl CraftOps for AppCraftOps {
             .map(|a| a.name.clone())
             .collect();
 
-        // TODO: retrieve actual podlang source when available
-        let predicate_source = format!("Is{class_name}(state) = OR(...)");
+        let predicate_source = extract_predicate(&self.podlang_src, &format!("Is{class_name}"))
+            .unwrap_or_else(|| format!("Is{class_name}(state) = OR(...)"));
 
         Ok(mcp::ClassDetail {
             class_name: class_name.to_string(),
@@ -278,6 +284,10 @@ impl CraftOps for AppCraftOps {
             missing_inputs: missing,
         })
     }
+
+    fn generated_podlang(&self) -> Option<String> {
+        Some(self.podlang_src.clone())
+    }
 }
 
 fn to_mcp_inventory_object(record: &ObjectRecord, file_name: &str) -> mcp::InventoryObject {
@@ -300,4 +310,42 @@ fn object_fields(record: &ObjectRecord) -> HashMap<String, serde_json::Value> {
         }
         Err(_) => HashMap::new(),
     }
+}
+
+/// Extract a named predicate definition from podlang source.
+///
+/// Podlang definitions have the form:
+///   Name(args) = AND/OR(\n  ...\n)\n
+///
+/// We find `name(` at a line start, then scan forward to find the
+/// `= AND(` or `= OR(` combiner, and track paren depth from there
+/// to find the closing `)`.
+fn extract_predicate(podlang_src: &str, name: &str) -> Option<String> {
+    let prefix = format!("{name}(");
+    let start = podlang_src.find(&prefix)?;
+    let after_prefix = &podlang_src[start..];
+
+    // Find the combiner `= AND(` or `= OR(`
+    let combiner_pos = after_prefix
+        .find("= AND(")
+        .or_else(|| after_prefix.find("= OR("))?;
+
+    // Find the opening `(` of the combiner
+    let open = start + combiner_pos + after_prefix[combiner_pos..].find('(')?;
+
+    // Track depth from the combiner's `(`
+    let mut depth = 0;
+    for (i, ch) in podlang_src[open..].char_indices() {
+        match ch {
+            '(' => depth += 1,
+            ')' => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some(podlang_src[start..open + i + 1].trim().to_string());
+                }
+            }
+            _ => {}
+        }
+    }
+    None
 }

--- a/app-gui/src-tauri/src/mcp.rs
+++ b/app-gui/src-tauri/src/mcp.rs
@@ -1,0 +1,303 @@
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use tauri::Emitter;
+use zk_craft_mcp::ops::CraftOps;
+use zk_craft_mcp::types as mcp;
+
+use crate::objects::ObjectRecord;
+use crate::sdk::{object_store, synchronizer_client};
+use crate::settings::AppSettings;
+use crate::spec;
+
+/// Real implementation of CraftOps backed by the app's live state.
+///
+/// Read-only tools are implemented directly (disk reads + HTTP to synchronizer).
+/// `run_action` delegates to the Tauri command so it gets the full pipeline:
+/// run gate, progress events, proof generation, relayer, synchronizer, file I/O.
+pub(crate) struct AppCraftOps {
+    objects_dir: PathBuf,
+    app: tauri::AppHandle,
+    settings: AppSettings,
+}
+
+impl AppCraftOps {
+    pub(crate) fn new(objects_dir: PathBuf, app: tauri::AppHandle, settings: AppSettings) -> Self {
+        Self {
+            objects_dir,
+            app,
+            settings,
+        }
+    }
+
+    fn load_objects(&self) -> anyhow::Result<Vec<(String, ObjectRecord)>> {
+        let entries =
+            object_store::load_object_files(&self.objects_dir).map_err(|e| anyhow::anyhow!(e))?;
+        Ok(entries
+            .into_iter()
+            .map(|e| (e.file_name, e.record))
+            .collect())
+    }
+
+    /// Resolve a path that may be a bare filename to an absolute path.
+    fn resolve_object_path(&self, path_str: &str) -> PathBuf {
+        let path = std::path::Path::new(path_str.trim());
+        if path.is_absolute() {
+            path.to_path_buf()
+        } else {
+            self.objects_dir.join(path)
+        }
+    }
+}
+
+impl CraftOps for AppCraftOps {
+    fn list_inventory(&self) -> anyhow::Result<Vec<mcp::InventoryObject>> {
+        let objects = self.load_objects()?;
+        Ok(objects
+            .iter()
+            .map(|(file_name, record)| to_mcp_inventory_object(record, file_name))
+            .collect())
+    }
+
+    fn list_actions(&self) -> anyhow::Result<Vec<mcp::Action>> {
+        Ok(spec::visible_action_descriptors()
+            .into_iter()
+            .map(|d| mcp::Action {
+                id: d.name,
+                description: d.ui.description.to_string(),
+                input_classes: d.input_classes.clone(),
+                output_classes: d.output_classes.clone(),
+                cpu_cost: d.ui.cpu_cost.to_string(),
+            })
+            .collect())
+    }
+
+    fn list_classes(&self) -> anyhow::Result<Vec<mcp::ClassSummary>> {
+        let objects = self.load_objects()?;
+        let actions = spec::visible_action_descriptors();
+
+        let mut classes: Vec<mcp::ClassSummary> = spec::class_names()
+            .into_iter()
+            .map(|name| {
+                let live_count = objects
+                    .iter()
+                    .filter(|(_, r)| r.class_name == name && !r.is_nullified())
+                    .count();
+                let produced_by = actions
+                    .iter()
+                    .filter(|a| a.output_classes.contains(&name))
+                    .map(|a| a.name.clone())
+                    .collect();
+                let consumed_by = actions
+                    .iter()
+                    .filter(|a| a.input_classes.contains(&name))
+                    .map(|a| a.name.clone())
+                    .collect();
+                mcp::ClassSummary {
+                    name,
+                    live_count,
+                    produced_by,
+                    consumed_by,
+                }
+            })
+            .collect();
+        classes.sort_by(|a, b| a.name.cmp(&b.name));
+        Ok(classes)
+    }
+
+    fn get_state_root(&self) -> anyhow::Result<String> {
+        let sync_state =
+            synchronizer_client::fetch_synchronizer_state(&self.settings.synchronizer_api_url)
+                .map_err(|e| anyhow::anyhow!(e))?;
+        Ok(synchronizer_client::encode_hash_hex(
+            &sync_state.current_gsr,
+        ))
+    }
+
+    fn inspect_object(&self, object_id: &str) -> anyhow::Result<mcp::ObjectDetail> {
+        let objects = self.load_objects()?;
+        let (_, record) = objects
+            .iter()
+            .find(|(_, r)| r.id == object_id)
+            .ok_or_else(|| anyhow::anyhow!("object not found: {object_id}"))?;
+
+        let class_detail = self.inspect_class(&record.class_name)?;
+        let fields = object_fields(record);
+
+        Ok(mcp::ObjectDetail {
+            id: record.id.clone(),
+            class_name: record.class_name.clone(),
+            live: !record.is_nullified(),
+            state: fields,
+            predicate_source: class_detail.predicate_source,
+        })
+    }
+
+    fn inspect_class(&self, class_name: &str) -> anyhow::Result<mcp::ClassDetail> {
+        if !spec::class_names().contains(&class_name.to_string()) {
+            anyhow::bail!("unknown class: {class_name}");
+        }
+
+        let actions = spec::visible_action_descriptors();
+        let produced_by = actions
+            .iter()
+            .filter(|a| a.output_classes.contains(&class_name.to_string()))
+            .map(|a| a.name.clone())
+            .collect();
+        let consumed_by = actions
+            .iter()
+            .filter(|a| a.input_classes.contains(&class_name.to_string()))
+            .map(|a| a.name.clone())
+            .collect();
+
+        // TODO: retrieve actual podlang source when available
+        let predicate_source = format!("Is{class_name}(state) = OR(...)");
+
+        Ok(mcp::ClassDetail {
+            class_name: class_name.to_string(),
+            predicate_source,
+            produced_by,
+            consumed_by,
+        })
+    }
+
+    fn run_action(&self, input: mcp::RunActionInput) -> anyhow::Result<mcp::RunActionResult> {
+        // Resolve bare filenames to absolute paths
+        let absolute_paths: Vec<String> = input
+            .input_object_paths
+            .iter()
+            .map(|p| self.resolve_object_path(p).to_string_lossy().into_owned())
+            .collect();
+
+        let tauri_input = crate::sdk::run_action::RunSdkActionInput {
+            action_id: input.action_id.clone(),
+            input_object_paths: absolute_paths,
+        };
+
+        // Delegate to the shared action pipeline. This is the same code path as
+        // the GUI's "Run" button: run gate, progress events, proof generation,
+        // relayer submission, synchronizer wait, file I/O — all with live GUI feedback.
+        //
+        // CraftOps::run_action is sync but the pipeline is async. We spawn a
+        // dedicated thread with its own tokio runtime to avoid deadlocking
+        // whichever runtime the MCP server is using.
+        let app = self.app.clone();
+        let run_gate = std::sync::Arc::clone(&*tauri::Manager::state::<
+            std::sync::Arc<crate::sdk::runtime::ActionRunGate>,
+        >(&self.app));
+
+        // Notify the GUI so it shows the proof progress panel
+        let cpu_cost = spec::visible_action_descriptors()
+            .iter()
+            .find(|d| d.name == input.action_id)
+            .map(|d| d.ui.cpu_cost.to_string())
+            .unwrap_or_default();
+        let _ = self.app.emit(
+            "mcp-action-started",
+            serde_json::json!({
+                "actionId": input.action_id,
+                "cpuCost": cpu_cost,
+            }),
+        );
+
+        // Spawn on Tauri's async runtime (so spawn_blocking inside
+        // run_sdk_action_core resolves correctly) and wait via a channel.
+        let (tx, rx) = std::sync::mpsc::channel();
+        tauri::async_runtime::spawn(async move {
+            let result = crate::sdk::run_sdk_action_core(app, &run_gate, tauri_input).await;
+            let _ = tx.send(result);
+        });
+        let result = rx
+            .recv()
+            .map_err(|_| anyhow::anyhow!("action task dropped unexpectedly"))?
+            .map_err(|e| anyhow::anyhow!(e))?;
+
+        // Load output objects from disk to populate full details
+        let outputs = result
+            .output_files
+            .iter()
+            .map(|f| {
+                let path = self.objects_dir.join(f);
+                match crate::sdk::object_store::parse_object_file_from_path(&path) {
+                    Ok(record) => to_mcp_inventory_object(&record, f),
+                    Err(_) => mcp::InventoryObject {
+                        id: String::new(),
+                        class_name: String::new(),
+                        file_name: f.clone(),
+                        live: true,
+                        fields: HashMap::new(),
+                    },
+                }
+            })
+            .collect();
+
+        Ok(mcp::RunActionResult {
+            success: result.ok,
+            message: format!(
+                "Action {} completed. Old root: {}, New root: {}",
+                input.action_id, result.old_root, result.new_root
+            ),
+            outputs,
+            consumed: result.nullified_files,
+        })
+    }
+
+    fn check_feasibility(&self, action_id: &str) -> anyhow::Result<mcp::FeasibilityReport> {
+        let descriptors = spec::action_descriptors_by_name();
+        let descriptor = descriptors
+            .get(action_id)
+            .ok_or_else(|| anyhow::anyhow!("unknown action: {action_id}"))?;
+
+        let objects = self.load_objects()?;
+        let live_objects: Vec<_> = objects.iter().filter(|(_, r)| !r.is_nullified()).collect();
+
+        let mut available = Vec::new();
+        let mut missing = Vec::new();
+        let mut used_ids = std::collections::HashSet::new();
+
+        for required_class in &descriptor.input_classes {
+            if let Some((file_name, record)) = live_objects
+                .iter()
+                .find(|(_, r)| &r.class_name == required_class && !used_ids.contains(&r.id))
+            {
+                used_ids.insert(record.id.clone());
+                available.push(mcp::FeasibilityInput {
+                    class_name: record.class_name.clone(),
+                    object_id: record.id.clone(),
+                    file_name: file_name.clone(),
+                });
+            } else {
+                missing.push(required_class.clone());
+            }
+        }
+
+        Ok(mcp::FeasibilityReport {
+            feasible: missing.is_empty(),
+            action_id: action_id.to_string(),
+            available_inputs: available,
+            missing_inputs: missing,
+        })
+    }
+}
+
+fn to_mcp_inventory_object(record: &ObjectRecord, file_name: &str) -> mcp::InventoryObject {
+    mcp::InventoryObject {
+        id: record.id.clone(),
+        class_name: record.class_name.clone(),
+        file_name: file_name.to_string(),
+        live: !record.is_nullified(),
+        fields: object_fields(record),
+    }
+}
+
+fn object_fields(record: &ObjectRecord) -> HashMap<String, serde_json::Value> {
+    match serde_json::to_value(&record.obj) {
+        Ok(serde_json::Value::Object(map)) => map.into_iter().collect(),
+        Ok(val) => {
+            let mut m = HashMap::new();
+            m.insert("_raw".to_string(), val);
+            m
+        }
+        Err(_) => HashMap::new(),
+    }
+}

--- a/app-gui/src-tauri/src/mcp.rs
+++ b/app-gui/src-tauri/src/mcp.rs
@@ -1,9 +1,9 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
 
+use craft_mcp::ops::CraftOps;
+use craft_mcp::types as mcp;
 use tauri::Emitter;
-use zk_craft_mcp::ops::CraftOps;
-use zk_craft_mcp::types as mcp;
 
 use crate::objects::ObjectRecord;
 use crate::sdk::{object_store, synchronizer_client};

--- a/app-gui/src-tauri/src/sdk/engine.rs
+++ b/app-gui/src-tauri/src/sdk/engine.rs
@@ -11,7 +11,7 @@ use txlib::StateRoot;
 
 use crate::spec;
 
-pub(super) fn execute_action(
+pub(crate) fn execute_action(
     action_id: String,
     state_root: StateRoot,
     inputs: Vec<SpendableObject>,
@@ -22,7 +22,7 @@ pub(super) fn execute_action(
     Ok(builder.action(&action_id, inputs))
 }
 
-pub(super) fn build_relayer_payload(
+pub(crate) fn build_relayer_payload(
     old_state_root_hash: &Hash,
     action_output: &SpendableObjects,
 ) -> Result<Vec<u8>> {

--- a/app-gui/src-tauri/src/sdk/mod.rs
+++ b/app-gui/src-tauri/src/sdk/mod.rs
@@ -1,13 +1,14 @@
 mod bootstrap;
-mod engine;
-mod object_store;
+pub(crate) mod engine;
+pub(crate) mod object_store;
 mod progress;
-mod relayer_client;
-mod run_action;
-mod runtime;
-mod synchronizer_client;
+pub(crate) mod relayer_client;
+pub(crate) mod run_action;
+pub(crate) mod runtime;
+pub(crate) mod synchronizer_client;
 
 pub use bootstrap::{get_global_state_root, load_gui_inventory};
 pub(crate) use object_store::parse_object_file_from_path;
 pub use run_action::run_sdk_action;
+pub(crate) use run_action::run_sdk_action_core;
 pub(crate) use runtime::ActionRunGate;

--- a/app-gui/src-tauri/src/sdk/object_store.rs
+++ b/app-gui/src-tauri/src/sdk/object_store.rs
@@ -3,12 +3,12 @@ use std::{collections::HashMap, fs, path::Path};
 
 use crate::objects::{nullified_objects_dir, ObjectRecord};
 
-pub(super) struct ObjectFileEntry {
-    pub(super) file_name: String,
-    pub(super) record: ObjectRecord,
+pub(crate) struct ObjectFileEntry {
+    pub(crate) file_name: String,
+    pub(crate) record: ObjectRecord,
 }
 
-pub(super) fn ensure_objects_dirs(objects_dir: &Path) -> Result<()> {
+pub(crate) fn ensure_objects_dirs(objects_dir: &Path) -> Result<()> {
     fs::create_dir_all(objects_dir)
         .map_err(|err| anyhow!("failed to create objects directory: {err}"))?;
     fs::create_dir_all(nullified_objects_dir(objects_dir))
@@ -21,7 +21,7 @@ fn parse_object_file(contents: &str, file_name: &str) -> Result<ObjectRecord> {
         .map_err(|err| anyhow!("failed to parse {file_name} as object file: {err}"))
 }
 
-pub(super) fn write_object_file(
+pub(crate) fn write_object_file(
     record: &ObjectRecord,
     file_name: &str,
     objects_dir: &Path,
@@ -127,7 +127,7 @@ fn load_object_files_from_dir(
     Ok(())
 }
 
-pub(super) fn load_object_files(objects_dir: &Path) -> Result<Vec<ObjectFileEntry>> {
+pub(crate) fn load_object_files(objects_dir: &Path) -> Result<Vec<ObjectFileEntry>> {
     let mut records_by_file = HashMap::<String, ObjectRecord>::new();
     load_object_files_from_dir(&mut records_by_file, objects_dir, false)?;
     load_object_files_from_dir(

--- a/app-gui/src-tauri/src/sdk/relayer_client.rs
+++ b/app-gui/src-tauri/src/sdk/relayer_client.rs
@@ -3,13 +3,13 @@ use std::time::{Duration, Instant};
 use anyhow::{anyhow, Result};
 use base64::{engine::general_purpose::STANDARD, Engine};
 use common::blob::MAX_SIMPLE_BLOB_PAYLOAD_BYTES;
-pub(super) use relayer::api_types::JobStatus;
+pub(crate) use relayer::api_types::JobStatus;
 use relayer::api_types::{JobStatusResponse, SubmitProofRequest, SubmitProofResponse};
 
-pub(super) const RELAYER_POLL_TIMEOUT_SECS: u64 = 180;
-pub(super) const RELAYER_POLL_INTERVAL_MS: u64 = 1500;
+pub(crate) const RELAYER_POLL_TIMEOUT_SECS: u64 = 180;
+pub(crate) const RELAYER_POLL_INTERVAL_MS: u64 = 1500;
 
-pub(super) fn submit_proof_to_relayer(
+pub(crate) fn submit_proof_to_relayer(
     relayer_api_url: &str,
     payload_bytes: &[u8],
     client_ref: Option<String>,
@@ -76,7 +76,7 @@ fn fetch_relayer_job_status(relayer_api_url: &str, job_id: &str) -> Result<JobSt
         .map_err(|err| anyhow!("failed to decode relayer status response: {err}; body={body}"))
 }
 
-pub(super) fn wait_for_relayer_confirmation(
+pub(crate) fn wait_for_relayer_confirmation(
     relayer_api_url: &str,
     job_id: &str,
     timeout_secs: u64,

--- a/app-gui/src-tauri/src/sdk/run_action.rs
+++ b/app-gui/src-tauri/src/sdk/run_action.rs
@@ -362,7 +362,16 @@ fn rollback_results(objects_dir: &Path, resolved_inputs: &[ResolvedInput], saved
 #[tauri::command]
 pub async fn run_sdk_action(
     app: tauri::AppHandle,
-    runtime: tauri::State<'_, ActionRunGate>,
+    runtime: tauri::State<'_, std::sync::Arc<ActionRunGate>>,
+    input: RunSdkActionInput,
+) -> Result<RunSdkActionResult, String> {
+    run_sdk_action_core(app, &runtime, input).await
+}
+
+/// Core action pipeline shared by the Tauri command and MCP server.
+pub(crate) async fn run_sdk_action_core(
+    app: tauri::AppHandle,
+    runtime: &ActionRunGate,
     input: RunSdkActionInput,
 ) -> Result<RunSdkActionResult, CommandError> {
     let objects_dir: PathBuf = objects_dir(&app)?;
@@ -375,7 +384,7 @@ pub async fn run_sdk_action(
     validate_run_request(&input, &descriptor)?;
 
     let app_settings = get_app_settings(app.clone())?;
-    let _run_guard = acquire_run_in_progress_guard(&runtime)?;
+    let _run_guard = acquire_run_in_progress_guard(runtime)?;
 
     let action_id = input.action_id.clone();
     emit_generate_proof_step(&app, &action_id, "Verifying Inputs")?;

--- a/app-gui/src-tauri/src/sdk/run_action.rs
+++ b/app-gui/src-tauri/src/sdk/run_action.rs
@@ -364,7 +364,7 @@ pub async fn run_sdk_action(
     app: tauri::AppHandle,
     runtime: tauri::State<'_, std::sync::Arc<ActionRunGate>>,
     input: RunSdkActionInput,
-) -> Result<RunSdkActionResult, String> {
+) -> Result<RunSdkActionResult, CommandError> {
     run_sdk_action_core(app, &runtime, input).await
 }
 

--- a/app-gui/src-tauri/src/sdk/runtime.rs
+++ b/app-gui/src-tauri/src/sdk/runtime.rs
@@ -20,7 +20,7 @@ impl ActionRunGate {
     }
 }
 
-pub(super) fn lock_runtime_state<'a>(
+pub(crate) fn lock_runtime_state<'a>(
     state_lock: &'a Mutex<ActionRunState>,
 ) -> MutexGuard<'a, ActionRunState> {
     match state_lock.lock() {
@@ -32,13 +32,7 @@ pub(super) fn lock_runtime_state<'a>(
     }
 }
 
-pub(super) fn lock_runtime<'a>(
-    runtime: &'a tauri::State<'_, ActionRunGate>,
-) -> MutexGuard<'a, ActionRunState> {
-    lock_runtime_state(&runtime.inner)
-}
-
-pub(super) struct RunInProgressGuard<'a> {
+pub(crate) struct RunInProgressGuard<'a> {
     state_lock: &'a Mutex<ActionRunState>,
 }
 
@@ -49,15 +43,15 @@ impl Drop for RunInProgressGuard<'_> {
     }
 }
 
-pub(super) fn acquire_run_in_progress_guard<'a, 'b>(
-    runtime: &'a tauri::State<'b, ActionRunGate>,
-) -> Result<RunInProgressGuard<'a>> {
-    let mut inner = lock_runtime(runtime);
+pub(crate) fn acquire_run_in_progress_guard(
+    gate: &ActionRunGate,
+) -> Result<RunInProgressGuard<'_>> {
+    let mut inner = lock_runtime_state(&gate.inner);
     if inner.run_in_progress {
         return Err(anyhow!("another action run is already in progress"));
     }
     inner.run_in_progress = true;
     Ok(RunInProgressGuard {
-        state_lock: &runtime.inner,
+        state_lock: &gate.inner,
     })
 }

--- a/app-gui/src-tauri/src/sdk/synchronizer_client.rs
+++ b/app-gui/src-tauri/src/sdk/synchronizer_client.rs
@@ -11,15 +11,15 @@ use synchronizer::api_types::{
 };
 use txlib::StateRoot;
 
-pub(super) const SYNCHRONIZER_POLL_TIMEOUT_SECS: u64 = 120;
-pub(super) const SYNCHRONIZER_POLL_INTERVAL_MS: u64 = 1200;
-pub(super) use common::encode_hash_hex;
+pub(crate) const SYNCHRONIZER_POLL_TIMEOUT_SECS: u64 = 120;
+pub(crate) const SYNCHRONIZER_POLL_INTERVAL_MS: u64 = 1200;
+pub(crate) use common::encode_hash_hex;
 
-pub(super) struct SynchronizerState {
-    pub(super) state_root: StateRoot,
-    pub(super) current_gsr: Hash,
-    pub(super) transactions: HashSet<Hash>,
-    pub(super) nullifiers: HashSet<Hash>,
+pub(crate) struct SynchronizerState {
+    pub(crate) state_root: StateRoot,
+    pub(crate) current_gsr: Hash,
+    pub(crate) transactions: HashSet<Hash>,
+    pub(crate) nullifiers: HashSet<Hash>,
 }
 
 fn parse_hash_hex(value: &str) -> Result<Hash> {
@@ -27,7 +27,7 @@ fn parse_hash_hex(value: &str) -> Result<Hash> {
     Hash::from_hex(trimmed).map_err(|err| anyhow!("invalid hash {value}: {err}"))
 }
 
-pub(super) fn fetch_synchronizer_state(sync_api_url: &str) -> Result<SynchronizerState> {
+pub(crate) fn fetch_synchronizer_state(sync_api_url: &str) -> Result<SynchronizerState> {
     let endpoint = format!("{}/v1/state/full", sync_api_url.trim_end_matches('/'));
     let response = reqwest::blocking::get(&endpoint)
         .map_err(|err| anyhow!("failed to query synchronizer at {endpoint}: {err}"))?;
@@ -82,7 +82,7 @@ pub(super) fn fetch_synchronizer_state(sync_api_url: &str) -> Result<Synchronize
     })
 }
 
-pub(super) fn fetch_synchronizer_tx_contains(
+pub(crate) fn fetch_synchronizer_tx_contains(
     sync_api_url: &str,
     tx_hashes: &[Hash],
 ) -> Result<HashSet<Hash>> {
@@ -144,7 +144,7 @@ fn fetch_synchronizer_tx_status(sync_api_url: &str, tx_hash: &Hash) -> Result<Tx
         .map_err(|err| anyhow!("failed to decode synchronizer tx status response: {err}"))
 }
 
-pub(super) fn wait_for_synchronizer_tx(
+pub(crate) fn wait_for_synchronizer_tx(
     sync_api_url: &str,
     tx_final: Hash,
     timeout_secs: u64,

--- a/app-gui/src/App.tsx
+++ b/app-gui/src/App.tsx
@@ -10,6 +10,7 @@ import {
   listenOpenSettings,
   listenObjectsChanged,
   listenRunSdkActionProgress,
+  listenMcpActionStarted,
   openObjectsDir,
   sampleAppCpu,
 } from "./shared/api/tauriClient";
@@ -113,21 +114,15 @@ function App() {
   useEffect(() => {
     let cancelled = false;
     let unlisten: (() => void) | null = null;
-    import("@tauri-apps/api/event")
-      .then(({ listen }) =>
-        listen<{ actionId: string; cpuCost: string }>(
-          "mcp-action-started",
-          (event) => {
-            if (!cancelled) {
-              initProofPanel({
-                actionId: event.payload.actionId,
-                cpuCost: event.payload.cpuCost,
-                args: ["(via MCP)"],
-              });
-            }
-          },
-        ),
-      )
+    listenMcpActionStarted((event) => {
+      if (!cancelled) {
+        initProofPanel({
+          actionId: event.actionId,
+          cpuCost: event.cpuCost,
+          args: ["(via MCP)"],
+        });
+      }
+    })
       .then((dispose) => {
         if (cancelled) {
           dispose();

--- a/app-gui/src/App.tsx
+++ b/app-gui/src/App.tsx
@@ -44,6 +44,7 @@ function App() {
   const applyRunSdkActionProgress = useStore(
     (state) => state.applyRunSdkActionProgress,
   );
+  const initProofPanel = useStore((state) => state.initProofPanel);
   const runProof = useStore((state) => state.runProof);
   const proofStatus = useStore((state) => state.proof.status);
   const proofRunning = useStore(
@@ -107,6 +108,41 @@ function App() {
       if (unlisten) unlisten();
     };
   }, [applyRunSdkActionProgress]);
+
+  // Listen for MCP-initiated actions so the proof panel shows progress
+  useEffect(() => {
+    let cancelled = false;
+    let unlisten: (() => void) | null = null;
+    import("@tauri-apps/api/event")
+      .then(({ listen }) =>
+        listen<{ actionId: string; cpuCost: string }>(
+          "mcp-action-started",
+          (event) => {
+            if (!cancelled) {
+              initProofPanel({
+                actionId: event.payload.actionId,
+                cpuCost: event.payload.cpuCost,
+                args: ["(via MCP)"],
+              });
+            }
+          },
+        ),
+      )
+      .then((dispose) => {
+        if (cancelled) {
+          dispose();
+          return;
+        }
+        unlisten = dispose;
+      })
+      .catch((error) => {
+        console.error("Failed to subscribe to mcp-action-started:", error);
+      });
+    return () => {
+      cancelled = true;
+      if (unlisten) unlisten();
+    };
+  }, [initProofPanel]);
 
   useEffect(() => {
     let cancelled = false;

--- a/app-gui/src/shared/api/tauriClient.ts
+++ b/app-gui/src/shared/api/tauriClient.ts
@@ -78,6 +78,17 @@ export function getGlobalStateRoot(): Promise<string> {
   return invoke<string>("get_global_state_root");
 }
 
+export function listenMcpActionStarted(
+  handler: (event: { actionId: string; cpuCost: string }) => void,
+): Promise<UnlistenFn> {
+  return listen<{ actionId: string; cpuCost: string }>(
+    "mcp-action-started",
+    (event) => {
+      handler(event.payload);
+    },
+  );
+}
+
 export function getAppSettings(): Promise<AppSettingsPayload> {
   return invoke<AppSettingsPayload>("get_app_settings");
 }

--- a/app-gui/src/shared/state/store.ts
+++ b/app-gui/src/shared/state/store.ts
@@ -65,6 +65,11 @@ export interface AppState {
   recordCpuSample: (usagePct: number, totalCpuSecs: number) => void;
   setGlobalStateRoot: (hash: string | null) => void;
   applyRunSdkActionProgress: (event: RunSdkActionProgress) => void;
+  initProofPanel: (input: {
+    actionId: string;
+    cpuCost: string;
+    args: string[];
+  }) => void;
   runProof: (input: {
     actionId: ActionId;
     inputBindings: Array<{
@@ -245,13 +250,7 @@ export const useStore = create<AppState>((set) => ({
         },
       };
     }),
-  runProof: async ({ actionId, inputBindings, cpuCost }) => {
-    const postDoneHoldMs = 2800;
-    const verifyTargets =
-      inputBindings.length > 0
-        ? inputBindings.map((binding) => binding.label)
-        : ["(no inputs)"];
-
+  initProofPanel: ({ actionId, cpuCost, args }) =>
     set((prev) => {
       if (
         prev.proof.status === "generating" ||
@@ -265,7 +264,7 @@ export const useStore = create<AppState>((set) => ({
           runActionId: actionId,
           status: "generating",
           cpuCost,
-          args: verifyTargets,
+          args,
           messages: ["Running SDK action..."],
           steps: [
             {
@@ -288,7 +287,15 @@ export const useStore = create<AppState>((set) => ({
           stats: prev.proof.stats,
         },
       };
-    });
+    }),
+  runProof: async ({ actionId, inputBindings, cpuCost }) => {
+    const postDoneHoldMs = 2800;
+    const verifyTargets =
+      inputBindings.length > 0
+        ? inputBindings.map((binding) => binding.label)
+        : ["(no inputs)"];
+
+    get().initProofPanel({ actionId, cpuCost, args: verifyTargets });
 
     try {
       const result = await runSdkAction({

--- a/app-gui/src/shared/state/store.ts
+++ b/app-gui/src/shared/state/store.ts
@@ -90,7 +90,7 @@ const initialAppState: Pick<
   showNullifiedItems: false,
 };
 
-export const useStore = create<AppState>((set) => ({
+export const useStore = create<AppState>((set, get) => ({
   ...initialAppState,
   inventory: [],
   actions: [],

--- a/justfile
+++ b/justfile
@@ -11,7 +11,7 @@ relayer:
 
 # Run the gui
 gui:
-    cd app-gui && pnpm tauri dev --release
+    cd app-gui && RUST_LOG=trace pnpm tauri dev --release
 
 # Run relayer + synchronizer + gui together via mprocs
 # https://github.com/pvolok/mprocs

--- a/mcp/Cargo.toml
+++ b/mcp/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "zk-craft-mcp"
+name = "craft-mcp"
 version = "0.1.0"
 edition = "2024"
 
@@ -30,14 +30,14 @@ proxy = ["reqwest"]
 tokio = { version = "1", features = ["full"] }
 
 [[bin]]
-name = "zk-craft-mcp-mock"
+name = "craft-mcp-mock"
 path = "src/bin/mock_server.rs"
 
 [[bin]]
-name = "zk-craft-mcp-stdio"
+name = "craft-mcp-stdio"
 path = "src/bin/mock_stdio.rs"
 
 [[bin]]
-name = "zk-craft-mcp-proxy"
+name = "craft-mcp-proxy"
 path = "src/bin/proxy_stdio.rs"
 required-features = ["proxy"]

--- a/mcp/Cargo.toml
+++ b/mcp/Cargo.toml
@@ -20,6 +20,11 @@ axum = "0.8.8"
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 thiserror = "2"
+reqwest = { version = "0.12", default-features = false, features = ["json", "blocking", "rustls-tls"], optional = true }
+
+[features]
+default = []
+proxy = ["reqwest"]
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }
@@ -31,3 +36,8 @@ path = "src/bin/mock_server.rs"
 [[bin]]
 name = "zk-craft-mcp-stdio"
 path = "src/bin/mock_stdio.rs"
+
+[[bin]]
+name = "zk-craft-mcp-proxy"
+path = "src/bin/proxy_stdio.rs"
+required-features = ["proxy"]

--- a/mcp/Cargo.toml
+++ b/mcp/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "zk-craft-mcp"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+rmcp = { version = "1.2.0", features = [
+    "server",
+    "macros",
+    "transport-io",
+    "transport-streamable-http-server",
+] }
+serde = { workspace = true }
+serde_json = { workspace = true }
+schemars = "1"
+anyhow = { workspace = true }
+tokio = { version = "1", features = ["sync", "macros", "rt", "rt-multi-thread", "time", "signal", "net"] }
+tokio-util = "0.7"
+axum = "0.8.8"
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+thiserror = "2"
+
+[dev-dependencies]
+tokio = { version = "1", features = ["full"] }
+
+[[bin]]
+name = "zk-craft-mcp-mock"
+path = "src/bin/mock_server.rs"
+
+[[bin]]
+name = "zk-craft-mcp-stdio"
+path = "src/bin/mock_stdio.rs"

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -1,0 +1,160 @@
+# ZK-Craft MCP Server
+
+An MCP (Model Context Protocol) server that exposes ZK-Craft's digital object operations to AI agents. Claude Desktop or Claude Code can inspect inventory, explore crafting actions, read documentation, and execute ZK proof-based crafting operations through this server.
+
+## Architecture
+
+```
+Claude Desktop <--stdio--> zk-craft-mcp-proxy <--HTTP--> Tauri app (MCP + GUI)
+```
+
+The Tauri app embeds a streamable HTTP MCP server on port 3001. A thin stdio proxy binary bridges Claude Desktop (which expects stdio transport) to the app's HTTP endpoint. The GUI and MCP server share in-process state — when Claude runs an action, the GUI shows real-time progress.
+
+### Crate structure
+
+```
+mcp/
+  src/
+    lib.rs          McpServer, McpConfig — HTTP embedding interface
+    ops.rs          CraftOps trait — boundary between MCP and the host app
+    types.rs        MCP request/response types (simple, LLM-friendly, with JsonSchema)
+    server.rs       CraftMcpService — rmcp tool handlers and ServerHandler impl
+    mock.rs         MockCraftOps — realistic test fixtures
+    resources.rs    MCP resources (docs + podlang source files)
+    bin/
+      mock_server.rs   Standalone HTTP server with mock data (port 3001)
+      mock_stdio.rs    Standalone stdio server with mock data
+      proxy_stdio.rs   Stdio-to-HTTP proxy for Claude Desktop
+  docs/
+    podlang-reference.md   Full podlang language reference
+    object-lifecycle.md    Digital Object lifecycle walkthrough
+```
+
+The `mcp` crate has **no dependencies** on pod2, txlib, craft_sdk, or app-gui. The `CraftOps` trait is the integration boundary — the real implementation lives in `app-gui/src-tauri/src/mcp.rs`.
+
+## Tools
+
+| Tool | Description |
+|------|-------------|
+| `list_inventory` | All objects with types, fields, liveness status |
+| `list_actions` | Available crafting actions with input/output classes and CPU cost |
+| `list_classes` | All object classes with live counts and producing/consuming actions |
+| `get_state_root` | Current global state root from the synchronizer |
+| `inspect_object` | Full object detail: fields, class, liveness, predicate source |
+| `inspect_class` | Class predicate definition and related actions |
+| `run_action` | Execute a crafting action (blocks for proof generation) |
+| `check_feasibility` | Check if an action can run with current inventory |
+| `read_doc` | Read reference docs (podlang ref, object lifecycle, predicate sources, generated podlang) |
+
+All tools return structured content (`structuredContent` + `outputSchema`) for clients that support it, with a text fallback for older clients.
+
+## Setup with Claude Desktop
+
+### 1. Build the proxy
+
+```sh
+cd zk-craft
+cargo build -p zk-craft-mcp --bin zk-craft-mcp-proxy --features proxy --release
+```
+
+### 2. Add to Claude Desktop config
+
+Open Claude Desktop settings and edit the MCP server configuration (`claude_desktop_config.json`):
+
+```json
+{
+  "mcpServers": {
+    "zk-craft": {
+      "command": "/absolute/path/to/zk-craft/target/release/zk-craft-mcp-proxy",
+      "args": ["--port", "3001"]
+    }
+  }
+}
+```
+
+### 3. Start the Tauri app
+
+The proxy connects to the app's MCP endpoint. The app must be running first:
+
+```sh
+cd zk-craft/app-gui
+npm run tauri dev
+```
+
+The MCP server starts automatically on `http://127.0.0.1:3001/mcp`.
+
+### 4. Restart Claude Desktop
+
+Claude Desktop reads the config on startup. After adding the server config and starting the app, restart Claude Desktop. You should see "zk-craft" listed as a connected MCP server.
+
+## Setup with Claude Code
+
+The proxy works with Claude Code the same way as Claude Desktop. With the app running:
+
+```sh
+claude mcp add zk-craft /absolute/path/to/zk-craft/target/release/zk-craft-mcp-proxy -- --port 3001
+```
+
+Or add to `.claude/settings.json` manually:
+
+```json
+{
+  "mcpServers": {
+    "zk-craft": {
+      "command": "/absolute/path/to/zk-craft/target/release/zk-craft-mcp-proxy",
+      "args": ["--port", "3001"]
+    }
+  }
+}
+```
+
+### Mock mode (no app required)
+
+For development and testing without the full app stack, use the stdio mock server:
+
+```sh
+claude mcp add zk-craft-mock /absolute/path/to/zk-craft/target/release/zk-craft-mcp-stdio
+```
+
+This serves mock data — useful for testing MCP tools or developing new ones.
+
+## Development
+
+### Running tests
+
+```sh
+cargo test -p zk-craft-mcp --release
+```
+
+Tests run against `MockCraftOps` and cover tool handlers, structured output, error cases, and server startup.
+
+### Mock servers
+
+**HTTP mock** (for testing the proxy or direct HTTP clients):
+
+```sh
+cargo run -p zk-craft-mcp --bin zk-craft-mcp-mock --release
+# Listens on http://127.0.0.1:3001/mcp
+```
+
+**Stdio mock** (for testing with Claude Desktop/Code without the app):
+
+```sh
+cargo run -p zk-craft-mcp --bin zk-craft-mcp-stdio --release
+```
+
+### Proxy
+
+```sh
+cargo run -p zk-craft-mcp --bin zk-craft-mcp-proxy --features proxy --release -- --port 3001
+```
+
+The proxy accepts `--port <PORT>` or `--url <URL>` to configure the upstream endpoint. Default: `http://127.0.0.1:3001/mcp`.
+
+### Adding tools
+
+1. Add the method to `CraftOps` in `ops.rs`
+2. Add the mock implementation in `mock.rs`
+3. Add the tool handler in `server.rs` (use `#[tool(description = "...")]`)
+4. Add request/response types to `types.rs` if needed
+5. Update the tool count assertion in the test

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -5,7 +5,7 @@ An MCP (Model Context Protocol) server that exposes ZK-Craft's digital object op
 ## Architecture
 
 ```
-Claude Desktop <--stdio--> zk-craft-mcp-proxy <--HTTP--> Tauri app (MCP + GUI)
+Claude Desktop <--stdio--> craft-mcp-proxy <--HTTP--> Tauri app (MCP + GUI)
 ```
 
 The Tauri app embeds a streamable HTTP MCP server on port 3001. A thin stdio proxy binary bridges Claude Desktop (which expects stdio transport) to the app's HTTP endpoint. The GUI and MCP server share in-process state — when Claude runs an action, the GUI shows real-time progress.
@@ -54,7 +54,7 @@ All tools return structured content (`structuredContent` + `outputSchema`) for c
 
 ```sh
 cd zk-craft
-cargo build -p zk-craft-mcp --bin zk-craft-mcp-proxy --features proxy --release
+cargo build -p craft-mcp --bin craft-mcp-proxy --features proxy --release
 ```
 
 ### 2. Add to Claude Desktop config
@@ -65,7 +65,7 @@ Open Claude Desktop settings and edit the MCP server configuration (`claude_desk
 {
   "mcpServers": {
     "zk-craft": {
-      "command": "/absolute/path/to/zk-craft/target/release/zk-craft-mcp-proxy",
+      "command": "/absolute/path/to/zk-craft/target/release/craft-mcp-proxy",
       "args": ["--port", "3001"]
     }
   }
@@ -74,14 +74,14 @@ Open Claude Desktop settings and edit the MCP server configuration (`claude_desk
 
 ### 3. Start the Tauri app
 
-The proxy connects to the app's MCP endpoint. The app must be running first:
+The proxy connects to the app's MCP endpoint. The app (plus the synchronizer and relayer it depends on) must be running first:
 
 ```sh
-cd zk-craft/app-gui
-npm run tauri dev
+cd zk-craft
+just dev
 ```
 
-The MCP server starts automatically on `http://127.0.0.1:3001/mcp`.
+This starts the synchronizer, relayer, and GUI together. The MCP server starts automatically on `http://127.0.0.1:3001/mcp`.
 
 ### 4. Restart Claude Desktop
 
@@ -92,7 +92,7 @@ Claude Desktop reads the config on startup. After adding the server config and s
 The proxy works with Claude Code the same way as Claude Desktop. With the app running:
 
 ```sh
-claude mcp add zk-craft /absolute/path/to/zk-craft/target/release/zk-craft-mcp-proxy -- --port 3001
+claude mcp add zk-craft /absolute/path/to/zk-craft/target/release/craft-mcp-proxy -- --port 3001
 ```
 
 Or add to `.claude/settings.json` manually:
@@ -101,7 +101,7 @@ Or add to `.claude/settings.json` manually:
 {
   "mcpServers": {
     "zk-craft": {
-      "command": "/absolute/path/to/zk-craft/target/release/zk-craft-mcp-proxy",
+      "command": "/absolute/path/to/zk-craft/target/release/craft-mcp-proxy",
       "args": ["--port", "3001"]
     }
   }
@@ -113,7 +113,7 @@ Or add to `.claude/settings.json` manually:
 For development and testing without the full app stack, use the stdio mock server:
 
 ```sh
-claude mcp add zk-craft-mock /absolute/path/to/zk-craft/target/release/zk-craft-mcp-stdio
+claude mcp add zk-craft-mock /absolute/path/to/zk-craft/target/release/craft-mcp-stdio
 ```
 
 This serves mock data — useful for testing MCP tools or developing new ones.
@@ -123,7 +123,7 @@ This serves mock data — useful for testing MCP tools or developing new ones.
 ### Running tests
 
 ```sh
-cargo test -p zk-craft-mcp --release
+cargo test -p craft-mcp --release
 ```
 
 Tests run against `MockCraftOps` and cover tool handlers, structured output, error cases, and server startup.
@@ -133,20 +133,20 @@ Tests run against `MockCraftOps` and cover tool handlers, structured output, err
 **HTTP mock** (for testing the proxy or direct HTTP clients):
 
 ```sh
-cargo run -p zk-craft-mcp --bin zk-craft-mcp-mock --release
+cargo run -p craft-mcp --bin craft-mcp-mock --release
 # Listens on http://127.0.0.1:3001/mcp
 ```
 
 **Stdio mock** (for testing with Claude Desktop/Code without the app):
 
 ```sh
-cargo run -p zk-craft-mcp --bin zk-craft-mcp-stdio --release
+cargo run -p craft-mcp --bin craft-mcp-stdio --release
 ```
 
 ### Proxy
 
 ```sh
-cargo run -p zk-craft-mcp --bin zk-craft-mcp-proxy --features proxy --release -- --port 3001
+cargo run -p craft-mcp --bin craft-mcp-proxy --features proxy --release -- --port 3001
 ```
 
 The proxy accepts `--port <PORT>` or `--url <URL>` to configure the upstream endpoint. Default: `http://127.0.0.1:3001/mcp`.

--- a/mcp/docs/instructions.md
+++ b/mcp/docs/instructions.md
@@ -1,0 +1,37 @@
+# ZK-Craft MCP Server
+
+You are connected to a ZK-Craft game instance. This server lets you inspect and manipulate Digital Objects — items whose entire existence is proved by zero-knowledge proofs. There is no central database of objects; each object is a self-contained ZK certificate that its holder stores locally.
+
+## Core concepts
+
+**Digital Objects.** Each object is a key-value dictionary (fields like `blueprint`, `durability`, `key`) paired with a ZK proof that the object was created or transformed by a valid sequence of actions. The proof is constant-size regardless of history — it does not reveal how many transitions occurred or when the object was created.
+
+**Classes.** Every object belongs to a class. The class is determined by a podlang predicate — a declarative rule that defines all valid ways the object could have reached its current state. Use `list_actions` and `inspect_class` to discover the available classes and how they relate.
+
+**Actions.** Actions are state transitions that consume input objects, generate a ZK proof, and produce output objects. Each action takes seconds to minutes of CPU time for proof generation. Only one action can run at a time. Use `list_actions` to see what's available and what each action requires.
+
+**Nullifiers and liveness.** When an action consumes an object, it publishes a nullifier (a hash derived from the object's key). This prevents double-spending. An object is "live" if its nullifier has not been published. Dead objects remain in inventory for reference but cannot be used as inputs.
+
+**State root.** A Global State Root (GSR) is a hash of all published transactions and nullifiers at a given Ethereum block. Actions must be grounded in a recent GSR (within ~300 blocks / ~1 hour). The `get_state_root` tool returns the current GSR.
+
+## Using the tools
+
+- Start with `list_inventory` and `list_actions` to understand what's available.
+- Use `check_feasibility` before `run_action` to verify inputs exist.
+- Use `inspect_object` to see an object's fields and the predicate that certifies it.
+- Use `inspect_class` to understand a class without needing a specific instance.
+- `run_action` blocks for proof generation. It returns an error if another action is already running — do not retry immediately.
+- After `run_action`, call `list_inventory` again to see the updated state.
+
+## Podlang predicates
+
+The `predicateSource` field on objects and classes shows the podlang definition. Podlang is a declarative language for specifying ZK proof constraints:
+
+- `AND(...)` — all clauses must hold
+- `OR(...)` — any one branch must hold (used for state-machine patterns)
+- `DictContains(dict, "key", value)` — the dictionary contains this key-value pair
+- `DictInsert/DictUpdate/DictDelete` — dictionary mutation operations
+- `GtEq`, `Equal`, `SumOf` — arithmetic constraints
+- `HashOf` — hash computation
+
+The top-level pattern is always `IsClassName(state) = OR(Action1(...), Action2(...))`, meaning the object's current state must be reachable via at least one valid action.

--- a/mcp/docs/object-lifecycle.md
+++ b/mcp/docs/object-lifecycle.md
@@ -1,0 +1,63 @@
+# Digital Object Lifecycle
+
+This document walks through the lifecycle of a Digital Object from creation to consumption, showing what happens at each stage.
+
+## 1. Creation
+
+When an action creates a new object, it:
+
+1. Builds a fresh dictionary with the object's fields (e.g. `{key: 0xabc, blueprint: "Wood"}`).
+2. Generates a ZK proof that this dictionary satisfies the class predicate (e.g. `IsWood(state) = AND(CraftWood(state, log))`). The proof includes verification that the input `log` was itself valid.
+3. Records the new object in a transaction via `TxInserted`, adding it to the transaction's live set.
+4. The object appears in inventory as `live: true` with its fields visible.
+
+The resulting `.dobj` file contains the state dictionary and the proof. The proof is constant-size — it does not grow as objects are created from longer chains of prior objects.
+
+## 2. Inspection
+
+When you inspect a live object, you see:
+- **id**: a hash uniquely identifying this object state
+- **className**: determined by the predicate that certifies it
+- **fields**: the key-value pairs (blueprint, durability, key, etc.)
+- **predicateSource**: the podlang rule showing all valid transitions
+- **live**: true, meaning its nullifier has not been published
+
+## 3. Mutation
+
+Some actions mutate objects rather than consuming them (e.g. using a pickaxe decrements its durability). A mutation:
+
+1. Proves the current state is valid.
+2. Modifies fields (e.g. `DictUpdate(new, old, "durability", new_value)`).
+3. Publishes a nullifier for the OLD state (preventing it from being reused).
+4. Records the transition via `TxMutated(tx_after, tx_before, new, old)`.
+5. The old object becomes `live: false`. The new object appears as `live: true` with updated fields.
+
+The old object ID and the new object ID are different (the ID is a hash of the state dictionary, and the fields changed).
+
+## 4. Consumption
+
+When an object is consumed as input to an action (e.g. a Log consumed by CraftWood):
+
+1. The action proves the input is valid.
+2. A nullifier is published for the input object.
+3. The input is removed from the live set via `TxDeleted`.
+4. The input object becomes `live: false` permanently.
+5. Output objects are created as in step 1.
+
+## 5. Nullifiers and double-spend prevention
+
+A nullifier is a hash derived from the object's key: `hash(hash(obj_dict, obj_dict.key), "txlib-nullifier-v1")`. It is published to a global set tracked by the synchronizer.
+
+Once published, any attempt to use the same object in another action will fail because the nullifier is already in the set. This prevents double-spending without revealing which specific object was spent (the nullifier is a hash, not the object itself).
+
+## 6. State root grounding
+
+Every action must reference a recent Global State Root (GSR) — a hash of all published transactions and nullifiers. This ensures the action's inputs were live at a known point in time. The synchronizer rejects actions grounded in a GSR more than ~300 blocks (~1 hour) old.
+
+## Summary of what changes after each action
+
+| Before | Action | After |
+|--------|--------|-------|
+| Input objects: `live: true` | Action runs | Input objects: `live: false` (nullified) |
+| — | Proof generated | Output objects: `live: true` (new) |
+| Mutated objects: `live: true` | Action runs | Old state: `live: false`, New state: `live: true` |

--- a/mcp/docs/podlang-reference.md
+++ b/mcp/docs/podlang-reference.md
@@ -1,0 +1,193 @@
+# Podlang Reference
+
+Podlang is a declarative language for specifying zero-knowledge proof constraints in the POD2 framework. Predicates define what must be true for a proof to verify.
+
+## Syntax
+
+A predicate definition has the form:
+
+```
+PredicateName(public_arg1, public_arg2, private: priv_arg1, priv_arg2) = COMBINER(
+  Clause1(...)
+  Clause2(...)
+)
+```
+
+- **Public arguments** (before `private:`) are visible to the verifier. They appear in the proof's public inputs and can be constrained by callers.
+- **Private arguments** (after `private:`) are witnesses known only to the prover. They are consumed during proof generation and never revealed.
+- If there are no private arguments, the `private:` keyword is omitted.
+
+Comments use `// line comment` or `/* block comment */` syntax.
+
+Identifiers (predicate names, argument names) must start with a letter or `_`, followed by letters, digits, or `_`. The words `private`, `true`, and `false` are reserved.
+
+## Combiners
+
+- `AND(...)` — all clauses must hold simultaneously.
+- `OR(...)` — exactly one branch must hold. Used for the state-machine pattern where an object could have been produced by any of several actions.
+
+## Literal values
+
+- **Integer**: `0`, `42`, `-1` (64-bit signed)
+- **Boolean**: `true`, `false`
+- **String**: `"hello"`, `"escaped \" quote"`
+- **Raw (32-byte hex)**: `Raw(0x...64 hex digits...)`
+- **Public key**: `PublicKey(base58string)`
+- **Secret key**: `SecretKey(base64string)`
+- **Dictionary**: `{"key": value, ...}` or `{}` for empty. Keys must be strings.
+- **Set**: `#[element, ...]` or `#[]` for empty
+- **Array**: `[element, ...]` or `[]` for empty
+- **Predicate literal**: `::PredicateName` or `module::PredicateName` (resolves to the predicate's identity hash)
+
+All value types can be hashed (producing a 256-bit Poseidon hash). Dictionaries, arrays, and sets are collectively called "containers" and are implemented as Merkle trees, identified by their root hash.
+
+## Built-in predicates
+
+These are the predicates available in podlang. Some are native to the backend circuit; others are syntactic sugar that the compiler lowers to native operations.
+
+### Dictionary operations
+- `DictContains(dict, "key", value)` — the dictionary contains this key-value pair.
+- `DictNotContains(dict, "key")` — the dictionary does NOT contain this key.
+- `DictInsert(new, old, "key", value)` — `new` equals `old` with `key` added. Key must NOT exist in `old`.
+- `DictUpdate(new, old, "key", value)` — `new` equals `old` with `key`'s value changed. Key MUST already exist in `old`.
+- `DictDelete(new, old, "key")` — `new` equals `old` with `key` removed. Key MUST exist in `old`.
+
+### Set operations
+- `SetContains(set, element)` — the set contains this element.
+- `SetNotContains(set, element)` — the set does NOT contain this element.
+- `SetInsert(new, old, element)` — `new` equals `old` with element added.
+- `SetDelete(new, old, element)` — `new` equals `old` with element removed.
+
+### Array operations
+- `ArrayContains(array, index, element)` — the array contains element at index.
+- `ArrayUpdate(new, old, index, value)` — `new` equals `old` with value at index changed.
+
+### Equality and comparison
+- `Equal(a, b)` — `a` equals `b` (works on any type; for compound types, compares hashes).
+- `NotEqual(a, b)` — `a` does not equal `b`.
+- `Gt(a, b)` — `a > b` (integers only).
+- `GtEq(a, b)` — `a >= b` (integers only).
+- `Lt(a, b)` — `a < b` (integers only).
+- `LtEq(a, b)` — `a <= b` (integers only).
+
+### Arithmetic
+- `SumOf(sum, a, b)` — `sum = a + b`.
+- `ProductOf(product, a, b)` — `product = a * b`.
+- `MaxOf(max, a, b)` — `max = max(a, b)`.
+
+### Hashing
+- `HashOf(hash, input1, input2)` — `hash` is the Poseidon hash of the two inputs.
+
+### Cryptographic
+- `PublicKeyOf(pubkey, secret)` — `pubkey` is the public key derived from `secret`.
+- `SignedBy(message, pubkey)` — `message` is signed by the holder of `pubkey`.
+
+## Statement arguments
+
+Each argument to a predicate clause can be:
+
+- A **variable name** — bound by the predicate's public or private args
+- A **literal value** — an integer, string, boolean, empty dict `{}`, empty set `#[]`, etc.
+- An **anchored key** — a reference into a dictionary (see below)
+
+## Anchored keys
+
+An anchored key is a reference to a value inside a dictionary. There are two notations:
+
+- **Dot notation**: `state.field` — only valid for identifier-like keys
+- **Bracket notation**: `state["field"]` — allows any string key
+
+These work in built-in predicate clauses:
+
+```
+GtEq(distance, old_state.locked)
+DictContains(pod["name"], "Alice")
+```
+
+But anchored keys are **NOT allowed as arguments to a sub-predicate call**:
+
+```
+// WRONG — anchored key passed to sub-predicate:
+NotExpired(state.timeout_block, ...)
+
+// CORRECT — extract first via DictContains, then pass:
+MyPred(state, private: timeout) = AND(
+  DictContains(state, "timeout_block", timeout)
+  NotExpired(timeout, ...)
+)
+```
+
+## The IsX state-machine pattern
+
+Every object class has a top-level predicate following this pattern:
+
+```
+IsClassName(state) = OR(
+  CreateAction(state, ...)
+  MutateAction(state, prev_state)
+  AnotherAction(state, ...)
+)
+```
+
+Each OR branch represents one valid way the object could have reached its current state. When proving `IsClassName(state)`, the prover supplies the private witness for whichever branch actually applies. The verifier learns only that *some* valid branch holds — not which one.
+
+Private args of the OR are the union of all branches' private args.
+
+## Imports
+
+### Module import
+
+Imports a predicate group (identified by its Merkle root hash) and gives it a local alias:
+
+```
+use module 0xHASH as txlib
+
+MyPred(...) = AND(
+  txlib::StateRoot(...)
+)
+```
+
+Multiple predicates can be defined in a single group (file), and they can reference each other — including recursively.
+
+### Introduction pod import
+
+Imports a cryptographic primitive (introduction predicate) from an introduction pod:
+
+```
+use intro predicate_name(arg1, arg2) from 0xHASH
+```
+
+Introduction pods provide base-level facts (like signatures or VDF results) that don't come from custom predicates.
+
+## Recursive predicates
+
+Custom predicates can reference themselves or other predicates in the same group. This enables inductive definitions:
+
+```
+eth_dos_base(src, dst, distance) = AND(
+  Equal(src, dst)
+  Equal(distance, 0)
+)
+
+eth_dos_ind(src, dst, distance, private: shorter_distance, mid) = AND(
+  eth_dos(src, mid, shorter_distance)
+  SumOf(distance, shorter_distance, 1)
+  eth_friend(mid, dst)
+)
+
+eth_dos(src, dst, distance) = OR(
+  eth_dos_base(src, dst, distance)
+  eth_dos_ind(src, dst, distance)
+)
+```
+
+## Common patterns
+
+### Creating an object
+A create action typically initializes a fresh dictionary with `DictInsert` operations, then wraps it in a transaction via `TxInserted`.
+
+### Mutating an object
+A mutation proves the old state is valid (`IsClassName(old_state)`), modifies fields with `DictUpdate`, and records the transition via `TxMutated`. The old object gets a nullifier to prevent reuse.
+
+### Consuming an object
+Consumption proves validity of the input, then removes it via `TxDeleted`. The nullifier is published, permanently marking the object as spent.

--- a/mcp/src/bin/mock_server.rs
+++ b/mcp/src/bin/mock_server.rs
@@ -1,6 +1,6 @@
 use tracing_subscriber::{EnvFilter, layer::SubscriberExt, util::SubscriberInitExt};
-use zk_craft_mcp::{McpConfig, McpServer};
 use zk_craft_mcp::mock::MockCraftOps;
+use zk_craft_mcp::{McpConfig, McpServer};
 
 const BIND_ADDRESS: &str = "127.0.0.1:3001";
 

--- a/mcp/src/bin/mock_server.rs
+++ b/mcp/src/bin/mock_server.rs
@@ -1,24 +1,19 @@
-use tracing_subscriber::{EnvFilter, layer::SubscriberExt, util::SubscriberInitExt};
-use zk_craft_mcp::mock::MockCraftOps;
-use zk_craft_mcp::{McpConfig, McpServer};
-
-const BIND_ADDRESS: &str = "127.0.0.1:3001";
+use craft_mcp::mock::MockCraftOps;
+use craft_mcp::{DEFAULT_PORT, McpConfig, McpServer};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    tracing_subscriber::registry()
-        .with(EnvFilter::try_from_default_env().unwrap_or_else(|_| "info".into()))
-        .with(tracing_subscriber::fmt::layer())
-        .init();
+    craft_mcp::logging::init();
 
+    let bind_address = format!("127.0.0.1:{DEFAULT_PORT}");
     let ct = tokio_util::sync::CancellationToken::new();
     let config = McpConfig {
         cancellation_token: ct.clone(),
     };
     let server = McpServer::new(MockCraftOps::new(), config);
-    let listener = tokio::net::TcpListener::bind(BIND_ADDRESS).await?;
+    let listener = tokio::net::TcpListener::bind(&bind_address).await?;
 
-    tracing::info!("ZK-Craft MCP mock server listening on http://{BIND_ADDRESS}/mcp");
+    tracing::info!("ZK-Craft MCP mock server listening on http://{bind_address}/mcp");
 
     let ct2 = ct.clone();
     tokio::spawn(async move {

--- a/mcp/src/bin/mock_server.rs
+++ b/mcp/src/bin/mock_server.rs
@@ -1,0 +1,31 @@
+use tracing_subscriber::{EnvFilter, layer::SubscriberExt, util::SubscriberInitExt};
+use zk_craft_mcp::{McpConfig, McpServer};
+use zk_craft_mcp::mock::MockCraftOps;
+
+const BIND_ADDRESS: &str = "127.0.0.1:3001";
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::registry()
+        .with(EnvFilter::try_from_default_env().unwrap_or_else(|_| "info".into()))
+        .with(tracing_subscriber::fmt::layer())
+        .init();
+
+    let ct = tokio_util::sync::CancellationToken::new();
+    let config = McpConfig {
+        cancellation_token: ct.clone(),
+    };
+    let server = McpServer::new(MockCraftOps::new(), config);
+    let listener = tokio::net::TcpListener::bind(BIND_ADDRESS).await?;
+
+    tracing::info!("ZK-Craft MCP mock server listening on http://{BIND_ADDRESS}/mcp");
+
+    let ct2 = ct.clone();
+    tokio::spawn(async move {
+        tokio::signal::ctrl_c().await.unwrap();
+        tracing::info!("Shutting down...");
+        ct2.cancel();
+    });
+
+    server.serve(listener).await
+}

--- a/mcp/src/bin/mock_stdio.rs
+++ b/mcp/src/bin/mock_stdio.rs
@@ -1,16 +1,11 @@
+use craft_mcp::mock::MockCraftOps;
+use craft_mcp::server::CraftMcpService;
 use rmcp::ServiceExt;
 use rmcp::transport::io::stdio;
-use tracing_subscriber::{EnvFilter, layer::SubscriberExt, util::SubscriberInitExt};
-use zk_craft_mcp::mock::MockCraftOps;
-use zk_craft_mcp::server::CraftMcpService;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    // Log to stderr so stdout stays clean for JSON-RPC
-    tracing_subscriber::registry()
-        .with(EnvFilter::try_from_default_env().unwrap_or_else(|_| "info".into()))
-        .with(tracing_subscriber::fmt::layer().with_writer(std::io::stderr))
-        .init();
+    craft_mcp::logging::init_stderr();
 
     tracing::info!("ZK-Craft MCP mock server starting (stdio transport)");
 

--- a/mcp/src/bin/mock_stdio.rs
+++ b/mcp/src/bin/mock_stdio.rs
@@ -1,0 +1,22 @@
+use rmcp::ServiceExt;
+use rmcp::transport::io::stdio;
+use tracing_subscriber::{EnvFilter, layer::SubscriberExt, util::SubscriberInitExt};
+use zk_craft_mcp::mock::MockCraftOps;
+use zk_craft_mcp::server::CraftMcpService;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    // Log to stderr so stdout stays clean for JSON-RPC
+    tracing_subscriber::registry()
+        .with(EnvFilter::try_from_default_env().unwrap_or_else(|_| "info".into()))
+        .with(tracing_subscriber::fmt::layer().with_writer(std::io::stderr))
+        .init();
+
+    tracing::info!("ZK-Craft MCP mock server starting (stdio transport)");
+
+    let service = CraftMcpService::new(std::sync::Arc::new(MockCraftOps::new()));
+    let running = service.serve(stdio()).await?;
+    running.waiting().await?;
+
+    Ok(())
+}

--- a/mcp/src/bin/proxy_stdio.rs
+++ b/mcp/src/bin/proxy_stdio.rs
@@ -1,0 +1,107 @@
+/// Stdio-to-HTTP proxy for the ZK-Craft MCP server.
+///
+/// Claude Desktop launches this as a child process. It reads JSON-RPC from
+/// stdin, forwards to the Tauri app's streamable HTTP MCP endpoint, and
+/// writes responses to stdout.
+use std::io::{BufRead, Write};
+
+use tracing_subscriber::{EnvFilter, layer::SubscriberExt, util::SubscriberInitExt};
+
+const DEFAULT_URL: &str = "http://127.0.0.1:3001/mcp";
+
+fn main() -> anyhow::Result<()> {
+    tracing_subscriber::registry()
+        .with(EnvFilter::try_from_default_env().unwrap_or_else(|_| "info".into()))
+        .with(tracing_subscriber::fmt::layer().with_writer(std::io::stderr))
+        .init();
+
+    let url = parse_url_from_args();
+    tracing::info!("ZK-Craft MCP proxy connecting to {url}");
+
+    let client = reqwest::blocking::Client::builder()
+        .timeout(std::time::Duration::from_secs(600))
+        .build()?;
+    let mut session_id: Option<String> = None;
+
+    let stdin = std::io::stdin().lock();
+    let mut stdout = std::io::stdout().lock();
+
+    for line in stdin.lines() {
+        let line = line?;
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+
+        // Check if this is a request (has "id") or notification (no "id")
+        let parsed: serde_json::Value = serde_json::from_str(line)?;
+        let is_request = parsed.get("id").is_some();
+
+        // Build the HTTP request
+        let mut req = client
+            .post(&url)
+            .header("Content-Type", "application/json")
+            .header("Accept", "application/json, text/event-stream");
+
+        if let Some(sid) = &session_id {
+            req = req.header("Mcp-Session-Id", sid);
+        }
+
+        let resp = req.body(line.to_string()).send().map_err(|e| {
+            anyhow::anyhow!(
+                "Failed to connect to MCP server at {url}: {e}. Is the Tauri app running?"
+            )
+        })?;
+
+        // Capture session ID from response
+        if let Some(sid) = resp.headers().get("mcp-session-id") {
+            session_id = Some(sid.to_str().unwrap_or_default().to_string());
+        }
+
+        if !is_request {
+            // Notification — no response expected on stdio
+            continue;
+        }
+
+        // Parse SSE response to extract JSON-RPC messages
+        let body = resp.text()?;
+        for sse_line in body.lines() {
+            if let Some(data) = sse_line.strip_prefix("data: ") {
+                let data = data.trim();
+                if data.is_empty() {
+                    continue;
+                }
+                // Validate it's JSON before forwarding
+                if data.starts_with('{') {
+                    writeln!(stdout, "{data}")?;
+                    stdout.flush()?;
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn parse_url_from_args() -> String {
+    let args: Vec<String> = std::env::args().collect();
+    let mut i = 1;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--port" => {
+                if let Some(port) = args.get(i + 1) {
+                    return format!("http://127.0.0.1:{port}/mcp");
+                }
+                i += 2;
+            }
+            "--url" => {
+                if let Some(url) = args.get(i + 1) {
+                    return url.clone();
+                }
+                i += 2;
+            }
+            _ => i += 1,
+        }
+    }
+    DEFAULT_URL.to_string()
+}

--- a/mcp/src/bin/proxy_stdio.rs
+++ b/mcp/src/bin/proxy_stdio.rs
@@ -5,15 +5,8 @@
 /// writes responses to stdout.
 use std::io::{BufRead, Write};
 
-use tracing_subscriber::{EnvFilter, layer::SubscriberExt, util::SubscriberInitExt};
-
-const DEFAULT_URL: &str = "http://127.0.0.1:3001/mcp";
-
 fn main() -> anyhow::Result<()> {
-    tracing_subscriber::registry()
-        .with(EnvFilter::try_from_default_env().unwrap_or_else(|_| "info".into()))
-        .with(tracing_subscriber::fmt::layer().with_writer(std::io::stderr))
-        .init();
+    craft_mcp::logging::init_stderr();
 
     let url = parse_url_from_args();
     tracing::info!("ZK-Craft MCP proxy connecting to {url}");
@@ -103,5 +96,5 @@ fn parse_url_from_args() -> String {
             _ => i += 1,
         }
     }
-    DEFAULT_URL.to_string()
+    format!("http://127.0.0.1:{}/mcp", craft_mcp::DEFAULT_PORT)
 }

--- a/mcp/src/lib.rs
+++ b/mcp/src/lib.rs
@@ -1,8 +1,12 @@
+pub mod logging;
 pub mod mock;
 pub mod ops;
 pub mod resources;
 pub mod server;
 pub mod types;
+
+/// Default port for the MCP server.
+pub const DEFAULT_PORT: u16 = 3001;
 
 use std::sync::Arc;
 

--- a/mcp/src/lib.rs
+++ b/mcp/src/lib.rs
@@ -1,0 +1,77 @@
+pub mod mock;
+pub mod ops;
+pub mod server;
+pub mod types;
+
+use std::sync::Arc;
+
+use ops::CraftOps;
+use rmcp::transport::streamable_http_server::{
+    StreamableHttpServerConfig, StreamableHttpService, session::local::LocalSessionManager,
+};
+use server::CraftMcpService;
+use tokio_util::sync::CancellationToken;
+
+/// Configuration for the MCP server.
+pub struct McpConfig {
+    /// Cancellation token for graceful shutdown.
+    pub cancellation_token: CancellationToken,
+}
+
+impl Default for McpConfig {
+    fn default() -> Self {
+        Self {
+            cancellation_token: CancellationToken::new(),
+        }
+    }
+}
+
+/// Top-level MCP server handle.
+///
+/// Wraps `CraftOps` and provides an axum router that can be mounted
+/// into any axum application or served standalone.
+pub struct McpServer<T: CraftOps> {
+    ops: Arc<T>,
+    config: McpConfig,
+}
+
+impl<T: CraftOps> McpServer<T> {
+    pub fn new(ops: T, config: McpConfig) -> Self {
+        Self {
+            ops: Arc::new(ops),
+            config,
+        }
+    }
+
+    /// Build an axum `Router` with the MCP service mounted at `/mcp`.
+    pub fn router(self) -> axum::Router {
+        let ops = self.ops;
+        let ct = self.config.cancellation_token;
+
+        let service = StreamableHttpService::new(
+            move || Ok(CraftMcpService::new(ops.clone())),
+            LocalSessionManager::default().into(),
+            StreamableHttpServerConfig {
+                cancellation_token: ct.child_token(),
+                ..Default::default()
+            },
+        );
+
+        axum::Router::new().nest_service("/mcp", service)
+    }
+
+    /// Serve the MCP server on the given TCP listener.
+    /// Blocks until the cancellation token is cancelled or Ctrl+C.
+    pub async fn serve(self, listener: tokio::net::TcpListener) -> anyhow::Result<()> {
+        let ct = self.config.cancellation_token.clone();
+        let router = self.router();
+
+        axum::serve(listener, router)
+            .with_graceful_shutdown(async move {
+                ct.cancelled().await;
+            })
+            .await?;
+
+        Ok(())
+    }
+}

--- a/mcp/src/lib.rs
+++ b/mcp/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod mock;
 pub mod ops;
+pub mod resources;
 pub mod server;
 pub mod types;
 

--- a/mcp/src/logging.rs
+++ b/mcp/src/logging.rs
@@ -1,0 +1,18 @@
+use tracing_subscriber::{EnvFilter, layer::SubscriberExt, util::SubscriberInitExt};
+
+/// Initialize tracing to stdout (for non-stdio binaries).
+pub fn init() {
+    tracing_subscriber::registry()
+        .with(EnvFilter::try_from_default_env().unwrap_or_else(|_| "info".into()))
+        .with(tracing_subscriber::fmt::layer())
+        .init();
+}
+
+/// Initialize tracing to stderr (for stdio transport binaries where stdout
+/// carries JSON-RPC).
+pub fn init_stderr() {
+    tracing_subscriber::registry()
+        .with(EnvFilter::try_from_default_env().unwrap_or_else(|_| "info".into()))
+        .with(tracing_subscriber::fmt::layer().with_writer(std::io::stderr))
+        .init();
+}

--- a/mcp/src/mock.rs
+++ b/mcp/src/mock.rs
@@ -1,0 +1,469 @@
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use anyhow::{anyhow, bail};
+
+use crate::ops::CraftOps;
+use crate::types::*;
+
+/// Mock implementation of CraftOps for testing.
+/// Returns realistic fixtures matching the zk-craft game.
+pub struct MockCraftOps {
+    inventory: Vec<InventoryObject>,
+    actions: Vec<Action>,
+    state_root: String,
+    /// Simulates mutual exclusion: only one action at a time.
+    action_in_progress: Mutex<bool>,
+}
+
+impl MockCraftOps {
+    pub fn new() -> Self {
+        Self {
+            inventory: default_inventory(),
+            actions: default_actions(),
+            state_root: "0x9a8b7c6d5e4f3a2b1c0d9e8f7a6b5c4d3e2f1a0b".to_string(),
+            action_in_progress: Mutex::new(false),
+        }
+    }
+
+    /// Create a mock with a custom inventory.
+    pub fn with_inventory(mut self, inventory: Vec<InventoryObject>) -> Self {
+        self.inventory = inventory;
+        self
+    }
+
+    /// Create a mock that simulates an action already in progress.
+    pub fn with_action_in_progress(self) -> Self {
+        *self.action_in_progress.lock().unwrap() = true;
+        self
+    }
+}
+
+impl Default for MockCraftOps {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl CraftOps for MockCraftOps {
+    fn list_inventory(&self) -> anyhow::Result<Vec<InventoryObject>> {
+        Ok(self.inventory.clone())
+    }
+
+    fn list_actions(&self) -> anyhow::Result<Vec<Action>> {
+        Ok(self.actions.clone())
+    }
+
+    fn get_state_root(&self) -> anyhow::Result<String> {
+        Ok(self.state_root.clone())
+    }
+
+    fn inspect_object(&self, object_id: &str) -> anyhow::Result<ObjectDetail> {
+        let obj = self
+            .inventory
+            .iter()
+            .find(|o| o.id == object_id)
+            .ok_or_else(|| anyhow!("object not found: {object_id}"))?;
+
+        Ok(ObjectDetail {
+            id: obj.id.clone(),
+            class_name: obj.class_name.clone(),
+            live: obj.live,
+            state: obj.fields.clone(),
+            predicate_source: predicate_source_for(&obj.class_name),
+        })
+    }
+
+    fn inspect_class(&self, class_name: &str) -> anyhow::Result<ClassDetail> {
+        let actions = &self.actions;
+        let produced_by = actions
+            .iter()
+            .filter(|a| a.output_classes.contains(&class_name.to_string()))
+            .map(|a| a.id.clone())
+            .collect();
+        let consumed_by = actions
+            .iter()
+            .filter(|a| a.input_classes.contains(&class_name.to_string()))
+            .map(|a| a.id.clone())
+            .collect();
+
+        if !is_known_class(class_name) {
+            bail!("unknown class: {class_name}");
+        }
+
+        Ok(ClassDetail {
+            class_name: class_name.to_string(),
+            predicate_source: predicate_source_for(class_name),
+            produced_by,
+            consumed_by,
+        })
+    }
+
+    fn run_action(&self, input: RunActionInput) -> anyhow::Result<RunActionResult> {
+        let mut in_progress = self.action_in_progress.lock().unwrap();
+        if *in_progress {
+            bail!("an action is already in progress");
+        }
+
+        // Validate the action exists
+        if !self.actions.iter().any(|a| a.id == input.action_id) {
+            bail!("unknown action: {}", input.action_id);
+        }
+
+        *in_progress = true;
+        // Simulate completion (in real impl this would block for proof generation)
+        *in_progress = false;
+
+        Ok(RunActionResult {
+            success: true,
+            message: format!("Action {} completed successfully", input.action_id),
+            outputs: vec![InventoryObject {
+                id: "0xnew1234567890abcdef".to_string(),
+                class_name: "Wood".to_string(),
+                file_name: "Wood.dobj".to_string(),
+                live: true,
+                fields: HashMap::from([
+                    (
+                        "blueprint".to_string(),
+                        serde_json::Value::String("Wood".to_string()),
+                    ),
+                    (
+                        "key".to_string(),
+                        serde_json::Value::String("0xnew1234567890abcdef".to_string()),
+                    ),
+                ]),
+            }],
+            consumed: input.input_object_paths,
+        })
+    }
+
+    fn check_feasibility(&self, action_id: &str) -> anyhow::Result<FeasibilityReport> {
+        let action = self
+            .actions
+            .iter()
+            .find(|a| a.id == action_id)
+            .ok_or_else(|| anyhow!("unknown action: {action_id}"))?;
+
+        let mut available = Vec::new();
+        let mut missing = Vec::new();
+
+        for required_class in &action.input_classes {
+            if let Some(obj) = self
+                .inventory
+                .iter()
+                .find(|o| &o.class_name == required_class && o.live)
+            {
+                available.push(FeasibilityInput {
+                    class_name: obj.class_name.clone(),
+                    object_id: obj.id.clone(),
+                    file_name: obj.file_name.clone(),
+                });
+            } else {
+                missing.push(required_class.clone());
+            }
+        }
+
+        Ok(FeasibilityReport {
+            feasible: missing.is_empty(),
+            action_id: action_id.to_string(),
+            available_inputs: available,
+            missing_inputs: missing,
+        })
+    }
+}
+
+fn default_inventory() -> Vec<InventoryObject> {
+    vec![
+        InventoryObject {
+            id: "0xabc1111111111111".to_string(),
+            class_name: "Log".to_string(),
+            file_name: "Log.dobj".to_string(),
+            live: true,
+            fields: HashMap::from([
+                (
+                    "blueprint".to_string(),
+                    serde_json::Value::String("Log".to_string()),
+                ),
+                (
+                    "key".to_string(),
+                    serde_json::Value::String("0xabc1111111111111".to_string()),
+                ),
+            ]),
+        },
+        InventoryObject {
+            id: "0xabc2222222222222".to_string(),
+            class_name: "Wood".to_string(),
+            file_name: "Wood.dobj".to_string(),
+            live: true,
+            fields: HashMap::from([
+                (
+                    "blueprint".to_string(),
+                    serde_json::Value::String("Wood".to_string()),
+                ),
+                (
+                    "key".to_string(),
+                    serde_json::Value::String("0xabc2222222222222".to_string()),
+                ),
+            ]),
+        },
+        InventoryObject {
+            id: "0xabc3333333333333".to_string(),
+            class_name: "Stick".to_string(),
+            file_name: "Stick.dobj".to_string(),
+            live: true,
+            fields: HashMap::from([
+                (
+                    "blueprint".to_string(),
+                    serde_json::Value::String("Stick".to_string()),
+                ),
+                (
+                    "key".to_string(),
+                    serde_json::Value::String("0xabc3333333333333".to_string()),
+                ),
+            ]),
+        },
+        InventoryObject {
+            id: "0xabc4444444444444".to_string(),
+            class_name: "WoodPick".to_string(),
+            file_name: "WoodPick.dobj".to_string(),
+            live: true,
+            fields: HashMap::from([
+                (
+                    "blueprint".to_string(),
+                    serde_json::Value::String("WoodPick".to_string()),
+                ),
+                (
+                    "durability".to_string(),
+                    serde_json::Value::Number(3.into()),
+                ),
+                (
+                    "key".to_string(),
+                    serde_json::Value::String("0xabc4444444444444".to_string()),
+                ),
+            ]),
+        },
+        InventoryObject {
+            id: "0xabc5555555555555".to_string(),
+            class_name: "Stone".to_string(),
+            file_name: "Stone.dobj".to_string(),
+            live: true,
+            fields: HashMap::from([
+                (
+                    "blueprint".to_string(),
+                    serde_json::Value::String("Stone".to_string()),
+                ),
+                (
+                    "key".to_string(),
+                    serde_json::Value::String("0xabc5555555555555".to_string()),
+                ),
+            ]),
+        },
+        // A nullified object to test liveness filtering
+        InventoryObject {
+            id: "0xdead000000000000".to_string(),
+            class_name: "Log".to_string(),
+            file_name: "Log_old.dobj".to_string(),
+            live: false,
+            fields: HashMap::from([(
+                "blueprint".to_string(),
+                serde_json::Value::String("Log".to_string()),
+            )]),
+        },
+    ]
+}
+
+fn default_actions() -> Vec<Action> {
+    vec![
+        Action {
+            id: "FindLog".to_string(),
+            description: "Discover a log by proving a short VDF".to_string(),
+            input_classes: vec![],
+            output_classes: vec!["Log".to_string()],
+            cpu_cost: "~20-40s".to_string(),
+        },
+        Action {
+            id: "CraftWood".to_string(),
+            description: "Refine one log into wood".to_string(),
+            input_classes: vec!["Log".to_string()],
+            output_classes: vec!["Wood".to_string()],
+            cpu_cost: "~15-30s".to_string(),
+        },
+        Action {
+            id: "CraftSticks".to_string(),
+            description: "Split one wood into two sticks".to_string(),
+            input_classes: vec!["Wood".to_string()],
+            output_classes: vec!["Stick".to_string(), "Stick".to_string()],
+            cpu_cost: "~5-10s".to_string(),
+        },
+        Action {
+            id: "CraftWoodPick".to_string(),
+            description: "Combine wood and stick to craft a wood pickaxe".to_string(),
+            input_classes: vec!["Wood".to_string(), "Stick".to_string()],
+            output_classes: vec!["WoodPick".to_string()],
+            cpu_cost: "~10-20s".to_string(),
+        },
+        Action {
+            id: "CraftStonePick".to_string(),
+            description: "Combine stone and stick to craft a stone pickaxe".to_string(),
+            input_classes: vec!["Stone".to_string(), "Stick".to_string()],
+            output_classes: vec!["StonePick".to_string()],
+            cpu_cost: "~10-20s".to_string(),
+        },
+        Action {
+            id: "MineStoneWithWoodPick".to_string(),
+            description: "Mine stone using a wood pick (consumes durability)".to_string(),
+            input_classes: vec!["WoodPick".to_string()],
+            output_classes: vec!["Stone".to_string(), "WoodPick".to_string()],
+            cpu_cost: "~25-45s".to_string(),
+        },
+        Action {
+            id: "MineStoneWithStonePick".to_string(),
+            description: "Mine stone using a stone pick (consumes durability)".to_string(),
+            input_classes: vec!["StonePick".to_string()],
+            output_classes: vec!["Stone".to_string(), "StonePick".to_string()],
+            cpu_cost: "~15-35s".to_string(),
+        },
+    ]
+}
+
+const KNOWN_CLASSES: &[&str] = &["Log", "Wood", "Stick", "WoodPick", "Stone", "StonePick"];
+
+fn is_known_class(name: &str) -> bool {
+    KNOWN_CLASSES.contains(&name)
+}
+
+fn predicate_source_for(class_name: &str) -> String {
+    match class_name {
+        "Log" => "IsLog(state) = AND(\n  FindLog(state)\n)".to_string(),
+        "Wood" => "IsWood(state) = AND(\n  CraftWood(state, log)\n)".to_string(),
+        "Stick" => "IsStick(state) = AND(\n  CraftSticks(state, wood)\n)".to_string(),
+        "WoodPick" => {
+            "IsWoodPick(state) = OR(\n  CraftWoodPick(state, wood, stick)\n  UseWoodPick(state, prev)\n)"
+                .to_string()
+        }
+        "Stone" => {
+            "IsStone(state) = OR(\n  MineStoneWithWoodPick(state, pick)\n  MineStoneWithStonePick(state, pick)\n)"
+                .to_string()
+        }
+        "StonePick" => {
+            "IsStonePick(state) = OR(\n  CraftStonePick(state, stone, stick)\n  UseStonePick(state, prev)\n)"
+                .to_string()
+        }
+        _ => format!("Is{class_name}(state) = UNKNOWN"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default_inventory_has_all_classes() {
+        let mock = MockCraftOps::new();
+        let inv = mock.list_inventory().unwrap();
+        let classes: Vec<&str> = inv.iter().map(|o| o.class_name.as_str()).collect();
+        assert!(classes.contains(&"Log"));
+        assert!(classes.contains(&"Wood"));
+        assert!(classes.contains(&"Stick"));
+        assert!(classes.contains(&"WoodPick"));
+        assert!(classes.contains(&"Stone"));
+    }
+
+    #[test]
+    fn test_inspect_object_found() {
+        let mock = MockCraftOps::new();
+        let detail = mock.inspect_object("0xabc1111111111111").unwrap();
+        assert_eq!(detail.class_name, "Log");
+        assert!(detail.live);
+        assert!(detail.predicate_source.contains("FindLog"));
+    }
+
+    #[test]
+    fn test_inspect_object_not_found() {
+        let mock = MockCraftOps::new();
+        assert!(mock.inspect_object("0xnonexistent").is_err());
+    }
+
+    #[test]
+    fn test_inspect_class() {
+        let mock = MockCraftOps::new();
+        let detail = mock.inspect_class("Wood").unwrap();
+        assert!(detail.produced_by.contains(&"CraftWood".to_string()));
+        assert!(detail.consumed_by.contains(&"CraftSticks".to_string()));
+        assert!(detail.consumed_by.contains(&"CraftWoodPick".to_string()));
+    }
+
+    #[test]
+    fn test_inspect_unknown_class() {
+        let mock = MockCraftOps::new();
+        assert!(mock.inspect_class("Diamond").is_err());
+    }
+
+    #[test]
+    fn test_check_feasibility_feasible() {
+        let mock = MockCraftOps::new();
+        let report = mock.check_feasibility("CraftWoodPick").unwrap();
+        assert!(report.feasible);
+        assert!(report.missing_inputs.is_empty());
+        assert_eq!(report.available_inputs.len(), 2);
+    }
+
+    #[test]
+    fn test_check_feasibility_missing() {
+        let mock = MockCraftOps::new();
+        let report = mock.check_feasibility("CraftStonePick").unwrap();
+        // We have Stone and Stick, so this should be feasible
+        assert!(report.feasible);
+    }
+
+    #[test]
+    fn test_check_feasibility_unknown_action() {
+        let mock = MockCraftOps::new();
+        assert!(mock.check_feasibility("CraftDiamond").is_err());
+    }
+
+    #[test]
+    fn test_run_action_success() {
+        let mock = MockCraftOps::new();
+        let result = mock
+            .run_action(RunActionInput {
+                action_id: "CraftWood".to_string(),
+                input_object_paths: vec!["Log.dobj".to_string()],
+            })
+            .unwrap();
+        assert!(result.success);
+    }
+
+    #[test]
+    fn test_run_action_already_in_progress() {
+        let mock = MockCraftOps::new().with_action_in_progress();
+        let result = mock.run_action(RunActionInput {
+            action_id: "CraftWood".to_string(),
+            input_object_paths: vec!["Log.dobj".to_string()],
+        });
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("already in progress")
+        );
+    }
+
+    #[test]
+    fn test_run_action_unknown() {
+        let mock = MockCraftOps::new();
+        let result = mock.run_action(RunActionInput {
+            action_id: "CraftDiamond".to_string(),
+            input_object_paths: vec![],
+        });
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_get_state_root() {
+        let mock = MockCraftOps::new();
+        let root = mock.get_state_root().unwrap();
+        assert!(root.starts_with("0x"));
+    }
+}

--- a/mcp/src/mock.rs
+++ b/mcp/src/mock.rs
@@ -54,6 +54,39 @@ impl CraftOps for MockCraftOps {
         Ok(self.actions.clone())
     }
 
+    fn list_classes(&self) -> anyhow::Result<Vec<ClassSummary>> {
+        let mut classes: Vec<ClassSummary> = KNOWN_CLASSES
+            .iter()
+            .map(|&name| {
+                let live_count = self
+                    .inventory
+                    .iter()
+                    .filter(|o| o.class_name == name && o.live)
+                    .count();
+                let produced_by = self
+                    .actions
+                    .iter()
+                    .filter(|a| a.output_classes.contains(&name.to_string()))
+                    .map(|a| a.id.clone())
+                    .collect();
+                let consumed_by = self
+                    .actions
+                    .iter()
+                    .filter(|a| a.input_classes.contains(&name.to_string()))
+                    .map(|a| a.id.clone())
+                    .collect();
+                ClassSummary {
+                    name: name.to_string(),
+                    live_count,
+                    produced_by,
+                    consumed_by,
+                }
+            })
+            .collect();
+        classes.sort_by(|a, b| a.name.cmp(&b.name));
+        Ok(classes)
+    }
+
     fn get_state_root(&self) -> anyhow::Result<String> {
         Ok(self.state_root.clone())
     }

--- a/mcp/src/ops.rs
+++ b/mcp/src/ops.rs
@@ -1,0 +1,14 @@
+use crate::types::*;
+
+/// The interface the MCP server needs from the host application.
+/// During testing, this is mocked. In production, implemented by
+/// the Tauri app (or a future headless binary).
+pub trait CraftOps: Send + Sync + 'static {
+    fn list_inventory(&self) -> anyhow::Result<Vec<InventoryObject>>;
+    fn list_actions(&self) -> anyhow::Result<Vec<Action>>;
+    fn get_state_root(&self) -> anyhow::Result<String>;
+    fn inspect_object(&self, object_id: &str) -> anyhow::Result<ObjectDetail>;
+    fn inspect_class(&self, class_name: &str) -> anyhow::Result<ClassDetail>;
+    fn run_action(&self, input: RunActionInput) -> anyhow::Result<RunActionResult>;
+    fn check_feasibility(&self, action_id: &str) -> anyhow::Result<FeasibilityReport>;
+}

--- a/mcp/src/ops.rs
+++ b/mcp/src/ops.rs
@@ -6,6 +6,7 @@ use crate::types::*;
 pub trait CraftOps: Send + Sync + 'static {
     fn list_inventory(&self) -> anyhow::Result<Vec<InventoryObject>>;
     fn list_actions(&self) -> anyhow::Result<Vec<Action>>;
+    fn list_classes(&self) -> anyhow::Result<Vec<ClassSummary>>;
     fn get_state_root(&self) -> anyhow::Result<String>;
     fn inspect_object(&self, object_id: &str) -> anyhow::Result<ObjectDetail>;
     fn inspect_class(&self, class_name: &str) -> anyhow::Result<ClassDetail>;

--- a/mcp/src/ops.rs
+++ b/mcp/src/ops.rs
@@ -12,4 +12,10 @@ pub trait CraftOps: Send + Sync + 'static {
     fn inspect_class(&self, class_name: &str) -> anyhow::Result<ClassDetail>;
     fn run_action(&self, input: RunActionInput) -> anyhow::Result<RunActionResult>;
     fn check_feasibility(&self, action_id: &str) -> anyhow::Result<FeasibilityReport>;
+
+    /// Returns the generated podlang source for all actions and classes,
+    /// or None if not available (e.g. in mock mode).
+    fn generated_podlang(&self) -> Option<String> {
+        None
+    }
 }

--- a/mcp/src/resources.rs
+++ b/mcp/src/resources.rs
@@ -1,0 +1,69 @@
+use rmcp::model::{Annotated, RawResource, ReadResourceResult, Resource, ResourceContents};
+
+const PODLANG_REFERENCE_URI: &str = "zk-craft://docs/podlang-reference";
+const TXLIB_PREDICATES_URI: &str = "zk-craft://source/txlib.podlang";
+const TIME_PREDICATES_URI: &str = "zk-craft://source/time.podlang";
+const OBJECT_LIFECYCLE_URI: &str = "zk-craft://docs/object-lifecycle";
+
+pub fn list() -> Vec<Resource> {
+    vec![
+        Annotated::new(
+            RawResource::new(PODLANG_REFERENCE_URI, "Podlang Reference")
+                .with_description(
+                    "Complete reference for the podlang predicate language: \
+                     syntax, built-in operations, public/private arguments, \
+                     OR state-machine pattern, and common pitfalls.",
+                )
+                .with_mime_type("text/markdown"),
+            None,
+        ),
+        Annotated::new(
+            RawResource::new(TXLIB_PREDICATES_URI, "txlib.podlang")
+                .with_description(
+                    "Core transaction-model predicates: StateRoot, TxInit, \
+                     TxInserted, TxMutated, TxDeleted, TxFinalized, and \
+                     nullifier logic. This is the foundation all actions build on.",
+                )
+                .with_mime_type("text/plain"),
+            None,
+        ),
+        Annotated::new(
+            RawResource::new(TIME_PREDICATES_URI, "time.podlang")
+                .with_description(
+                    "Time-related predicates: LockObject, UnlockObject, \
+                     SetExpiry, NotExpired, DistanceBetweenStateRoots. Used \
+                     for time-locked objects and expiry deadlines.",
+                )
+                .with_mime_type("text/plain"),
+            None,
+        ),
+        Annotated::new(
+            RawResource::new(OBJECT_LIFECYCLE_URI, "Object Lifecycle")
+                .with_description(
+                    "Worked example of a Digital Object's lifecycle: creation, \
+                     mutation, consumption, nullifiers, and what each step \
+                     looks like in the inventory.",
+                )
+                .with_mime_type("text/markdown"),
+            None,
+        ),
+    ]
+}
+
+pub fn read(uri: &str) -> Option<ReadResourceResult> {
+    let (content, mime) = match uri {
+        PODLANG_REFERENCE_URI => (PODLANG_REFERENCE, "text/markdown"),
+        TXLIB_PREDICATES_URI => (TXLIB_PREDICATES, "text/plain"),
+        TIME_PREDICATES_URI => (TIME_PREDICATES, "text/plain"),
+        OBJECT_LIFECYCLE_URI => (OBJECT_LIFECYCLE, "text/markdown"),
+        _ => return None,
+    };
+    Some(ReadResourceResult::new(vec![
+        ResourceContents::text(content, uri).with_mime_type(mime),
+    ]))
+}
+
+const PODLANG_REFERENCE: &str = include_str!("../docs/podlang-reference.md");
+const OBJECT_LIFECYCLE: &str = include_str!("../docs/object-lifecycle.md");
+const TXLIB_PREDICATES: &str = include_str!("../../txlib/src/predicates/txlib.podlang");
+const TIME_PREDICATES: &str = include_str!("../../timelib/src/predicates/time.podlang");

--- a/mcp/src/server.rs
+++ b/mcp/src/server.rs
@@ -1,8 +1,13 @@
 use std::sync::Arc;
 
+use rmcp::ErrorData as McpError;
 use rmcp::handler::server::router::tool::ToolRouter;
 use rmcp::handler::server::wrapper::{Json, Parameters};
-use rmcp::model::{ServerCapabilities, ServerInfo};
+use rmcp::model::{
+    ListResourcesResult, ReadResourceRequestParams, ReadResourceResult, ServerCapabilities,
+    ServerInfo,
+};
+use rmcp::service::{RequestContext, RoleServer};
 use rmcp::{ServerHandler, tool, tool_handler, tool_router};
 use schemars::JsonSchema;
 use serde::Deserialize;
@@ -46,6 +51,12 @@ pub struct CheckFeasibilityParams {
     pub action_id: String,
 }
 
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ReadDocParams {
+    /// Document name. Use "list" to see available documents. Available: "podlang-reference", "object-lifecycle", "txlib.podlang", "time.podlang"
+    pub name: String,
+}
+
 // -- Tool implementations --
 
 #[tool_router]
@@ -67,6 +78,16 @@ impl<T: CraftOps> CraftMcpService<T> {
         self.ops
             .list_actions()
             .map(|actions| Json(ActionList { actions }))
+            .map_err(|e| e.to_string())
+    }
+
+    #[tool(
+        description = "List all known object classes with live inventory counts and which actions produce/consume each class"
+    )]
+    fn list_classes(&self) -> Result<Json<ClassList>, String> {
+        self.ops
+            .list_classes()
+            .map(|classes| Json(ClassList { classes }))
             .map_err(|e| e.to_string())
     }
 
@@ -129,17 +150,159 @@ impl<T: CraftOps> CraftMcpService<T> {
             .map(Json)
             .map_err(|e| e.to_string())
     }
+
+    #[tool(
+        description = "Read reference documentation. Available docs: \"podlang-reference\" (full podlang language reference), \"object-lifecycle\" (how Digital Objects are created, mutated, consumed), \"txlib.podlang\" (core transaction predicates source), \"time.podlang\" (time/locking predicates source). Pass \"list\" to see all available documents."
+    )]
+    fn read_doc(&self, Parameters(params): Parameters<ReadDocParams>) -> String {
+        match params.name.as_str() {
+            "list" => {
+                let docs = crate::resources::list();
+                let lines: Vec<String> = docs
+                    .iter()
+                    .map(|r| {
+                        format!(
+                            "- {} ({})\n  {}",
+                            r.name,
+                            r.uri,
+                            r.description.as_deref().unwrap_or("")
+                        )
+                    })
+                    .collect();
+                lines.join("\n")
+            }
+            _ => {
+                let uri = match params.name.as_str() {
+                    "podlang-reference" => "zk-craft://docs/podlang-reference",
+                    "object-lifecycle" => "zk-craft://docs/object-lifecycle",
+                    "txlib.podlang" => "zk-craft://source/txlib.podlang",
+                    "time.podlang" => "zk-craft://source/time.podlang",
+                    other => {
+                        return format!(
+                            "Unknown document: \"{other}\". Use read_doc(\"list\") to see available documents."
+                        );
+                    }
+                };
+                crate::resources::read(uri)
+                    .map(|r| {
+                        r.contents
+                            .into_iter()
+                            .next()
+                            .map(|c| match c {
+                                rmcp::model::ResourceContents::TextResourceContents {
+                                    text,
+                                    ..
+                                } => text,
+                                rmcp::model::ResourceContents::BlobResourceContents {
+                                    blob,
+                                    ..
+                                } => blob,
+                            })
+                            .unwrap_or_default()
+                    })
+                    .unwrap_or_else(|| "Resource not found".to_string())
+            }
+        }
+    }
 }
+
+// -- Instructions --
+
+const INSTRUCTIONS: &str = "\
+# ZK-Craft MCP Server
+
+You are connected to a ZK-Craft game instance. This server lets you inspect \
+and manipulate Digital Objects — items whose entire existence is proved by \
+zero-knowledge proofs. There is no central database of objects; each object is \
+a self-contained ZK certificate that its holder stores locally.
+
+## Core concepts
+
+**Digital Objects.** Each object is a key-value dictionary (fields like \
+`blueprint`, `durability`, `key`) paired with a ZK proof that the object was \
+created or transformed by a valid sequence of actions. The proof is constant-size \
+regardless of history — it does not reveal how many transitions occurred or when \
+the object was created.
+
+**Classes.** Every object belongs to a class. The class is determined by a \
+podlang predicate — a declarative rule that defines all valid ways the object \
+could have reached its current state. Use `list_actions` and `inspect_class` \
+to discover the available classes and how they relate.
+
+**Actions.** Actions are state transitions that consume input objects, generate \
+a ZK proof, and produce output objects. Each action takes seconds to minutes of \
+CPU time for proof generation. Only one action can run at a time. Use \
+`list_actions` to see what's available and what each action requires.
+
+**Nullifiers and liveness.** When an action consumes an object, it publishes a \
+nullifier (a hash derived from the object's key). This prevents double-spending. \
+An object is \"live\" if its nullifier has not been published. Dead objects remain \
+in inventory for reference but cannot be used as inputs.
+
+**State root.** A Global State Root (GSR) is a hash of all published transactions \
+and nullifiers at a given Ethereum block. Actions must be grounded in a recent GSR \
+(within ~300 blocks / ~1 hour). The `get_state_root` tool returns the current GSR.
+
+## Using the tools
+
+- Start with `list_inventory` and `list_actions` to understand what's available.
+- Use `check_feasibility` before `run_action` to verify inputs exist.
+- Use `inspect_object` to see an object's fields and the predicate that certifies it.
+- Use `inspect_class` to understand a class without needing a specific instance.
+- `run_action` blocks for proof generation. It returns an error if another \
+  action is already running — do not retry immediately.
+- After `run_action`, call `list_inventory` again to see the updated state.
+
+## Podlang predicates
+
+The `predicateSource` field on objects and classes shows the podlang definition. \
+Podlang is a declarative language for specifying ZK proof constraints:
+
+- `AND(...)` — all clauses must hold
+- `OR(...)` — any one branch must hold (used for state-machine patterns)
+- `DictContains(dict, \"key\", value)` — the dictionary contains this key-value pair
+- `DictInsert/DictUpdate/DictDelete` — dictionary mutation operations
+- `GtEq`, `Equal`, `SumOf` — arithmetic constraints
+- `HashOf` — hash computation
+
+The top-level pattern is always `IsClassName(state) = OR(Action1(...), Action2(...))`, \
+meaning the object's current state must be reachable via at least one valid action.
+";
 
 // -- ServerHandler --
 
 #[tool_handler]
 impl<T: CraftOps> ServerHandler for CraftMcpService<T> {
     fn get_info(&self) -> ServerInfo {
-        ServerInfo::new(ServerCapabilities::builder().enable_tools().build()).with_instructions(
-            "ZK-Craft MCP server. Provides tools to inspect inventory, \
-             explore crafting actions, and execute ZK proof-based crafting operations.",
+        ServerInfo::new(
+            ServerCapabilities::builder()
+                .enable_tools()
+                .enable_resources()
+                .build(),
         )
+        .with_instructions(INSTRUCTIONS)
+    }
+
+    fn list_resources(
+        &self,
+        _request: Option<rmcp::model::PaginatedRequestParams>,
+        _context: RequestContext<RoleServer>,
+    ) -> impl std::future::Future<Output = Result<ListResourcesResult, McpError>> + Send + '_ {
+        std::future::ready(Ok(ListResourcesResult {
+            meta: None,
+            resources: crate::resources::list(),
+            next_cursor: None,
+        }))
+    }
+
+    fn read_resource(
+        &self,
+        request: ReadResourceRequestParams,
+        _context: RequestContext<RoleServer>,
+    ) -> impl std::future::Future<Output = Result<ReadResourceResult, McpError>> + Send + '_ {
+        std::future::ready(crate::resources::read(&request.uri).ok_or_else(|| {
+            McpError::resource_not_found(format!("unknown resource: {}", request.uri), None)
+        }))
     }
 }
 
@@ -169,7 +332,9 @@ mod tests {
         assert!(tools.contains(&"inspect_class".to_string()));
         assert!(tools.contains(&"run_action".to_string()));
         assert!(tools.contains(&"check_feasibility".to_string()));
-        assert_eq!(tools.len(), 7);
+        assert!(tools.contains(&"list_classes".to_string()));
+        assert!(tools.contains(&"read_doc".to_string()));
+        assert_eq!(tools.len(), 9);
     }
 
     #[test]
@@ -178,7 +343,7 @@ mod tests {
         let info = service.get_info();
         assert!(info.capabilities.tools.is_some());
         assert!(info.instructions.is_some());
-        assert!(info.instructions.unwrap().contains("ZK-Craft MCP server"));
+        assert!(info.instructions.unwrap().contains("ZK-Craft MCP Server"));
     }
 
     #[test]

--- a/mcp/src/server.rs
+++ b/mcp/src/server.rs
@@ -222,66 +222,7 @@ impl<T: CraftOps> CraftMcpService<T> {
 
 // -- Instructions --
 
-const INSTRUCTIONS: &str = "\
-# ZK-Craft MCP Server
-
-You are connected to a ZK-Craft game instance. This server lets you inspect \
-and manipulate Digital Objects — items whose entire existence is proved by \
-zero-knowledge proofs. There is no central database of objects; each object is \
-a self-contained ZK certificate that its holder stores locally.
-
-## Core concepts
-
-**Digital Objects.** Each object is a key-value dictionary (fields like \
-`blueprint`, `durability`, `key`) paired with a ZK proof that the object was \
-created or transformed by a valid sequence of actions. The proof is constant-size \
-regardless of history — it does not reveal how many transitions occurred or when \
-the object was created.
-
-**Classes.** Every object belongs to a class. The class is determined by a \
-podlang predicate — a declarative rule that defines all valid ways the object \
-could have reached its current state. Use `list_actions` and `inspect_class` \
-to discover the available classes and how they relate.
-
-**Actions.** Actions are state transitions that consume input objects, generate \
-a ZK proof, and produce output objects. Each action takes seconds to minutes of \
-CPU time for proof generation. Only one action can run at a time. Use \
-`list_actions` to see what's available and what each action requires.
-
-**Nullifiers and liveness.** When an action consumes an object, it publishes a \
-nullifier (a hash derived from the object's key). This prevents double-spending. \
-An object is \"live\" if its nullifier has not been published. Dead objects remain \
-in inventory for reference but cannot be used as inputs.
-
-**State root.** A Global State Root (GSR) is a hash of all published transactions \
-and nullifiers at a given Ethereum block. Actions must be grounded in a recent GSR \
-(within ~300 blocks / ~1 hour). The `get_state_root` tool returns the current GSR.
-
-## Using the tools
-
-- Start with `list_inventory` and `list_actions` to understand what's available.
-- Use `check_feasibility` before `run_action` to verify inputs exist.
-- Use `inspect_object` to see an object's fields and the predicate that certifies it.
-- Use `inspect_class` to understand a class without needing a specific instance.
-- `run_action` blocks for proof generation. It returns an error if another \
-  action is already running — do not retry immediately.
-- After `run_action`, call `list_inventory` again to see the updated state.
-
-## Podlang predicates
-
-The `predicateSource` field on objects and classes shows the podlang definition. \
-Podlang is a declarative language for specifying ZK proof constraints:
-
-- `AND(...)` — all clauses must hold
-- `OR(...)` — any one branch must hold (used for state-machine patterns)
-- `DictContains(dict, \"key\", value)` — the dictionary contains this key-value pair
-- `DictInsert/DictUpdate/DictDelete` — dictionary mutation operations
-- `GtEq`, `Equal`, `SumOf` — arithmetic constraints
-- `HashOf` — hash computation
-
-The top-level pattern is always `IsClassName(state) = OR(Action1(...), Action2(...))`, \
-meaning the object's current state must be reachable via at least one valid action.
-";
+const INSTRUCTIONS: &str = include_str!("../docs/instructions.md");
 
 // -- ServerHandler --
 

--- a/mcp/src/server.rs
+++ b/mcp/src/server.rs
@@ -128,12 +128,16 @@ impl<T: CraftOps> CraftMcpService<T> {
     #[tool(
         description = "Execute a crafting action. Blocks until proof generation completes. Returns error if another action is already in progress."
     )]
-    fn run_action(
+    async fn run_action(
         &self,
         Parameters(params): Parameters<RunActionInput>,
     ) -> Result<Json<RunActionResult>, String> {
-        self.ops
-            .run_action(params)
+        // Run on the blocking thread pool so we don't starve the async runtime
+        // while proof generation, relayer submission, and sync polling happen.
+        let ops = self.ops.clone();
+        tokio::task::spawn_blocking(move || ops.run_action(params))
+            .await
+            .map_err(|e| format!("action task failed: {e}"))?
             .map(Json)
             .map_err(|e| e.to_string())
     }
@@ -403,25 +407,28 @@ mod tests {
         assert!(detail.produced_by.contains(&"CraftSticks".to_string()));
     }
 
-    #[test]
-    fn test_run_action_via_handler() {
+    #[tokio::test]
+    async fn test_run_action_via_handler() {
         let service = make_service();
         let Json(result) = service
             .run_action(Parameters(RunActionInput {
                 action_id: "FindLog".to_string(),
                 input_object_paths: vec![],
             }))
+            .await
             .unwrap();
         assert!(result.success);
     }
 
-    #[test]
-    fn test_run_action_in_progress_returns_error() {
+    #[tokio::test]
+    async fn test_run_action_in_progress_returns_error() {
         let service = CraftMcpService::new(Arc::new(MockCraftOps::new().with_action_in_progress()));
-        let result = service.run_action(Parameters(RunActionInput {
-            action_id: "FindLog".to_string(),
-            input_object_paths: vec![],
-        }));
+        let result = service
+            .run_action(Parameters(RunActionInput {
+                action_id: "FindLog".to_string(),
+                input_object_paths: vec![],
+            }))
+            .await;
         let err = result.err().expect("should be an error");
         assert!(err.contains("already in progress"));
     }

--- a/mcp/src/server.rs
+++ b/mcp/src/server.rs
@@ -156,13 +156,13 @@ impl<T: CraftOps> CraftMcpService<T> {
     }
 
     #[tool(
-        description = "Read reference documentation. Available docs: \"podlang-reference\" (full podlang language reference), \"object-lifecycle\" (how Digital Objects are created, mutated, consumed), \"txlib.podlang\" (core transaction predicates source), \"time.podlang\" (time/locking predicates source). Pass \"list\" to see all available documents."
+        description = "Read reference documentation. Available docs: \"podlang-reference\" (full podlang language reference), \"object-lifecycle\" (how Digital Objects are created, mutated, consumed), \"txlib.podlang\" (core transaction predicates source), \"time.podlang\" (time/locking predicates source), \"generated.podlang\" (generated podlang for all actions and classes in this game). Pass \"list\" to see all available documents."
     )]
     fn read_doc(&self, Parameters(params): Parameters<ReadDocParams>) -> String {
         match params.name.as_str() {
             "list" => {
                 let docs = crate::resources::list();
-                let lines: Vec<String> = docs
+                let mut lines: Vec<String> = docs
                     .iter()
                     .map(|r| {
                         format!(
@@ -173,6 +173,10 @@ impl<T: CraftOps> CraftMcpService<T> {
                         )
                     })
                     .collect();
+                lines.push(
+                    "- generated.podlang\n  Generated podlang source for all actions and IsClassName predicates in this game instance."
+                        .to_string(),
+                );
                 lines.join("\n")
             }
             _ => {
@@ -181,6 +185,12 @@ impl<T: CraftOps> CraftMcpService<T> {
                     "object-lifecycle" => "zk-craft://docs/object-lifecycle",
                     "txlib.podlang" => "zk-craft://source/txlib.podlang",
                     "time.podlang" => "zk-craft://source/time.podlang",
+                    "generated.podlang" => {
+                        return self
+                            .ops
+                            .generated_podlang()
+                            .unwrap_or_else(|| "(not available in mock mode)".to_string());
+                    }
                     other => {
                         return format!(
                             "Unknown document: \"{other}\". Use read_doc(\"list\") to see available documents."

--- a/mcp/src/server.rs
+++ b/mcp/src/server.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use rmcp::handler::server::router::tool::ToolRouter;
-use rmcp::handler::server::wrapper::Parameters;
+use rmcp::handler::server::wrapper::{Json, Parameters};
 use rmcp::model::{ServerCapabilities, ServerInfo};
 use rmcp::{ServerHandler, tool, tool_handler, tool_router};
 use schemars::JsonSchema;
@@ -53,76 +53,81 @@ impl<T: CraftOps> CraftMcpService<T> {
     #[tool(
         description = "List all objects in the inventory with their types, fields, and liveness status"
     )]
-    fn list_inventory(&self) -> String {
-        match self.ops.list_inventory() {
-            Ok(items) => serde_json::to_string_pretty(&items)
-                .unwrap_or_else(|e| format!("serialization error: {e}")),
-            Err(e) => format!("error: {e}"),
-        }
+    fn list_inventory(&self) -> Result<Json<InventoryList>, String> {
+        self.ops
+            .list_inventory()
+            .map(|objects| Json(InventoryList { objects }))
+            .map_err(|e| e.to_string())
     }
 
     #[tool(
         description = "List all available crafting actions with input/output class requirements and CPU cost"
     )]
-    fn list_actions(&self) -> String {
-        match self.ops.list_actions() {
-            Ok(actions) => serde_json::to_string_pretty(&actions)
-                .unwrap_or_else(|e| format!("serialization error: {e}")),
-            Err(e) => format!("error: {e}"),
-        }
+    fn list_actions(&self) -> Result<Json<ActionList>, String> {
+        self.ops
+            .list_actions()
+            .map(|actions| Json(ActionList { actions }))
+            .map_err(|e| e.to_string())
     }
 
     #[tool(description = "Get the current global state root hash from the synchronizer")]
-    fn get_state_root(&self) -> String {
-        match self.ops.get_state_root() {
-            Ok(root) => serde_json::to_string_pretty(&StateRootResponse { state_root: root })
-                .unwrap_or_else(|e| format!("serialization error: {e}")),
-            Err(e) => format!("error: {e}"),
-        }
+    fn get_state_root(&self) -> Result<Json<StateRootResponse>, String> {
+        self.ops
+            .get_state_root()
+            .map(|root| Json(StateRootResponse { state_root: root }))
+            .map_err(|e| e.to_string())
     }
 
     #[tool(
         description = "Inspect an object by ID: full detail including fields, class, liveness, and predicate source"
     )]
-    fn inspect_object(&self, Parameters(params): Parameters<InspectObjectParams>) -> String {
-        match self.ops.inspect_object(&params.object_id) {
-            Ok(detail) => serde_json::to_string_pretty(&detail)
-                .unwrap_or_else(|e| format!("serialization error: {e}")),
-            Err(e) => format!("error: {e}"),
-        }
+    fn inspect_object(
+        &self,
+        Parameters(params): Parameters<InspectObjectParams>,
+    ) -> Result<Json<ObjectDetail>, String> {
+        self.ops
+            .inspect_object(&params.object_id)
+            .map(Json)
+            .map_err(|e| e.to_string())
     }
 
     #[tool(
         description = "Inspect a class by name: predicate definition, and which actions produce/consume it"
     )]
-    fn inspect_class(&self, Parameters(params): Parameters<InspectClassParams>) -> String {
-        match self.ops.inspect_class(&params.class_name) {
-            Ok(detail) => serde_json::to_string_pretty(&detail)
-                .unwrap_or_else(|e| format!("serialization error: {e}")),
-            Err(e) => format!("error: {e}"),
-        }
+    fn inspect_class(
+        &self,
+        Parameters(params): Parameters<InspectClassParams>,
+    ) -> Result<Json<ClassDetail>, String> {
+        self.ops
+            .inspect_class(&params.class_name)
+            .map(Json)
+            .map_err(|e| e.to_string())
     }
 
     #[tool(
         description = "Execute a crafting action. Blocks until proof generation completes. Returns error if another action is already in progress."
     )]
-    fn run_action(&self, Parameters(params): Parameters<RunActionInput>) -> String {
-        match self.ops.run_action(params) {
-            Ok(result) => serde_json::to_string_pretty(&result)
-                .unwrap_or_else(|e| format!("serialization error: {e}")),
-            Err(e) => format!("error: {e}"),
-        }
+    fn run_action(
+        &self,
+        Parameters(params): Parameters<RunActionInput>,
+    ) -> Result<Json<RunActionResult>, String> {
+        self.ops
+            .run_action(params)
+            .map(Json)
+            .map_err(|e| e.to_string())
     }
 
     #[tool(
         description = "Check whether an action can be executed with the current inventory. Reports available and missing inputs."
     )]
-    fn check_feasibility(&self, Parameters(params): Parameters<CheckFeasibilityParams>) -> String {
-        match self.ops.check_feasibility(&params.action_id) {
-            Ok(report) => serde_json::to_string_pretty(&report)
-                .unwrap_or_else(|e| format!("serialization error: {e}")),
-            Err(e) => format!("error: {e}"),
-        }
+    fn check_feasibility(
+        &self,
+        Parameters(params): Parameters<CheckFeasibilityParams>,
+    ) -> Result<Json<FeasibilityReport>, String> {
+        self.ops
+            .check_feasibility(&params.action_id)
+            .map(Json)
+            .map_err(|e| e.to_string())
     }
 }
 
@@ -142,6 +147,7 @@ impl<T: CraftOps> ServerHandler for CraftMcpService<T> {
 mod tests {
     use super::*;
     use crate::mock::MockCraftOps;
+    use rmcp::handler::server::wrapper::Json;
 
     fn make_service() -> CraftMcpService<MockCraftOps> {
         CraftMcpService::new(Arc::new(MockCraftOps::new()))
@@ -176,40 +182,38 @@ mod tests {
     }
 
     #[test]
-    fn test_list_inventory_returns_valid_json() {
+    fn test_list_inventory_returns_structured() {
         let service = make_service();
-        let result = service.list_inventory();
-        let parsed: Vec<InventoryObject> = serde_json::from_str(&result).unwrap();
-        assert!(!parsed.is_empty());
-        assert!(parsed.iter().any(|o| o.class_name == "Log"));
+        let Json(list) = service.list_inventory().unwrap();
+        assert!(!list.objects.is_empty());
+        assert!(list.objects.iter().any(|o| o.class_name == "Log"));
     }
 
     #[test]
-    fn test_list_actions_returns_valid_json() {
+    fn test_list_actions_returns_structured() {
         let service = make_service();
-        let result = service.list_actions();
-        let parsed: Vec<Action> = serde_json::from_str(&result).unwrap();
-        assert!(!parsed.is_empty());
-        assert!(parsed.iter().any(|a| a.id == "CraftWoodPick"));
+        let Json(list) = service.list_actions().unwrap();
+        assert!(!list.actions.is_empty());
+        assert!(list.actions.iter().any(|a| a.id == "CraftWoodPick"));
     }
 
     #[test]
-    fn test_get_state_root_returns_valid_json() {
+    fn test_get_state_root_returns_structured() {
         let service = make_service();
-        let result = service.get_state_root();
-        let parsed: StateRootResponse = serde_json::from_str(&result).unwrap();
-        assert!(parsed.state_root.starts_with("0x"));
+        let Json(resp) = service.get_state_root().unwrap();
+        assert!(resp.state_root.starts_with("0x"));
     }
 
     #[test]
     fn test_inspect_object_via_handler() {
         let service = make_service();
-        let result = service.inspect_object(Parameters(InspectObjectParams {
-            object_id: "0xabc4444444444444".to_string(),
-        }));
-        let parsed: ObjectDetail = serde_json::from_str(&result).unwrap();
-        assert_eq!(parsed.class_name, "WoodPick");
-        assert!(parsed.predicate_source.contains("CraftWoodPick"));
+        let Json(detail) = service
+            .inspect_object(Parameters(InspectObjectParams {
+                object_id: "0xabc4444444444444".to_string(),
+            }))
+            .unwrap();
+        assert_eq!(detail.class_name, "WoodPick");
+        assert!(detail.predicate_source.contains("CraftWoodPick"));
     }
 
     #[test]
@@ -218,29 +222,32 @@ mod tests {
         let result = service.inspect_object(Parameters(InspectObjectParams {
             object_id: "0xnonexistent".to_string(),
         }));
-        assert!(result.starts_with("error:"));
+        let err = result.err().expect("should be an error");
+        assert!(err.contains("not found"));
     }
 
     #[test]
     fn test_inspect_class_via_handler() {
         let service = make_service();
-        let result = service.inspect_class(Parameters(InspectClassParams {
-            class_name: "Stick".to_string(),
-        }));
-        let parsed: ClassDetail = serde_json::from_str(&result).unwrap();
-        assert_eq!(parsed.class_name, "Stick");
-        assert!(parsed.produced_by.contains(&"CraftSticks".to_string()));
+        let Json(detail) = service
+            .inspect_class(Parameters(InspectClassParams {
+                class_name: "Stick".to_string(),
+            }))
+            .unwrap();
+        assert_eq!(detail.class_name, "Stick");
+        assert!(detail.produced_by.contains(&"CraftSticks".to_string()));
     }
 
     #[test]
     fn test_run_action_via_handler() {
         let service = make_service();
-        let result = service.run_action(Parameters(RunActionInput {
-            action_id: "FindLog".to_string(),
-            input_object_paths: vec![],
-        }));
-        let parsed: RunActionResult = serde_json::from_str(&result).unwrap();
-        assert!(parsed.success);
+        let Json(result) = service
+            .run_action(Parameters(RunActionInput {
+                action_id: "FindLog".to_string(),
+                input_object_paths: vec![],
+            }))
+            .unwrap();
+        assert!(result.success);
     }
 
     #[test]
@@ -250,32 +257,33 @@ mod tests {
             action_id: "FindLog".to_string(),
             input_object_paths: vec![],
         }));
-        assert!(result.starts_with("error:"));
-        assert!(result.contains("already in progress"));
+        let err = result.err().expect("should be an error");
+        assert!(err.contains("already in progress"));
     }
 
     #[test]
     fn test_check_feasibility_via_handler() {
         let service = make_service();
-        let result = service.check_feasibility(Parameters(CheckFeasibilityParams {
-            action_id: "CraftWoodPick".to_string(),
-        }));
-        let parsed: FeasibilityReport = serde_json::from_str(&result).unwrap();
-        assert!(parsed.feasible);
-        assert_eq!(parsed.available_inputs.len(), 2);
+        let Json(report) = service
+            .check_feasibility(Parameters(CheckFeasibilityParams {
+                action_id: "CraftWoodPick".to_string(),
+            }))
+            .unwrap();
+        assert!(report.feasible);
+        assert_eq!(report.available_inputs.len(), 2);
     }
 
     #[test]
     fn test_check_feasibility_infeasible() {
-        // Use an empty inventory so nothing is available
         let mock = MockCraftOps::new().with_inventory(vec![]);
         let service = CraftMcpService::new(Arc::new(mock));
-        let result = service.check_feasibility(Parameters(CheckFeasibilityParams {
-            action_id: "CraftWoodPick".to_string(),
-        }));
-        let parsed: FeasibilityReport = serde_json::from_str(&result).unwrap();
-        assert!(!parsed.feasible);
-        assert!(!parsed.missing_inputs.is_empty());
+        let Json(report) = service
+            .check_feasibility(Parameters(CheckFeasibilityParams {
+                action_id: "CraftWoodPick".to_string(),
+            }))
+            .unwrap();
+        assert!(!report.feasible);
+        assert!(!report.missing_inputs.is_empty());
     }
 
     #[tokio::test]

--- a/mcp/src/server.rs
+++ b/mcp/src/server.rs
@@ -1,0 +1,307 @@
+use std::sync::Arc;
+
+use rmcp::handler::server::router::tool::ToolRouter;
+use rmcp::handler::server::wrapper::Parameters;
+use rmcp::model::{ServerCapabilities, ServerInfo};
+use rmcp::{ServerHandler, tool, tool_handler, tool_router};
+use schemars::JsonSchema;
+use serde::Deserialize;
+
+use crate::ops::CraftOps;
+use crate::types::*;
+
+/// MCP server service that exposes zk-craft operations as tools.
+#[derive(Clone)]
+pub struct CraftMcpService<T: CraftOps> {
+    ops: Arc<T>,
+    tool_router: ToolRouter<Self>,
+}
+
+impl<T: CraftOps> CraftMcpService<T> {
+    pub fn new(ops: Arc<T>) -> Self {
+        Self {
+            ops,
+            tool_router: Self::tool_router(),
+        }
+    }
+}
+
+// -- Tool parameter types --
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct InspectObjectParams {
+    /// The object ID (hex hash) to inspect
+    pub object_id: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct InspectClassParams {
+    /// The class name to inspect, e.g. "WoodPick"
+    pub class_name: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct CheckFeasibilityParams {
+    /// The action ID to check, e.g. "CraftWoodPick"
+    pub action_id: String,
+}
+
+// -- Tool implementations --
+
+#[tool_router]
+impl<T: CraftOps> CraftMcpService<T> {
+    #[tool(
+        description = "List all objects in the inventory with their types, fields, and liveness status"
+    )]
+    fn list_inventory(&self) -> String {
+        match self.ops.list_inventory() {
+            Ok(items) => serde_json::to_string_pretty(&items)
+                .unwrap_or_else(|e| format!("serialization error: {e}")),
+            Err(e) => format!("error: {e}"),
+        }
+    }
+
+    #[tool(
+        description = "List all available crafting actions with input/output class requirements and CPU cost"
+    )]
+    fn list_actions(&self) -> String {
+        match self.ops.list_actions() {
+            Ok(actions) => serde_json::to_string_pretty(&actions)
+                .unwrap_or_else(|e| format!("serialization error: {e}")),
+            Err(e) => format!("error: {e}"),
+        }
+    }
+
+    #[tool(description = "Get the current global state root hash from the synchronizer")]
+    fn get_state_root(&self) -> String {
+        match self.ops.get_state_root() {
+            Ok(root) => serde_json::to_string_pretty(&StateRootResponse { state_root: root })
+                .unwrap_or_else(|e| format!("serialization error: {e}")),
+            Err(e) => format!("error: {e}"),
+        }
+    }
+
+    #[tool(
+        description = "Inspect an object by ID: full detail including fields, class, liveness, and predicate source"
+    )]
+    fn inspect_object(&self, Parameters(params): Parameters<InspectObjectParams>) -> String {
+        match self.ops.inspect_object(&params.object_id) {
+            Ok(detail) => serde_json::to_string_pretty(&detail)
+                .unwrap_or_else(|e| format!("serialization error: {e}")),
+            Err(e) => format!("error: {e}"),
+        }
+    }
+
+    #[tool(
+        description = "Inspect a class by name: predicate definition, and which actions produce/consume it"
+    )]
+    fn inspect_class(&self, Parameters(params): Parameters<InspectClassParams>) -> String {
+        match self.ops.inspect_class(&params.class_name) {
+            Ok(detail) => serde_json::to_string_pretty(&detail)
+                .unwrap_or_else(|e| format!("serialization error: {e}")),
+            Err(e) => format!("error: {e}"),
+        }
+    }
+
+    #[tool(
+        description = "Execute a crafting action. Blocks until proof generation completes. Returns error if another action is already in progress."
+    )]
+    fn run_action(&self, Parameters(params): Parameters<RunActionInput>) -> String {
+        match self.ops.run_action(params) {
+            Ok(result) => serde_json::to_string_pretty(&result)
+                .unwrap_or_else(|e| format!("serialization error: {e}")),
+            Err(e) => format!("error: {e}"),
+        }
+    }
+
+    #[tool(
+        description = "Check whether an action can be executed with the current inventory. Reports available and missing inputs."
+    )]
+    fn check_feasibility(&self, Parameters(params): Parameters<CheckFeasibilityParams>) -> String {
+        match self.ops.check_feasibility(&params.action_id) {
+            Ok(report) => serde_json::to_string_pretty(&report)
+                .unwrap_or_else(|e| format!("serialization error: {e}")),
+            Err(e) => format!("error: {e}"),
+        }
+    }
+}
+
+// -- ServerHandler --
+
+#[tool_handler]
+impl<T: CraftOps> ServerHandler for CraftMcpService<T> {
+    fn get_info(&self) -> ServerInfo {
+        ServerInfo::new(ServerCapabilities::builder().enable_tools().build()).with_instructions(
+            "ZK-Craft MCP server. Provides tools to inspect inventory, \
+             explore crafting actions, and execute ZK proof-based crafting operations.",
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mock::MockCraftOps;
+
+    fn make_service() -> CraftMcpService<MockCraftOps> {
+        CraftMcpService::new(Arc::new(MockCraftOps::new()))
+    }
+
+    #[test]
+    fn test_tool_router_lists_all_seven_tools() {
+        let service = make_service();
+        let tools: Vec<String> = service
+            .tool_router
+            .map
+            .keys()
+            .map(|k| k.to_string())
+            .collect();
+        assert!(tools.contains(&"list_inventory".to_string()));
+        assert!(tools.contains(&"list_actions".to_string()));
+        assert!(tools.contains(&"get_state_root".to_string()));
+        assert!(tools.contains(&"inspect_object".to_string()));
+        assert!(tools.contains(&"inspect_class".to_string()));
+        assert!(tools.contains(&"run_action".to_string()));
+        assert!(tools.contains(&"check_feasibility".to_string()));
+        assert_eq!(tools.len(), 7);
+    }
+
+    #[test]
+    fn test_get_info_has_tools_capability() {
+        let service = make_service();
+        let info = service.get_info();
+        assert!(info.capabilities.tools.is_some());
+        assert!(info.instructions.is_some());
+        assert!(info.instructions.unwrap().contains("ZK-Craft MCP server"));
+    }
+
+    #[test]
+    fn test_list_inventory_returns_valid_json() {
+        let service = make_service();
+        let result = service.list_inventory();
+        let parsed: Vec<InventoryObject> = serde_json::from_str(&result).unwrap();
+        assert!(!parsed.is_empty());
+        assert!(parsed.iter().any(|o| o.class_name == "Log"));
+    }
+
+    #[test]
+    fn test_list_actions_returns_valid_json() {
+        let service = make_service();
+        let result = service.list_actions();
+        let parsed: Vec<Action> = serde_json::from_str(&result).unwrap();
+        assert!(!parsed.is_empty());
+        assert!(parsed.iter().any(|a| a.id == "CraftWoodPick"));
+    }
+
+    #[test]
+    fn test_get_state_root_returns_valid_json() {
+        let service = make_service();
+        let result = service.get_state_root();
+        let parsed: StateRootResponse = serde_json::from_str(&result).unwrap();
+        assert!(parsed.state_root.starts_with("0x"));
+    }
+
+    #[test]
+    fn test_inspect_object_via_handler() {
+        let service = make_service();
+        let result = service.inspect_object(Parameters(InspectObjectParams {
+            object_id: "0xabc4444444444444".to_string(),
+        }));
+        let parsed: ObjectDetail = serde_json::from_str(&result).unwrap();
+        assert_eq!(parsed.class_name, "WoodPick");
+        assert!(parsed.predicate_source.contains("CraftWoodPick"));
+    }
+
+    #[test]
+    fn test_inspect_object_not_found_returns_error() {
+        let service = make_service();
+        let result = service.inspect_object(Parameters(InspectObjectParams {
+            object_id: "0xnonexistent".to_string(),
+        }));
+        assert!(result.starts_with("error:"));
+    }
+
+    #[test]
+    fn test_inspect_class_via_handler() {
+        let service = make_service();
+        let result = service.inspect_class(Parameters(InspectClassParams {
+            class_name: "Stick".to_string(),
+        }));
+        let parsed: ClassDetail = serde_json::from_str(&result).unwrap();
+        assert_eq!(parsed.class_name, "Stick");
+        assert!(parsed.produced_by.contains(&"CraftSticks".to_string()));
+    }
+
+    #[test]
+    fn test_run_action_via_handler() {
+        let service = make_service();
+        let result = service.run_action(Parameters(RunActionInput {
+            action_id: "FindLog".to_string(),
+            input_object_paths: vec![],
+        }));
+        let parsed: RunActionResult = serde_json::from_str(&result).unwrap();
+        assert!(parsed.success);
+    }
+
+    #[test]
+    fn test_run_action_in_progress_returns_error() {
+        let service = CraftMcpService::new(Arc::new(MockCraftOps::new().with_action_in_progress()));
+        let result = service.run_action(Parameters(RunActionInput {
+            action_id: "FindLog".to_string(),
+            input_object_paths: vec![],
+        }));
+        assert!(result.starts_with("error:"));
+        assert!(result.contains("already in progress"));
+    }
+
+    #[test]
+    fn test_check_feasibility_via_handler() {
+        let service = make_service();
+        let result = service.check_feasibility(Parameters(CheckFeasibilityParams {
+            action_id: "CraftWoodPick".to_string(),
+        }));
+        let parsed: FeasibilityReport = serde_json::from_str(&result).unwrap();
+        assert!(parsed.feasible);
+        assert_eq!(parsed.available_inputs.len(), 2);
+    }
+
+    #[test]
+    fn test_check_feasibility_infeasible() {
+        // Use an empty inventory so nothing is available
+        let mock = MockCraftOps::new().with_inventory(vec![]);
+        let service = CraftMcpService::new(Arc::new(mock));
+        let result = service.check_feasibility(Parameters(CheckFeasibilityParams {
+            action_id: "CraftWoodPick".to_string(),
+        }));
+        let parsed: FeasibilityReport = serde_json::from_str(&result).unwrap();
+        assert!(!parsed.feasible);
+        assert!(!parsed.missing_inputs.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_server_starts_and_binds() {
+        use crate::McpConfig;
+        use crate::McpServer;
+        use tokio_util::sync::CancellationToken;
+
+        let ct = CancellationToken::new();
+        let config = McpConfig {
+            cancellation_token: ct.clone(),
+        };
+        let server = McpServer::new(MockCraftOps::new(), config);
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let handle = tokio::spawn(async move {
+            server.serve(listener).await.unwrap();
+        });
+
+        // Verify the server is listening by connecting
+        let stream = tokio::net::TcpStream::connect(addr).await;
+        assert!(stream.is_ok());
+
+        ct.cancel();
+        // Give the server time to shut down
+        let _ = tokio::time::timeout(std::time::Duration::from_secs(2), handle).await;
+    }
+}

--- a/mcp/src/types.rs
+++ b/mcp/src/types.rs
@@ -19,6 +19,26 @@ pub struct ActionList {
     pub actions: Vec<Action>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ClassList {
+    /// All known object classes
+    pub classes: Vec<ClassSummary>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ClassSummary {
+    /// Class name, e.g. "WoodPick"
+    pub name: String,
+    /// Number of live objects of this class in inventory
+    pub live_count: usize,
+    /// Actions that produce objects of this class
+    pub produced_by: Vec<String>,
+    /// Actions that consume objects of this class
+    pub consumed_by: Vec<String>,
+}
+
 // -- Inventory / State --
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]

--- a/mcp/src/types.rs
+++ b/mcp/src/types.rs
@@ -3,6 +3,22 @@ use std::collections::HashMap;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
+// -- List response wrappers (MCP outputSchema requires root type "object") --
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct InventoryList {
+    /// All objects in the inventory
+    pub objects: Vec<InventoryObject>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ActionList {
+    /// All available crafting actions
+    pub actions: Vec<Action>,
+}
+
 // -- Inventory / State --
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]

--- a/mcp/src/types.rs
+++ b/mcp/src/types.rs
@@ -1,0 +1,121 @@
+use std::collections::HashMap;
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+// -- Inventory / State --
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct InventoryObject {
+    /// Unique object identifier (hex hash)
+    pub id: String,
+    /// Object class name, e.g. "WoodPick"
+    pub class_name: String,
+    /// The .dobj filename, e.g. "WoodPick.dobj"
+    pub file_name: String,
+    /// Whether this object is live (not nullified)
+    pub live: bool,
+    /// Application-layer fields as key-value pairs
+    pub fields: HashMap<String, serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct Action {
+    /// Action identifier, e.g. "CraftWoodPick"
+    pub id: String,
+    /// Human-readable description
+    pub description: String,
+    /// Class names required as inputs
+    pub input_classes: Vec<String>,
+    /// Class names produced as outputs
+    pub output_classes: Vec<String>,
+    /// Approximate CPU cost, e.g. "~10s"
+    pub cpu_cost: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct StateRootResponse {
+    /// The current global state root hash
+    pub state_root: String,
+}
+
+// -- Object inspection --
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ObjectDetail {
+    /// Unique object identifier (hex hash)
+    pub id: String,
+    /// Object class name
+    pub class_name: String,
+    /// Whether this object is live (not nullified)
+    pub live: bool,
+    /// Application-layer state fields
+    pub state: HashMap<String, serde_json::Value>,
+    /// Podlang predicate source for this object's class
+    pub predicate_source: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ClassDetail {
+    /// Class name
+    pub class_name: String,
+    /// Predicate definition in podlang source
+    pub predicate_source: String,
+    /// Actions that produce objects of this class
+    pub produced_by: Vec<String>,
+    /// Actions that consume objects of this class
+    pub consumed_by: Vec<String>,
+}
+
+// -- Actions --
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct RunActionInput {
+    /// The action to execute, e.g. "CraftWoodPick"
+    pub action_id: String,
+    /// Paths to .dobj files to use as inputs
+    pub input_object_paths: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct RunActionResult {
+    /// Whether the action succeeded
+    pub success: bool,
+    /// Human-readable status message
+    pub message: String,
+    /// Objects produced by the action
+    pub outputs: Vec<InventoryObject>,
+    /// Objects consumed (nullified) by the action
+    pub consumed: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct FeasibilityReport {
+    /// Whether the action can be executed with current inventory
+    pub feasible: bool,
+    /// The action being checked
+    pub action_id: String,
+    /// Objects available to satisfy input requirements
+    pub available_inputs: Vec<FeasibilityInput>,
+    /// Input classes that have no matching object in inventory
+    pub missing_inputs: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct FeasibilityInput {
+    /// Class name of the available object
+    pub class_name: String,
+    /// Object identifier
+    pub object_id: String,
+    /// The .dobj filename
+    pub file_name: String,
+}


### PR DESCRIPTION
Adds an MCP server to the main app, and a proxy MCP client which connects to the main app via HTTP. The README includes instructions for configuring Claude to use the MCP server in conversations. Claude should be capable of figuring out what is going on, and performing crafting operations when connected to the app.

When compiling/restarting, sometimes it is necessary to restart Claude or to inspect Claude's logs in Settings -> Developer.