### PR TITLE
refactor for the new pod2 value api for persistent containers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -944,13 +944,14 @@ checksum = "170433209e817da6aae2c51aa0dd443009a613425dd041ebfb2492d1c4c11a25"
 name = "app-gui"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "base64 0.22.1",
  "common",
  "craft_sdk",
  "hex",
  "lt_eq_u256_pod",
  "notify",
- "pod2 0.1.0 (git+https://github.com/0xPARC/pod2?rev=9993799c08e6e95b11eb016763fcc13f5030293e)",
+ "pod2 0.1.0 (git+https://github.com/0xPARC/pod2?rev=f49fdd816bc73240cdca6610f9cf6924fc109ead)",
  "pod2utils",
  "relayer",
  "reqwest 0.12.28",
@@ -962,6 +963,7 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-opener",
+ "thiserror 2.0.18",
  "txlib",
  "vdfpod",
 ]
@@ -2011,7 +2013,7 @@ dependencies = [
  "itertools 0.14.0",
  "log",
  "plonky2",
- "pod2 0.1.0 (git+https://github.com/0xPARC/pod2?rev=9993799c08e6e95b11eb016763fcc13f5030293e)",
+ "pod2 0.1.0 (git+https://github.com/0xPARC/pod2?rev=f49fdd816bc73240cdca6610f9cf6924fc109ead)",
  "pod2_onchain",
  "serde",
  "serde_json",
@@ -2188,7 +2190,7 @@ dependencies = [
  "log",
  "lt_eq_u256_pod",
  "plonky2",
- "pod2 0.1.0 (git+https://github.com/0xPARC/pod2?rev=9993799c08e6e95b11eb016763fcc13f5030293e)",
+ "pod2 0.1.0 (git+https://github.com/0xPARC/pod2?rev=f49fdd816bc73240cdca6610f9cf6924fc109ead)",
  "pod2utils",
  "rand 0.9.2",
  "serde",
@@ -4612,7 +4614,7 @@ dependencies = [
  "itertools 0.14.0",
  "log",
  "plonky2",
- "pod2 0.1.0 (git+https://github.com/0xPARC/pod2?rev=9993799c08e6e95b11eb016763fcc13f5030293e)",
+ "pod2 0.1.0 (git+https://github.com/0xPARC/pod2?rev=f49fdd816bc73240cdca6610f9cf6924fc109ead)",
  "pod2utils",
  "serde",
  "serde_json",
@@ -5929,7 +5931,7 @@ dependencies = [
 [[package]]
 name = "pod2"
 version = "0.1.0"
-source = "git+https://github.com/0xPARC/pod2?rev=9993799c08e6e95b11eb016763fcc13f5030293e#9993799c08e6e95b11eb016763fcc13f5030293e"
+source = "git+https://github.com/0xPARC/pod2?rev=f49fdd816bc73240cdca6610f9cf6924fc109ead#f49fdd816bc73240cdca6610f9cf6924fc109ead"
 dependencies = [
  "annotate-snippets",
  "anyhow",
@@ -6030,7 +6032,7 @@ dependencies = [
  "itertools 0.14.0",
  "log",
  "plonky2",
- "pod2 0.1.0 (git+https://github.com/0xPARC/pod2?rev=9993799c08e6e95b11eb016763fcc13f5030293e)",
+ "pod2 0.1.0 (git+https://github.com/0xPARC/pod2?rev=f49fdd816bc73240cdca6610f9cf6924fc109ead)",
  "rand 0.9.2",
  "serde",
  "serde_json",
@@ -6591,7 +6593,7 @@ dependencies = [
  "common",
  "dotenvy",
  "hex",
- "pod2 0.1.0 (git+https://github.com/0xPARC/pod2?rev=9993799c08e6e95b11eb016763fcc13f5030293e)",
+ "pod2 0.1.0 (git+https://github.com/0xPARC/pod2?rev=f49fdd816bc73240cdca6610f9cf6924fc109ead)",
  "serde",
  "serde_json",
  "sqlx",
@@ -7947,7 +7949,7 @@ dependencies = [
  "hex",
  "minicbor-serde 0.6.2",
  "plonky2",
- "pod2 0.1.0 (git+https://github.com/0xPARC/pod2?rev=9993799c08e6e95b11eb016763fcc13f5030293e)",
+ "pod2 0.1.0 (git+https://github.com/0xPARC/pod2?rev=f49fdd816bc73240cdca6610f9cf6924fc109ead)",
  "pod2utils",
  "rand 0.8.5",
  "reqwest 0.12.28",
@@ -8474,7 +8476,7 @@ dependencies = [
  "hex",
  "log",
  "plonky2",
- "pod2 0.1.0 (git+https://github.com/0xPARC/pod2?rev=9993799c08e6e95b11eb016763fcc13f5030293e)",
+ "pod2 0.1.0 (git+https://github.com/0xPARC/pod2?rev=f49fdd816bc73240cdca6610f9cf6924fc109ead)",
  "pod2utils",
  "rand 0.9.2",
  "serde",
@@ -8883,7 +8885,7 @@ dependencies = [
  "hex",
  "log",
  "plonky2",
- "pod2 0.1.0 (git+https://github.com/0xPARC/pod2?rev=9993799c08e6e95b11eb016763fcc13f5030293e)",
+ "pod2 0.1.0 (git+https://github.com/0xPARC/pod2?rev=f49fdd816bc73240cdca6610f9cf6924fc109ead)",
  "pod2utils",
  "rand 0.9.2",
  "serde",
@@ -9143,7 +9145,7 @@ dependencies = [
  "itertools 0.14.0",
  "log",
  "plonky2",
- "pod2 0.1.0 (git+https://github.com/0xPARC/pod2?rev=9993799c08e6e95b11eb016763fcc13f5030293e)",
+ "pod2 0.1.0 (git+https://github.com/0xPARC/pod2?rev=f49fdd816bc73240cdca6610f9cf6924fc109ead)",
  "pod2utils",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,10 @@ members = [
 resolver = "2"
 
 [workspace.dependencies]
-# Branch `tmp/more-wildcards`
-pod2 = { git = "https://github.com/0xPARC/pod2", rev = "9993799c08e6e95b11eb016763fcc13f5030293e", default-features = false, features = [
+# Branch `next/2026-03-18`: Includes:
+# - bump params wildcards to 9
+# - Support persistent storage in Containers https://github.com/0xPARC/pod2/pull/493
+pod2 = { git = "https://github.com/0xPARC/pod2", rev = "f49fdd816bc73240cdca6610f9cf6924fc109ead", default-features = false, features = [
     "backend_plonky2",
     "disk_cache",
     "zk",
@@ -53,3 +55,4 @@ tracing-subscriber = { version = "0.3", features = [
 tracing-log = "0.1.1"
 time = { version = "0.3.44", features = ["formatting", "local-offset"] }
 rand = { version = "0.9.2", features = ["std_rng"] }
+thiserror = "2.0.18"

--- a/app-gui/src-tauri/Cargo.toml
+++ b/app-gui/src-tauri/Cargo.toml
@@ -38,3 +38,5 @@ base64 = "0.22"
 pod2 = { workspace = true }
 notify = "6"
 rfd = "0.14"
+anyhow = { workspace = true }
+thiserror = { workspace = true }

--- a/app-gui/src-tauri/src/error.rs
+++ b/app-gui/src-tauri/src/error.rs
@@ -1,0 +1,16 @@
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum CommandError {
+    #[error(transparent)]
+    Anyhow(#[from] anyhow::Error),
+}
+
+impl serde::Serialize for CommandError {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::ser::Serializer,
+    {
+        serializer.serialize_str(self.to_string().as_ref())
+    }
+}

--- a/app-gui/src-tauri/src/lib.rs
+++ b/app-gui/src-tauri/src/lib.rs
@@ -1,4 +1,5 @@
 mod cpu;
+mod error;
 mod objects;
 mod sdk;
 mod settings;

--- a/app-gui/src-tauri/src/objects/api.rs
+++ b/app-gui/src-tauri/src/objects/api.rs
@@ -1,44 +1,46 @@
 use std::{fs, path::PathBuf};
 
+use crate::error::CommandError;
 use crate::objects::objects_dir;
 use crate::objects::ObjectRecord;
 use crate::sdk::parse_object_file_from_path;
+use anyhow::{anyhow, Result};
 use rfd::FileDialog;
 use tauri_plugin_opener::OpenerExt;
 
 #[tauri::command]
-pub fn get_objects_dir(app: tauri::AppHandle) -> Result<String, String> {
+pub fn get_objects_dir(app: tauri::AppHandle) -> Result<String, CommandError> {
     let path = objects_dir(&app)?;
     Ok(path.to_string_lossy().to_string())
 }
 
 #[tauri::command]
-pub fn open_objects_dir(app: tauri::AppHandle) -> Result<String, String> {
+pub fn open_objects_dir(app: tauri::AppHandle) -> Result<String, CommandError> {
     let path: PathBuf = objects_dir(&app)?;
     fs::create_dir_all(&path)
-        .map_err(|err| format!("failed to create objects directory: {err}"))?;
+        .map_err(|err| anyhow!("failed to create objects directory: {err}"))?;
     app.opener()
         .open_path(path.to_string_lossy().to_string(), None::<&str>)
-        .map_err(|err| format!("failed to open objects directory: {err}"))?;
+        .map_err(|err| anyhow!("failed to open objects directory: {err}"))?;
     Ok(path.to_string_lossy().to_string())
 }
 
 #[tauri::command]
-pub fn pick_dobj_file_path() -> Result<String, String> {
+pub fn pick_dobj_file_path() -> Result<String, CommandError> {
     let Some(path) = FileDialog::new()
         .add_filter("Digital Object (.dobj)", &["dobj"])
         .pick_file()
     else {
-        return Err("No file selected".to_string());
+        return Err(anyhow!("No file selected").into());
     };
     Ok(path.to_string_lossy().to_string())
 }
 
 #[tauri::command]
-pub fn read_dobj_file(path: String) -> Result<ObjectRecord, String> {
+pub fn read_dobj_file(path: String) -> Result<ObjectRecord, CommandError> {
     let path = PathBuf::from(path.trim());
     if !path.exists() {
-        return Err(format!("selected file does not exist: {}", path.display()));
+        return Err(anyhow!("selected file does not exist: {}", path.display()).into());
     }
-    parse_object_file_from_path(&path)
+    Ok(parse_object_file_from_path(&path)?)
 }

--- a/app-gui/src-tauri/src/objects/paths.rs
+++ b/app-gui/src-tauri/src/objects/paths.rs
@@ -1,14 +1,15 @@
 use std::path::{Path, PathBuf};
 
+use anyhow::{anyhow, Result};
 use tauri::{AppHandle, Manager};
 
-fn home_dir(app: &AppHandle) -> Result<PathBuf, String> {
+fn home_dir(app: &AppHandle) -> Result<PathBuf> {
     app.path()
         .home_dir()
-        .map_err(|err| format!("failed to resolve home directory: {err}"))
+        .map_err(|err| anyhow!("failed to resolve home directory: {err}"))
 }
 
-pub(crate) fn objects_dir(app: &AppHandle) -> Result<PathBuf, String> {
+pub(crate) fn objects_dir(app: &AppHandle) -> Result<PathBuf> {
     Ok(home_dir(app)?.join(".objects"))
 }
 

--- a/app-gui/src-tauri/src/objects/watcher.rs
+++ b/app-gui/src-tauri/src/objects/watcher.rs
@@ -1,6 +1,7 @@
 use std::{fs, path::Path, sync::mpsc, thread};
 
 use crate::objects::objects_dir;
+use anyhow::{anyhow, Result};
 use notify::{Config, Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
 use tauri::{AppHandle, Emitter};
 
@@ -24,10 +25,10 @@ fn is_objects_change(event: &Event, watch_dir: &Path) -> bool {
     event.paths.iter().any(|path| path.starts_with(watch_dir))
 }
 
-pub fn start_objects_watcher(app: AppHandle) -> Result<(), String> {
+pub fn start_objects_watcher(app: AppHandle) -> Result<()> {
     let watch_dir = objects_dir(&app)?;
     fs::create_dir_all(&watch_dir)
-        .map_err(|err| format!("failed to create objects directory for watcher: {err}"))?;
+        .map_err(|err| anyhow!("failed to create objects directory for watcher: {err}"))?;
 
     thread::spawn(move || {
         let app_handle = app.clone();

--- a/app-gui/src-tauri/src/sdk/bootstrap.rs
+++ b/app-gui/src-tauri/src/sdk/bootstrap.rs
@@ -1,5 +1,7 @@
 use super::object_store::{ensure_objects_dirs, load_object_files, write_object_file};
+use crate::error::CommandError;
 use crate::objects::objects_dir;
+use anyhow::Result;
 use craft_sdk::Helper;
 use pod2::middleware::Hash;
 use serde::Serialize;
@@ -140,7 +142,9 @@ fn reconcile_objects(
 }
 
 #[tauri::command]
-pub async fn load_gui_inventory(app: tauri::AppHandle) -> Result<LoadGuiInventoryResult, String> {
+pub async fn load_gui_inventory(
+    app: tauri::AppHandle,
+) -> Result<LoadGuiInventoryResult, CommandError> {
     let objects_dir = objects_dir(&app)?;
     ensure_objects_dirs(&objects_dir)?;
     let mut objects = load_object_files(&objects_dir)?;
@@ -176,7 +180,7 @@ pub async fn load_gui_inventory(app: tauri::AppHandle) -> Result<LoadGuiInventor
 }
 
 #[tauri::command]
-pub async fn get_global_state_root(app: tauri::AppHandle) -> Result<String, String> {
+pub async fn get_global_state_root(app: tauri::AppHandle) -> Result<String, CommandError> {
     let app_settings = get_app_settings(app)?;
     let sync_state = fetch_synchronizer_state(&app_settings.synchronizer_api_url)?;
     Ok(encode_hash_hex(&sync_state.current_gsr))

--- a/app-gui/src-tauri/src/sdk/engine.rs
+++ b/app-gui/src-tauri/src/sdk/engine.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use anyhow::{anyhow, Result};
 use common::{
     payload::{Payload, PayloadProof},
     shrink::{shrink_compress_pod, ShrunkMainPodSetup},
@@ -14,7 +15,7 @@ pub(super) fn execute_action(
     action_id: String,
     state_root: StateRoot,
     inputs: Vec<SpendableObject>,
-) -> Result<SpendableObjects, String> {
+) -> Result<SpendableObjects> {
     let helper = Helper::new(spec::dependencies(), spec::actions());
     // Relayed payloads are recursively verified/compressed, which is incompatible with MockMainPod.
     let builder = helper.builder(false, Arc::new(state_root));
@@ -24,22 +25,21 @@ pub(super) fn execute_action(
 pub(super) fn build_relayer_payload(
     old_state_root_hash: &Hash,
     action_output: &SpendableObjects,
-) -> Result<Vec<u8>, String> {
+) -> Result<Vec<u8>> {
     let params = Params::default();
     let shrunk_main_pod = ShrunkMainPodSetup::new(&params)
         .build()
-        .map_err(|err| format!("failed to build shrunk proof circuit: {err}"))?;
+        .map_err(|err| anyhow!("failed to build shrunk proof circuit: {err}"))?;
     let compressed = shrink_compress_pod(&shrunk_main_pod, action_output.tx_pod.clone())
-        .map_err(|err| format!("failed to shrink/compress tx proof: {err}"))?;
+        .map_err(|err| anyhow!("failed to shrink/compress tx proof: {err}"))?;
 
     let tx_final = action_output.tx.dict().commitment();
     let nullifiers = action_output
         .tx
         .nullifiers
-        .set()
         .iter()
-        .map(|entry| Hash(entry.raw().0))
-        .collect::<Vec<_>>();
+        .map(|entry| Ok(Hash(entry?.raw().0)))
+        .collect::<Result<Vec<_>>>()?;
     let payload = Payload {
         proof: PayloadProof::Plonky2(Box::new(compressed)),
         tx_final,

--- a/app-gui/src-tauri/src/sdk/object_store.rs
+++ b/app-gui/src-tauri/src/sdk/object_store.rs
@@ -1,3 +1,4 @@
+use anyhow::{anyhow, Result};
 use std::{collections::HashMap, fs, path::Path};
 
 use crate::objects::{nullified_objects_dir, ObjectRecord};
@@ -7,38 +8,38 @@ pub(super) struct ObjectFileEntry {
     pub(super) record: ObjectRecord,
 }
 
-pub(super) fn ensure_objects_dirs(objects_dir: &Path) -> Result<(), String> {
+pub(super) fn ensure_objects_dirs(objects_dir: &Path) -> Result<()> {
     fs::create_dir_all(objects_dir)
-        .map_err(|err| format!("failed to create objects directory: {err}"))?;
+        .map_err(|err| anyhow!("failed to create objects directory: {err}"))?;
     fs::create_dir_all(nullified_objects_dir(objects_dir))
-        .map_err(|err| format!("failed to create nullified directory: {err}"))?;
+        .map_err(|err| anyhow!("failed to create nullified directory: {err}"))?;
     Ok(())
 }
 
-fn parse_object_file(contents: &str, file_name: &str) -> Result<ObjectRecord, String> {
+fn parse_object_file(contents: &str, file_name: &str) -> Result<ObjectRecord> {
     serde_json::from_str::<ObjectRecord>(contents)
-        .map_err(|err| format!("failed to parse {file_name} as object file: {err}"))
+        .map_err(|err| anyhow!("failed to parse {file_name} as object file: {err}"))
 }
 
 pub(super) fn write_object_file(
     record: &ObjectRecord,
     file_name: &str,
     objects_dir: &Path,
-) -> Result<(), String> {
+) -> Result<()> {
     ensure_objects_dirs(objects_dir)?;
     let nullified_dir = nullified_objects_dir(objects_dir);
 
     let persisted = serde_json::to_value(record)
-        .map_err(|err| format!("failed to serialize object file {file_name}: {err}"))?;
+        .map_err(|err| anyhow!("failed to serialize object file {file_name}: {err}"))?;
     let serialized = serde_json::to_string(&persisted)
-        .map_err(|err| format!("failed to serialize object file {file_name}: {err}"))?;
+        .map_err(|err| anyhow!("failed to serialize object file {file_name}: {err}"))?;
     let target_path = if record.is_nullified() {
         nullified_dir.join(file_name)
     } else {
         objects_dir.join(file_name)
     };
     fs::write(&target_path, serialized)
-        .map_err(|err| format!("failed to write object file {file_name}: {err}"))?;
+        .map_err(|err| anyhow!("failed to write object file {file_name}: {err}"))?;
 
     let stale_path = if record.is_nullified() {
         objects_dir.join(file_name)
@@ -65,14 +66,14 @@ fn load_object_files_from_dir(
     objects: &mut HashMap<String, ObjectRecord>,
     source_dir: &Path,
     in_nullified_dir: bool,
-) -> Result<(), String> {
+) -> Result<()> {
     if !source_dir.exists() {
         return Ok(());
     }
     for entry in fs::read_dir(source_dir)
-        .map_err(|err| format!("failed to read objects directory: {err}"))?
+        .map_err(|err| anyhow!("failed to read objects directory: {err}"))?
     {
-        let entry = entry.map_err(|err| format!("failed to read objects entry: {err}"))?;
+        let entry = entry.map_err(|err| anyhow!("failed to read objects entry: {err}"))?;
         let path = entry.path();
         if !path.is_file() {
             continue;
@@ -97,7 +98,7 @@ fn load_object_files_from_dir(
             Ok(record) => {
                 let is_nullified = record.is_nullified();
                 if is_nullified != in_nullified_dir {
-                    return Err(format!(
+                    return Err(anyhow!(
                         "invalid object placement for {}: expected {} in {}, found {}",
                         file_name,
                         if in_nullified_dir {
@@ -111,7 +112,7 @@ fn load_object_files_from_dir(
                 }
 
                 if objects.contains_key(file_name) {
-                    return Err(format!(
+                    return Err(anyhow!(
                         "duplicate object file name detected across object directories: {}",
                         file_name
                     ));
@@ -126,7 +127,7 @@ fn load_object_files_from_dir(
     Ok(())
 }
 
-pub(super) fn load_object_files(objects_dir: &Path) -> Result<Vec<ObjectFileEntry>, String> {
+pub(super) fn load_object_files(objects_dir: &Path) -> Result<Vec<ObjectFileEntry>> {
     let mut records_by_file = HashMap::<String, ObjectRecord>::new();
     load_object_files_from_dir(&mut records_by_file, objects_dir, false)?;
     load_object_files_from_dir(
@@ -143,12 +144,12 @@ pub(super) fn load_object_files(objects_dir: &Path) -> Result<Vec<ObjectFileEntr
     Ok(objects)
 }
 
-pub(crate) fn parse_object_file_from_path(path: &Path) -> Result<ObjectRecord, String> {
+pub(crate) fn parse_object_file_from_path(path: &Path) -> Result<ObjectRecord> {
     let file_name = path
         .file_name()
         .and_then(|name| name.to_str())
-        .ok_or_else(|| format!("invalid input path (missing file name): {}", path.display()))?;
+        .ok_or_else(|| anyhow!("invalid input path (missing file name): {}", path.display()))?;
     let contents = fs::read_to_string(path)
-        .map_err(|err| format!("failed to read input file {}: {err}", path.display()))?;
+        .map_err(|err| anyhow!("failed to read input file {}: {err}", path.display()))?;
     parse_object_file(&contents, file_name)
 }

--- a/app-gui/src-tauri/src/sdk/progress.rs
+++ b/app-gui/src-tauri/src/sdk/progress.rs
@@ -2,6 +2,7 @@ use serde::Serialize;
 use tauri::Emitter;
 
 use super::run_action::RunSdkActionResult;
+use anyhow::{anyhow, Result};
 
 #[derive(Debug, Serialize, Clone, Copy, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
@@ -29,16 +30,16 @@ pub(super) struct RunSdkActionProgress {
     pub(super) output_files: Option<Vec<String>>,
 }
 
-fn emit_progress(app: &tauri::AppHandle, payload: &RunSdkActionProgress) -> Result<(), String> {
+fn emit_progress(app: &tauri::AppHandle, payload: &RunSdkActionProgress) -> Result<()> {
     app.emit("run-sdk-action-progress", payload)
-        .map_err(|err| format!("failed to emit run progress: {err}"))
+        .map_err(|err| anyhow!("failed to emit run progress: {err}"))
 }
 
 pub(super) fn emit_generate_proof_step(
     app: &tauri::AppHandle,
     run_id: &str,
     step_label: &str,
-) -> Result<(), String> {
+) -> Result<()> {
     let payload = RunSdkActionProgress {
         run_id: run_id.to_string(),
         phase: ProofPhase::GenerateProof,
@@ -51,7 +52,7 @@ pub(super) fn emit_generate_proof_step(
     emit_progress(app, &payload)
 }
 
-pub(super) fn emit_generate_proof_done(app: &tauri::AppHandle, run_id: &str) -> Result<(), String> {
+pub(super) fn emit_generate_proof_done(app: &tauri::AppHandle, run_id: &str) -> Result<()> {
     let payload = RunSdkActionProgress {
         run_id: run_id.to_string(),
         phase: ProofPhase::GenerateProof,
@@ -69,7 +70,7 @@ pub(super) fn emit_commit_step(
     run_id: &str,
     step_label: &str,
     old_root: &str,
-) -> Result<(), String> {
+) -> Result<()> {
     let payload = RunSdkActionProgress {
         run_id: run_id.to_string(),
         phase: ProofPhase::Commit,
@@ -86,7 +87,7 @@ pub(super) fn emit_commit_done(
     app: &tauri::AppHandle,
     run_id: &str,
     result: &RunSdkActionResult,
-) -> Result<(), String> {
+) -> Result<()> {
     let payload = RunSdkActionProgress {
         run_id: run_id.to_string(),
         phase: ProofPhase::Commit,

--- a/app-gui/src-tauri/src/sdk/relayer_client.rs
+++ b/app-gui/src-tauri/src/sdk/relayer_client.rs
@@ -1,5 +1,6 @@
 use std::time::{Duration, Instant};
 
+use anyhow::{anyhow, Result};
 use base64::{engine::general_purpose::STANDARD, Engine};
 use common::blob::MAX_SIMPLE_BLOB_PAYLOAD_BYTES;
 pub(super) use relayer::api_types::JobStatus;
@@ -12,9 +13,9 @@ pub(super) fn submit_proof_to_relayer(
     relayer_api_url: &str,
     payload_bytes: &[u8],
     client_ref: Option<String>,
-) -> Result<SubmitProofResponse, String> {
+) -> Result<SubmitProofResponse> {
     if payload_bytes.len() > MAX_SIMPLE_BLOB_PAYLOAD_BYTES {
-        return Err(format!(
+        return Err(anyhow!(
             "payload exceeds single-blob limit: {} > {}",
             payload_bytes.len(),
             MAX_SIMPLE_BLOB_PAYLOAD_BYTES
@@ -32,12 +33,12 @@ pub(super) fn submit_proof_to_relayer(
         .post(&endpoint)
         .json(&request)
         .send()
-        .map_err(|err| format!("failed to submit proof to relayer at {endpoint}: {err}"))?;
+        .map_err(|err| anyhow!("failed to submit proof to relayer at {endpoint}: {err}"))?;
 
     let status = response.status();
     let body = response.text().unwrap_or_default();
     if !status.is_success() {
-        return Err(format!(
+        return Err(anyhow!(
             "relayer submit failed with {} {}: {}",
             status.as_u16(),
             status,
@@ -46,13 +47,10 @@ pub(super) fn submit_proof_to_relayer(
     }
 
     serde_json::from_str::<SubmitProofResponse>(&body)
-        .map_err(|err| format!("failed to decode relayer submit response: {err}; body={body}"))
+        .map_err(|err| anyhow!("failed to decode relayer submit response: {err}; body={body}"))
 }
 
-fn fetch_relayer_job_status(
-    relayer_api_url: &str,
-    job_id: &str,
-) -> Result<JobStatusResponse, String> {
+fn fetch_relayer_job_status(relayer_api_url: &str, job_id: &str) -> Result<JobStatusResponse> {
     let endpoint = format!(
         "{}/api/v1/proofs/{job_id}",
         relayer_api_url.trim_end_matches('/')
@@ -61,12 +59,12 @@ fn fetch_relayer_job_status(
     let response = client
         .get(&endpoint)
         .send()
-        .map_err(|err| format!("failed to query relayer job at {endpoint}: {err}"))?;
+        .map_err(|err| anyhow!("failed to query relayer job at {endpoint}: {err}"))?;
 
     let status = response.status();
     let body = response.text().unwrap_or_default();
     if !status.is_success() {
-        return Err(format!(
+        return Err(anyhow!(
             "relayer status failed with {} {}: {}",
             status.as_u16(),
             status,
@@ -75,7 +73,7 @@ fn fetch_relayer_job_status(
     }
 
     serde_json::from_str::<JobStatusResponse>(&body)
-        .map_err(|err| format!("failed to decode relayer status response: {err}; body={body}"))
+        .map_err(|err| anyhow!("failed to decode relayer status response: {err}; body={body}"))
 }
 
 pub(super) fn wait_for_relayer_confirmation(
@@ -83,7 +81,7 @@ pub(super) fn wait_for_relayer_confirmation(
     job_id: &str,
     timeout_secs: u64,
     poll_interval_ms: u64,
-) -> Result<JobStatusResponse, String> {
+) -> Result<JobStatusResponse> {
     let timeout = Duration::from_secs(timeout_secs);
     let poll_interval = Duration::from_millis(poll_interval_ms);
     let start = Instant::now();
@@ -93,7 +91,7 @@ pub(super) fn wait_for_relayer_confirmation(
         match status.status {
             JobStatus::Confirmed => return Ok(status),
             JobStatus::Failed => {
-                return Err(format!(
+                return Err(anyhow!(
                     "relayer job {} failed: {}",
                     status.job_id,
                     status
@@ -106,9 +104,10 @@ pub(super) fn wait_for_relayer_confirmation(
         }
 
         if start.elapsed() >= timeout {
-            return Err(format!(
+            return Err(anyhow!(
                 "timed out waiting for relayer job {} after {}s",
-                job_id, timeout_secs
+                job_id,
+                timeout_secs
             ));
         }
         std::thread::sleep(poll_interval);

--- a/app-gui/src-tauri/src/sdk/run_action.rs
+++ b/app-gui/src-tauri/src/sdk/run_action.rs
@@ -3,6 +3,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
+use anyhow::{anyhow, Result};
 use craft_sdk::SpendableObjects;
 use pod2::middleware::Hash;
 use serde::{Deserialize, Serialize};
@@ -26,8 +27,8 @@ use super::{
     },
 };
 use crate::{
-    objects::objects_dir,
-    objects::ObjectRecord,
+    error::CommandError,
+    objects::{objects_dir, ObjectRecord},
     settings::get_app_settings,
     spec::{self, action_descriptors_by_name},
 };
@@ -55,26 +56,26 @@ struct ResolvedInput {
     record: ObjectRecord,
 }
 
-fn file_name_from_path(path: &Path) -> Result<String, String> {
+fn file_name_from_path(path: &Path) -> Result<String> {
     path.file_name()
         .and_then(|name| name.to_str())
         .map(str::to_string)
-        .ok_or_else(|| format!("invalid input path (missing file name): {}", path.display()))
+        .ok_or_else(|| anyhow!("invalid input path (missing file name): {}", path.display()))
 }
 
 fn validate_run_request(
     input: &RunSdkActionInput,
     descriptor: &spec::ActionDescriptor,
-) -> Result<(), String> {
+) -> Result<()> {
     if descriptor.hidden {
-        return Err(format!(
+        return Err(anyhow!(
             "action is internal and cannot be run directly: {}",
             input.action_id
         ));
     }
 
     if input.input_object_paths.len() != descriptor.input_classes.len() {
-        return Err(format!(
+        return Err(anyhow!(
             "{} expects {} inputs, got {}",
             input.action_id,
             descriptor.input_classes.len(),
@@ -86,10 +87,12 @@ fn validate_run_request(
     for object_path_raw in &input.input_object_paths {
         let object_path = object_path_raw.trim();
         if object_path.is_empty() {
-            return Err("each inputObjectPaths entry must be a non-empty path".to_string());
+            return Err(anyhow!(
+                "each inputObjectPaths entry must be a non-empty path"
+            ));
         }
         if !seen_paths.insert(object_path.to_string()) {
-            return Err(format!(
+            return Err(anyhow!(
                 "duplicate input object path is not allowed: {object_path}"
             ));
         }
@@ -101,26 +104,28 @@ fn validate_run_request(
 fn resolve_inputs(
     input: &RunSdkActionInput,
     descriptor: &spec::ActionDescriptor,
-) -> Result<Vec<ResolvedInput>, String> {
+) -> Result<Vec<ResolvedInput>> {
     let mut resolved_inputs = Vec::new();
 
     for (slot, object_path_raw) in input.input_object_paths.iter().enumerate() {
         let expected_class = descriptor.input_classes[slot].as_str();
         let object_path = object_path_raw.trim();
         if object_path.is_empty() {
-            return Err(format!("missing objectPath for input slot {}", slot + 1));
+            return Err(anyhow!("missing objectPath for input slot {}", slot + 1));
         }
 
         let path_ref = Path::new(object_path);
         let record = parse_object_file_from_path(path_ref)?;
         let file_name = file_name_from_path(path_ref)?;
         if record.is_nullified() {
-            return Err(format!("input object is not live: {}", record.id));
+            return Err(anyhow!("input object is not live: {}", record.id));
         }
         if record.class_name != expected_class {
-            return Err(format!(
+            return Err(anyhow!(
                 "input class mismatch for {}: expected {}, got {}",
-                record.id, expected_class, record.class_name
+                record.id,
+                expected_class,
+                record.class_name
             ));
         }
         resolved_inputs.push(ResolvedInput { file_name, record });
@@ -129,7 +134,7 @@ fn resolve_inputs(
     Ok(resolved_inputs)
 }
 
-fn verify_inputs_grounded(sync_api_url: &str, inputs: &[ResolvedInput]) -> Result<(), String> {
+fn verify_inputs_grounded(sync_api_url: &str, inputs: &[ResolvedInput]) -> Result<()> {
     let input_sources = inputs
         .iter()
         .map(|input| {
@@ -146,7 +151,7 @@ fn verify_inputs_grounded(sync_api_url: &str, inputs: &[ResolvedInput]) -> Resul
 
     for (file_name, source_tx_hash) in input_sources {
         if !grounded_txs.contains(&source_tx_hash) {
-            return Err(format!(
+            return Err(anyhow!(
                 "input not yet synchronized; wait and retry: {} -> {}",
                 file_name,
                 encode_hash_hex(&source_tx_hash)
@@ -170,7 +175,7 @@ struct RelayerSubmitRequest<'a> {
 async fn submit_and_confirm_relayer(
     app: &tauri::AppHandle,
     request: RelayerSubmitRequest<'_>,
-) -> Result<(), String> {
+) -> Result<()> {
     let RelayerSubmitRequest {
         run_id,
         old_root,
@@ -197,11 +202,11 @@ async fn submit_and_confirm_relayer(
     let submit_response = match submit_job {
         Ok(Ok(response)) => response,
         Ok(Err(err)) => return Err(err),
-        Err(err) => return Err(format!("failed while submitting proof to relayer: {err}")),
+        Err(err) => return Err(anyhow!("failed while submitting proof to relayer: {err}")),
     };
 
     if submit_response.status == JobStatus::Failed {
-        return Err(format!(
+        return Err(anyhow!(
             "relayer rejected job {} immediately",
             submit_response.job_id
         ));
@@ -229,7 +234,7 @@ async fn submit_and_confirm_relayer(
     match wait_job {
         Ok(Ok(status)) => status,
         Ok(Err(err)) => return Err(err),
-        Err(err) => return Err(format!("failed while polling relayer job status: {err}")),
+        Err(err) => return Err(anyhow!("failed while polling relayer job status: {err}")),
     };
 
     Ok(())
@@ -240,7 +245,7 @@ fn wait_for_synchronizer_commit(
     expected_tx_final: Hash,
     timeout_secs: u64,
     poll_interval_ms: u64,
-) -> Result<SynchronizerState, String> {
+) -> Result<SynchronizerState> {
     wait_for_synchronizer_tx(
         sync_api_url,
         expected_tx_final,
@@ -248,7 +253,7 @@ fn wait_for_synchronizer_commit(
         poll_interval_ms,
     )
     .map_err(|err| {
-        format!("failed to observe relayed tx in synchronizer after relay confirmation: {err}")
+        anyhow!("failed to observe relayed tx in synchronizer after relay confirmation: {err}")
     })
 }
 
@@ -263,13 +268,13 @@ fn save_results(
     action_id: &str,
     resolved_inputs: &[ResolvedInput],
     spendable_outputs: &SpendableObjects,
-) -> Result<SavedFiles, String> {
+) -> Result<SavedFiles> {
     let mut nullified_files = Vec::new();
     for input in resolved_inputs {
         let input_record = &input.record;
         let spendable = input_record.spendable();
         let nullifier_hash = object_nullifier_hash(&spendable.obj).map_err(|err| {
-            format!(
+            anyhow!(
                 "failed to compute input nullifier for {}: {err}",
                 input_record.id
             )
@@ -290,7 +295,7 @@ fn save_results(
     }
 
     if spendable_outputs.objs.len() != descriptor.output_classes.len() {
-        return Err(format!(
+        return Err(anyhow!(
             "action {} output mismatch: descriptor expects {}, engine returned {}",
             action_id,
             descriptor.output_classes.len(),
@@ -359,13 +364,13 @@ pub async fn run_sdk_action(
     app: tauri::AppHandle,
     runtime: tauri::State<'_, ActionRunGate>,
     input: RunSdkActionInput,
-) -> Result<RunSdkActionResult, String> {
+) -> Result<RunSdkActionResult, CommandError> {
     let objects_dir: PathBuf = objects_dir(&app)?;
     let descriptors = action_descriptors_by_name();
     let descriptor = descriptors
         .get(&input.action_id)
         .cloned()
-        .ok_or_else(|| format!("unknown action: {}", input.action_id))?;
+        .ok_or_else(|| anyhow!("unknown action: {}", input.action_id))?;
 
     validate_run_request(&input, &descriptor)?;
 
@@ -398,7 +403,7 @@ pub async fn run_sdk_action(
     .await
     {
         Ok(result) => result,
-        Err(err) => Err(format!("failed while executing action: {err}")),
+        Err(err) => Err(anyhow!("failed while executing action: {err}")),
     }?;
 
     emit_generate_proof_done(&app, &action_id)?;
@@ -416,7 +421,7 @@ pub async fn run_sdk_action(
         &spendable_outputs,
     )?;
 
-    let commit_result: Result<SynchronizerState, String> = async {
+    let commit_result: Result<SynchronizerState> = async {
         submit_and_confirm_relayer(
             &app,
             RelayerSubmitRequest {
@@ -461,7 +466,7 @@ pub async fn run_sdk_action(
         }
         Err(err) => {
             rollback_results(&objects_dir, &resolved_inputs, &saved);
-            Err(err)
+            Err(err.into())
         }
     }
 }

--- a/app-gui/src-tauri/src/sdk/runtime.rs
+++ b/app-gui/src-tauri/src/sdk/runtime.rs
@@ -1,3 +1,4 @@
+use anyhow::{anyhow, Result};
 use std::sync::{Mutex, MutexGuard};
 
 #[derive(Debug)]
@@ -50,10 +51,10 @@ impl Drop for RunInProgressGuard<'_> {
 
 pub(super) fn acquire_run_in_progress_guard<'a, 'b>(
     runtime: &'a tauri::State<'b, ActionRunGate>,
-) -> Result<RunInProgressGuard<'a>, String> {
+) -> Result<RunInProgressGuard<'a>> {
     let mut inner = lock_runtime(runtime);
     if inner.run_in_progress {
-        return Err("another action run is already in progress".to_string());
+        return Err(anyhow!("another action run is already in progress"));
     }
     inner.run_in_progress = true;
     Ok(RunInProgressGuard {

--- a/app-gui/src-tauri/src/sdk/synchronizer_client.rs
+++ b/app-gui/src-tauri/src/sdk/synchronizer_client.rs
@@ -3,6 +3,7 @@ use std::{
     time::{Duration, Instant},
 };
 
+use anyhow::{anyhow, Result};
 use hex::FromHex;
 use pod2::middleware::Hash;
 use synchronizer::api_types::{
@@ -21,17 +22,17 @@ pub(super) struct SynchronizerState {
     pub(super) nullifiers: HashSet<Hash>,
 }
 
-fn parse_hash_hex(value: &str) -> Result<Hash, String> {
+fn parse_hash_hex(value: &str) -> Result<Hash> {
     let trimmed = value.trim().strip_prefix("0x").unwrap_or(value.trim());
-    Hash::from_hex(trimmed).map_err(|err| format!("invalid hash {value}: {err}"))
+    Hash::from_hex(trimmed).map_err(|err| anyhow!("invalid hash {value}: {err}"))
 }
 
-pub(super) fn fetch_synchronizer_state(sync_api_url: &str) -> Result<SynchronizerState, String> {
+pub(super) fn fetch_synchronizer_state(sync_api_url: &str) -> Result<SynchronizerState> {
     let endpoint = format!("{}/v1/state/full", sync_api_url.trim_end_matches('/'));
     let response = reqwest::blocking::get(&endpoint)
-        .map_err(|err| format!("failed to query synchronizer at {endpoint}: {err}"))?;
+        .map_err(|err| anyhow!("failed to query synchronizer at {endpoint}: {err}"))?;
     if !response.status().is_success() {
-        return Err(format!(
+        return Err(anyhow!(
             "synchronizer request failed: {} {}",
             response.status().as_u16(),
             response.status()
@@ -39,23 +40,23 @@ pub(super) fn fetch_synchronizer_state(sync_api_url: &str) -> Result<Synchronize
     }
     let payload: StateFullResponse = response
         .json()
-        .map_err(|err| format!("failed to decode synchronizer full state response: {err}"))?;
+        .map_err(|err| anyhow!("failed to decode synchronizer full state response: {err}"))?;
 
     let transactions = payload
         .transactions
         .iter()
         .map(|entry| parse_hash_hex(entry))
-        .collect::<Result<HashSet<_>, String>>()?;
+        .collect::<Result<HashSet<_>>>()?;
     let nullifiers = payload
         .nullifiers
         .iter()
         .map(|entry| parse_hash_hex(entry))
-        .collect::<Result<HashSet<_>, String>>()?;
+        .collect::<Result<HashSet<_>>>()?;
     let gsrs = payload
         .gsrs
         .iter()
         .map(|entry| parse_hash_hex(entry))
-        .collect::<Result<Vec<_>, String>>()?;
+        .collect::<Result<Vec<_>>>()?;
 
     let state_root = StateRoot::new(payload.block_number, &transactions, &nullifiers, &gsrs);
     let derived_gsr = state_root.hash();
@@ -84,7 +85,7 @@ pub(super) fn fetch_synchronizer_state(sync_api_url: &str) -> Result<Synchronize
 pub(super) fn fetch_synchronizer_tx_contains(
     sync_api_url: &str,
     tx_hashes: &[Hash],
-) -> Result<HashSet<Hash>, String> {
+) -> Result<HashSet<Hash>> {
     if tx_hashes.is_empty() {
         return Ok(HashSet::new());
     }
@@ -101,9 +102,9 @@ pub(super) fn fetch_synchronizer_tx_contains(
         .post(&endpoint)
         .json(&request)
         .send()
-        .map_err(|err| format!("failed to query synchronizer at {endpoint}: {err}"))?;
+        .map_err(|err| anyhow!("failed to query synchronizer at {endpoint}: {err}"))?;
     if !response.status().is_success() {
-        return Err(format!(
+        return Err(anyhow!(
             "synchronizer request failed: {} {}",
             response.status().as_u16(),
             response.status()
@@ -112,7 +113,7 @@ pub(super) fn fetch_synchronizer_tx_contains(
 
     let payload: TxContainsResponse = response
         .json()
-        .map_err(|err| format!("failed to decode synchronizer tx/contains response: {err}"))?;
+        .map_err(|err| anyhow!("failed to decode synchronizer tx/contains response: {err}"))?;
     let mut present = HashSet::new();
     for entry in payload.results {
         if entry.present {
@@ -122,19 +123,16 @@ pub(super) fn fetch_synchronizer_tx_contains(
     Ok(present)
 }
 
-fn fetch_synchronizer_tx_status(
-    sync_api_url: &str,
-    tx_hash: &Hash,
-) -> Result<TxStatusResponse, String> {
+fn fetch_synchronizer_tx_status(sync_api_url: &str, tx_hash: &Hash) -> Result<TxStatusResponse> {
     let endpoint = format!(
         "{}/v1/state/tx/{}",
         sync_api_url.trim_end_matches('/'),
         encode_hash_hex(tx_hash)
     );
     let response = reqwest::blocking::get(&endpoint)
-        .map_err(|err| format!("failed to query synchronizer at {endpoint}: {err}"))?;
+        .map_err(|err| anyhow!("failed to query synchronizer at {endpoint}: {err}"))?;
     if !response.status().is_success() {
-        return Err(format!(
+        return Err(anyhow!(
             "synchronizer request failed: {} {}",
             response.status().as_u16(),
             response.status()
@@ -143,7 +141,7 @@ fn fetch_synchronizer_tx_status(
 
     response
         .json::<TxStatusResponse>()
-        .map_err(|err| format!("failed to decode synchronizer tx status response: {err}"))
+        .map_err(|err| anyhow!("failed to decode synchronizer tx status response: {err}"))
 }
 
 pub(super) fn wait_for_synchronizer_tx(
@@ -151,7 +149,7 @@ pub(super) fn wait_for_synchronizer_tx(
     tx_final: Hash,
     timeout_secs: u64,
     poll_interval_ms: u64,
-) -> Result<SynchronizerState, String> {
+) -> Result<SynchronizerState> {
     let timeout = Duration::from_secs(timeout_secs);
     let poll_interval = Duration::from_millis(poll_interval_ms);
     let start = Instant::now();
@@ -161,7 +159,7 @@ pub(super) fn wait_for_synchronizer_tx(
             return fetch_synchronizer_state(sync_api_url);
         }
         if start.elapsed() >= timeout {
-            return Err(format!(
+            return Err(anyhow!(
                 "synchronizer did not index relayed tx {} within {}s",
                 encode_hash_hex(&tx_final),
                 timeout_secs

--- a/app-gui/src-tauri/src/settings.rs
+++ b/app-gui/src-tauri/src/settings.rs
@@ -1,5 +1,7 @@
+use anyhow::{anyhow, Result};
 use std::{fs, path::PathBuf};
 
+use crate::error::CommandError;
 use serde::{Deserialize, Serialize};
 use tauri::{
     menu::{Menu, MenuItem, MenuItemBuilder},
@@ -86,38 +88,38 @@ fn default_settings() -> AppSettings {
     }
 }
 
-fn settings_path(app: &tauri::AppHandle) -> Result<PathBuf, String> {
+fn settings_path(app: &tauri::AppHandle) -> Result<PathBuf> {
     let config_dir = app
         .path()
         .app_config_dir()
-        .map_err(|err| format!("failed to resolve app config directory: {err}"))?;
+        .map_err(|err| anyhow!("failed to resolve app config directory: {err}"))?;
     fs::create_dir_all(&config_dir)
-        .map_err(|err| format!("failed to create app config directory: {err}"))?;
+        .map_err(|err| anyhow!("failed to create app config directory: {err}"))?;
     Ok(config_dir.join("settings.json"))
 }
 
-fn read_settings(app: &tauri::AppHandle) -> Result<Option<AppSettings>, String> {
+fn read_settings(app: &tauri::AppHandle) -> Result<Option<AppSettings>> {
     let path = settings_path(app)?;
     if !path.exists() {
         return Ok(None);
     }
     let raw = fs::read_to_string(&path)
-        .map_err(|err| format!("failed to read settings file {}: {err}", path.display()))?;
+        .map_err(|err| anyhow!("failed to read settings file {}: {err}", path.display()))?;
     let settings = serde_json::from_str::<AppSettings>(&raw)
-        .map_err(|err| format!("failed to parse settings file {}: {err}", path.display()))?;
+        .map_err(|err| anyhow!("failed to parse settings file {}: {err}", path.display()))?;
     Ok(Some(settings))
 }
 
-fn write_settings(app: &tauri::AppHandle, settings: &AppSettings) -> Result<(), String> {
+fn write_settings(app: &tauri::AppHandle, settings: &AppSettings) -> Result<()> {
     let path = settings_path(app)?;
     let serialized = serde_json::to_string(settings)
-        .map_err(|err| format!("failed to serialize settings: {err}"))?;
+        .map_err(|err| anyhow!("failed to serialize settings: {err}"))?;
     fs::write(&path, serialized)
-        .map_err(|err| format!("failed to write settings file {}: {err}", path.display()))
+        .map_err(|err| anyhow!("failed to write settings file {}: {err}", path.display()))
 }
 
 #[tauri::command]
-pub fn get_app_settings(app: tauri::AppHandle) -> Result<AppSettings, String> {
+pub fn get_app_settings(app: tauri::AppHandle) -> Result<AppSettings, CommandError> {
     if let Some(settings) = read_settings(&app)? {
         return Ok(settings);
     }
@@ -127,7 +129,10 @@ pub fn get_app_settings(app: tauri::AppHandle) -> Result<AppSettings, String> {
 }
 
 #[tauri::command]
-pub fn save_app_settings(app: tauri::AppHandle, input: AppSettings) -> Result<AppSettings, String> {
+pub fn save_app_settings(
+    app: tauri::AppHandle,
+    input: AppSettings,
+) -> Result<AppSettings, CommandError> {
     write_settings(&app, &input)?;
     Ok(input)
 }

--- a/app-gui/src-tauri/src/spec.rs
+++ b/app-gui/src-tauri/src/spec.rs
@@ -233,19 +233,23 @@ fn use_pick_details(step: Step, name: &'static str, vdf_iters: usize) -> Step {
     step.condition(
         "Gt({state}.durability, 0)",
         Box::new(|ctx| {
-            let obj = ctx.vars.get_dict(name).unwrap();
+            let obj = ctx.vars.get(name).as_dictionary().unwrap();
             ctx.bld
                 .builder
-                .priv_op(Operation::gt((obj, "durability"), 0))
+                .priv_op(Operation::gt((&obj, "durability"), 0))
                 .unwrap()
         }),
     )
     .var(
         "durability",
         Box::new(|ctx| {
-            let obj = ctx.vars.get_dict(name).unwrap();
-            let mut durability =
-                i64::try_from(obj.get(&Key::from("durability")).unwrap().typed()).unwrap();
+            let obj = ctx.vars.get(name).as_dictionary().unwrap();
+            let mut durability = obj
+                .get(&Key::from("durability"))
+                .unwrap()
+                .unwrap()
+                .as_int()
+                .unwrap();
             durability -= 1;
             ctx.store("durability", Box::new(durability));
             Value::from(durability)
@@ -255,10 +259,10 @@ fn use_pick_details(step: Step, name: &'static str, vdf_iters: usize) -> Step {
         "SumOf({state}.durability, durability, 1)",
         Box::new(|ctx| {
             let durability: Box<i64> = ctx.take("durability");
-            let obj = ctx.vars.get_dict(name).unwrap();
+            let obj = ctx.vars.get(name).as_dictionary().unwrap();
             ctx.bld
                 .builder
-                .priv_op(Operation::sum_of((obj, "durability"), *durability, 1))
+                .priv_op(Operation::sum_of((&obj, "durability"), *durability, 1))
                 .unwrap()
         }),
     )
@@ -269,7 +273,7 @@ fn use_pick_details(step: Step, name: &'static str, vdf_iters: usize) -> Step {
         "work",
         Box::new(move |ctx| {
             let obj = ctx.vars.get(name);
-            let obj_raw = RawValue::from(obj);
+            let obj_raw = obj.as_raw();
             let (vdf_pod, st_vdf, work) = vdf(ctx, vdf_iters, obj_raw);
             ctx.store("vdf_pod", Box::new(vdf_pod));
             ctx.store("st_vdf", Box::new(st_vdf));
@@ -318,7 +322,7 @@ pub(crate) fn actions() -> Vec<api::Action> {
                         "work",
                         Box::new(|ctx| {
                             let log = ctx.vars.get("log");
-                            let log_raw = RawValue::from(log);
+                            let log_raw = log.as_raw();
                             let (vdf_pod, st_vdf, work) = vdf(ctx, 3, log_raw);
                             ctx.store("vdf_pod", Box::new(vdf_pod));
                             ctx.store("st_vdf", Box::new(st_vdf));
@@ -346,7 +350,7 @@ pub(crate) fn actions() -> Vec<api::Action> {
                     .var(
                         "key",
                         Box::new(|ctx| {
-                            let mut wood = ctx.vars.get_dict("wood").unwrap().clone();
+                            let mut wood = ctx.vars.get("wood").as_dictionary().unwrap();
                             let mut key = Value::from(rand_raw_value());
                             if !ctx.mock {
                                 while RawValue::from(wood.commitment()).0[3].0 > WOOD_POW_DIFFICULTY
@@ -363,7 +367,7 @@ pub(crate) fn actions() -> Vec<api::Action> {
                         "LtEqU256({state}, Raw(0x0020000000000000000000000000000000000000000000000000000000000000))",
                         Box::new(|ctx| {
                             let wood = ctx.vars.get("wood");
-                            let wood_raw = RawValue::from(wood);
+                            let wood_raw = wood.as_raw();
                             let (lt_eq_u256_pod, st_lt_eq_u256) = lt_eq_u256(
                                 ctx,
                                 wood_raw,

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -29,10 +29,10 @@ pub mod groth {
 
 use std::io;
 
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use hex::ToHex;
 use pod2::middleware::Hash;
-use tracing_subscriber::{fmt::time::OffsetTime, prelude::*, EnvFilter};
+use tracing_subscriber::{EnvFilter, fmt::time::OffsetTime, prelude::*};
 
 pub fn load_dotenv() -> Result<()> {
     for filename in [".env.default", ".env"] {

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -29,10 +29,10 @@ pub mod groth {
 
 use std::io;
 
-use anyhow::{Result, anyhow};
+use anyhow::{anyhow, Result};
 use hex::ToHex;
-use pod2::middleware::{Hash, Value, containers};
-use tracing_subscriber::{EnvFilter, fmt::time::OffsetTime, prelude::*};
+use pod2::middleware::Hash;
+use tracing_subscriber::{fmt::time::OffsetTime, prelude::*, EnvFilter};
 
 pub fn load_dotenv() -> Result<()> {
     for filename in [".env.default", ".env"] {
@@ -76,13 +76,6 @@ impl ProofType {
             ProofType::Plonky2 => 0u8,
             ProofType::Groth16 => 1u8,
         }
-    }
-}
-
-pub fn set_from_value(v: &Value) -> Result<containers::Set> {
-    match v.typed() {
-        pod2::middleware::TypedValue::Set(s) => Ok(s.clone()),
-        _ => Err(anyhow!("Invalid set")),
     }
 }
 

--- a/craft_sdk/src/lib.rs
+++ b/craft_sdk/src/lib.rs
@@ -6,10 +6,10 @@ use log::info;
 use pod2::{
     backends::plonky2::{basetypes::DEFAULT_VD_SET, mainpod::Prover, mock::mainpod::MockProver},
     frontend::{MainPod, MultiPodBuilder, Operation},
-    lang::{Module, load_module},
+    lang::{load_module, Module},
     middleware::{
-        EMPTY_VALUE, Hash, Key, MainPodProver, Params, Predicate, Statement, TypedValue, VDSet,
-        Value, containers::Dictionary,
+        containers::Dictionary, Hash, Key, MainPodProver, Params, Predicate, Statement, VDSet,
+        Value, EMPTY_VALUE,
     },
 };
 use pod2utils::{dict, macros::BuildContext, rand_raw_value};
@@ -498,7 +498,7 @@ impl<'a> ObjectBuilder<'a> {
             // On Mutate we save a copy of the initial object because it's required by the mutate
             // transaction
             if matches!(step.kind, StepKind::Mutate) {
-                let obj = ctx.vars.get_dict(&step.name).unwrap();
+                let obj = ctx.vars.get(&step.name).as_dictionary().unwrap();
                 objs0.insert(&step.name, obj.clone());
             }
 
@@ -509,8 +509,9 @@ impl<'a> ObjectBuilder<'a> {
                 match detail {
                     api::Detail::Set { key, value } => {
                         let value = ctx.vars.value(value);
-                        let obj = ctx.vars.get_dict_mut(&step.name).unwrap();
-                        obj.insert(&Key::from(key.clone()), &value).unwrap();
+                        ctx.vars.mut_dict(&step.name, |obj| {
+                            obj.insert(&Key::from(key.clone()), &value).unwrap();
+                        });
                         details_set_kv.push((key.clone(), value));
                     }
                     api::Detail::Update { key, value } => {
@@ -518,24 +519,21 @@ impl<'a> ObjectBuilder<'a> {
                             panic!("Update before last Set in the Step");
                         }
                         let value = ctx.vars.value(value);
-                        let obj = ctx.vars.get_dict_mut(&step.name).unwrap();
-                        let obj0 = obj.clone();
-                        obj.update(&Key::from(key.clone()), &value).unwrap();
+                        let (obj0, obj) = ctx.vars.mut_dict(&step.name, |obj| {
+                            let obj0 = obj.clone();
+                            obj.update(&Key::from(key.clone()), &value).unwrap();
+                            (obj0, obj.clone())
+                        });
                         sts.push(
                             ctx.bld
                                 .builder
-                                .priv_op(Operation::dict_update(
-                                    obj.clone(),
-                                    obj0,
-                                    key.clone(),
-                                    value,
-                                ))
+                                .priv_op(Operation::dict_update(obj, obj0, key.clone(), value))
                                 .unwrap(),
                         );
                     }
                     api::Detail::Var { name, f } => {
                         let value = f(ctx);
-                        ctx.vars.insert(name, value.take_typed());
+                        ctx.vars.insert(name, value);
                     }
                     api::Detail::Condition { pred: _, f } => {
                         if !details_set_done {
@@ -549,7 +547,7 @@ impl<'a> ObjectBuilder<'a> {
                 // refer to the same object state.
                 if !details_set_done && details_set_kv.len() == details_set_len {
                     for (key, value) in mem::take(&mut details_set_kv).into_iter() {
-                        let obj = ctx.vars.get_dict_mut(&step.name).unwrap();
+                        let obj = ctx.vars.get(&step.name).as_dictionary().unwrap();
                         sts.push(
                             ctx.bld
                                 .builder
@@ -563,7 +561,7 @@ impl<'a> ObjectBuilder<'a> {
 
             match step.kind {
                 StepKind::Output => {
-                    let obj = ctx.vars.get_dict(step.name.as_str()).unwrap().clone();
+                    let obj = ctx.vars.get(step.name.as_str()).as_dictionary().unwrap();
                     outputs.push(OutputData {
                         class: &step.class,
                         obj: obj.clone(),
@@ -571,12 +569,12 @@ impl<'a> ObjectBuilder<'a> {
                     sts.push(tx_builder.insert(&mut ctx.bld, obj));
                 }
                 StepKind::Input => {
-                    let obj = ctx.vars.get_dict(step.name.as_str()).unwrap().clone();
+                    let obj = ctx.vars.get(step.name.as_str()).as_dictionary().unwrap();
                     sts.push(tx_builder.delete(&mut ctx.bld, obj));
                 }
                 StepKind::Mutate => {
                     let obj0 = objs0.get(step.name.as_str()).unwrap();
-                    let obj = ctx.vars.get_dict(step.name.as_str()).unwrap().clone();
+                    let obj = ctx.vars.get(step.name.as_str()).as_dictionary().unwrap();
                     outputs.push(OutputData {
                         class: &step.class,
                         obj: obj.clone(),
@@ -683,35 +681,32 @@ impl<'a> ObjectBuilder<'a> {
 
 #[derive(Default)]
 pub struct Vars<'a> {
-    vars: HashMap<&'a str, TypedValue>,
+    vars: HashMap<&'a str, Value>,
 }
 
 impl<'a> Vars<'a> {
-    pub fn insert(&mut self, name: &'a str, value: impl Into<TypedValue>) {
+    pub(crate) fn insert(&mut self, name: &'a str, value: impl Into<Value>) {
         self.vars.insert(name, value.into());
     }
-    pub fn get(&self, name: &'a str) -> &TypedValue {
+    pub fn get(&self, name: &'a str) -> &Value {
         self.vars.get(name).unwrap()
     }
-    pub fn get_dict_mut(&mut self, name: &'a str) -> Option<&mut Dictionary> {
-        let v = self.vars.get_mut(name).unwrap();
-        match v {
-            TypedValue::Dictionary(v) => Some(v),
-            _ => None,
-        }
-    }
-    pub fn get_dict(&self, name: &'a str) -> Option<&Dictionary> {
-        let v = self.vars.get(name).unwrap();
-        match v {
-            TypedValue::Dictionary(v) => Some(v),
-            _ => None,
-        }
+    pub(crate) fn mut_dict<T>(
+        &mut self,
+        name: &'a str,
+        mut f: impl FnMut(&mut Dictionary) -> T,
+    ) -> T {
+        let obj = self.vars.get_mut(name).unwrap();
+        let mut dict = obj.as_dictionary().unwrap();
+        let output = f(&mut dict);
+        *obj = Value::from(dict);
+        output
     }
     // Resolve a Arg::Var or return its Literal value
     pub fn value(&self, arg: &api::Arg) -> Value {
         match arg {
             api::Arg::Literal(v) => v.clone(),
-            api::Arg::Var(name) => Value::new(self.vars[name.as_str()].clone()),
+            api::Arg::Var(name) => self.vars[name.as_str()].clone(),
         }
     }
 }
@@ -1104,13 +1099,13 @@ mod tests {
     use lt_eq_u256_pod::LtEqU256Pod;
     use pod2::{
         frontend::{MainPod, Operation},
-        middleware::{F, Hash, Key, Pod, RawValue, Statement, Value, containers::Array},
+        middleware::{containers::Array, Hash, Key, Pod, RawValue, Statement, Value, F},
     };
     use pod2utils::{rand_raw_value, set};
     use txlib::{StateRoot, Tx};
     use vdfpod::VdfPod;
 
-    use super::{Context, Helper, api::*};
+    use super::{api::*, Context, Helper};
 
     const WOOD_POW_DIFFICULTY: u64 = 0x0020_0000_0000_0000;
 
@@ -1119,8 +1114,9 @@ mod tests {
             .transactions
             .insert(&Value::from(tx.dict()))
             .unwrap();
-        for nullifier in tx.nullifiers.set() {
-            state_root.nullifiers.insert(nullifier).unwrap();
+        for nullifier in tx.nullifiers.iter() {
+            let nullifier = nullifier.unwrap();
+            state_root.nullifiers.insert(&nullifier).unwrap();
         }
         state_root.block_number += 1;
     }
@@ -1165,31 +1161,29 @@ mod tests {
 
         let find_log = Action {
             name: "FindLog",
-            steps: vec![
-                Step::output("log", "Log")
-                    .set("blueprint", Arg::literal("Log"))
-                    .var(
-                        "work",
-                        Box::new(|ctx| {
-                            let log = ctx.vars.get("log");
-                            let log_raw = RawValue::from(log);
-                            let (vdf_pod, st_vdf, work) = vdf(ctx, 3, log_raw);
-                            ctx.store("vdf_pod", Box::new(vdf_pod));
-                            ctx.store("st_vdf", Box::new(st_vdf));
-                            work
-                        }),
-                    )
-                    .condition(
-                        "Vdf(3, {state}, work)",
-                        Box::new(|ctx| {
-                            let vdf_pod: Box<MainPod> = ctx.take("vdf_pod");
-                            let st_vdf: Box<Statement> = ctx.take("st_vdf");
-                            ctx.bld.builder.add_pod(*vdf_pod).unwrap();
-                            *st_vdf
-                        }),
-                    )
-                    .update("work", Arg::var("work")),
-            ],
+            steps: vec![Step::output("log", "Log")
+                .set("blueprint", Arg::literal("Log"))
+                .var(
+                    "work",
+                    Box::new(|ctx| {
+                        let log = ctx.vars.get("log");
+                        let log_raw = log.as_raw();
+                        let (vdf_pod, st_vdf, work) = vdf(ctx, 3, log_raw);
+                        ctx.store("vdf_pod", Box::new(vdf_pod));
+                        ctx.store("st_vdf", Box::new(st_vdf));
+                        work
+                    }),
+                )
+                .condition(
+                    "Vdf(3, {state}, work)",
+                    Box::new(|ctx| {
+                        let vdf_pod: Box<MainPod> = ctx.take("vdf_pod");
+                        let st_vdf: Box<Statement> = ctx.take("st_vdf");
+                        ctx.bld.builder.add_pod(*vdf_pod).unwrap();
+                        *st_vdf
+                    }),
+                )
+                .update("work", Arg::var("work"))],
         };
 
         let craft_wood = Action {
@@ -1201,7 +1195,7 @@ mod tests {
                     .var(
                         "key",
                         Box::new(|ctx| {
-                            let mut wood = ctx.vars.get_dict("wood").unwrap().clone();
+                            let mut wood = ctx.vars.get("wood").as_dictionary().unwrap();
                             let mut key = Value::from(rand_raw_value());
                             if !ctx.mock {
                                 while RawValue::from(wood.commitment()).0[3].0
@@ -1220,7 +1214,7 @@ mod tests {
                         "LtEqU256({state}, Raw(0x0020000000000000000000000000000000000000000000000000000000000000))",
                         Box::new(|ctx| {
                             let wood = ctx.vars.get("wood");
-                            let wood_raw = RawValue::from(wood);
+                            let wood_raw = wood.as_raw();
                             let (lt_eq_u256_pod, st_lt_eq_u256) = lt_eq_u256(
                                 ctx,
                                 wood_raw,
@@ -1268,19 +1262,23 @@ mod tests {
             step.condition(
                 "Gt({state}.durability, 0)",
                 Box::new(|ctx| {
-                    let obj = ctx.vars.get_dict(name).unwrap();
+                    let obj = ctx.vars.get(name).as_dictionary().unwrap();
                     ctx.bld
                         .builder
-                        .priv_op(Operation::gt((obj, "durability"), 0))
+                        .priv_op(Operation::gt((&obj, "durability"), 0))
                         .unwrap()
                 }),
             )
             .var(
                 "durability",
                 Box::new(|ctx| {
-                    let obj = ctx.vars.get_dict(name).unwrap();
-                    let mut durability =
-                        i64::try_from(obj.get(&Key::from("durability")).unwrap().typed()).unwrap();
+                    let obj = ctx.vars.get(name).as_dictionary().unwrap();
+                    let mut durability = obj
+                        .get(&Key::from("durability"))
+                        .unwrap()
+                        .unwrap()
+                        .as_int()
+                        .unwrap();
                     durability -= 1;
                     ctx.store("durability", Box::new(durability));
                     Value::from(durability)
@@ -1290,10 +1288,10 @@ mod tests {
                 "SumOf({state}.durability, durability, 1)",
                 Box::new(|ctx| {
                     let durability: Box<i64> = ctx.take("durability");
-                    let obj = ctx.vars.get_dict(name).unwrap();
+                    let obj = ctx.vars.get(name).as_dictionary().unwrap();
                     ctx.bld
                         .builder
-                        .priv_op(Operation::sum_of((obj, "durability"), *durability, 1))
+                        .priv_op(Operation::sum_of((&obj, "durability"), *durability, 1))
                         .unwrap()
                 }),
             )
@@ -1304,7 +1302,7 @@ mod tests {
                 "work",
                 Box::new(move |ctx| {
                     let obj = ctx.vars.get(name);
-                    let obj_raw = RawValue::from(obj);
+                    let obj_raw = obj.as_raw();
                     let (vdf_pod, st_vdf, work) = vdf(ctx, vdf_iters, obj_raw);
                     ctx.store("vdf_pod", Box::new(vdf_pod));
                     ctx.store("st_vdf", Box::new(st_vdf));
@@ -1325,10 +1323,8 @@ mod tests {
 
         let use_wood_pick = Action {
             name: "UseWoodPick",
-            steps: vec![
-                Step::mutate("wood_pick", "WoodPick")
-                    .snippet(|step| use_pick_details(step, "wood_pick", 10)),
-            ],
+            steps: vec![Step::mutate("wood_pick", "WoodPick")
+                .snippet(|step| use_pick_details(step, "wood_pick", 10))],
         };
 
         let mine_stone_with_wood_pick = Action {
@@ -1341,10 +1337,8 @@ mod tests {
 
         let use_stone_pick = Action {
             name: "UseStonePick",
-            steps: vec![
-                Step::mutate("stone_pick", "StonePick")
-                    .snippet(|step| use_pick_details(step, "stone_pick", 5)),
-            ],
+            steps: vec![Step::mutate("stone_pick", "StonePick")
+                .snippet(|step| use_pick_details(step, "stone_pick", 5))],
         };
 
         let mine_stone_with_stone_pick = Action {

--- a/craft_sdk/src/lib.rs
+++ b/craft_sdk/src/lib.rs
@@ -6,10 +6,10 @@ use log::info;
 use pod2::{
     backends::plonky2::{basetypes::DEFAULT_VD_SET, mainpod::Prover, mock::mainpod::MockProver},
     frontend::{MainPod, MultiPodBuilder, Operation},
-    lang::{load_module, Module},
+    lang::{Module, load_module},
     middleware::{
-        containers::Dictionary, Hash, Key, MainPodProver, Params, Predicate, Statement, VDSet,
-        Value, EMPTY_VALUE,
+        EMPTY_VALUE, Hash, Key, MainPodProver, Params, Predicate, Statement, VDSet, Value,
+        containers::Dictionary,
     },
 };
 use pod2utils::{dict, macros::BuildContext, rand_raw_value};
@@ -1099,13 +1099,13 @@ mod tests {
     use lt_eq_u256_pod::LtEqU256Pod;
     use pod2::{
         frontend::{MainPod, Operation},
-        middleware::{containers::Array, Hash, Key, Pod, RawValue, Statement, Value, F},
+        middleware::{F, Hash, Key, Pod, RawValue, Statement, Value, containers::Array},
     };
     use pod2utils::{rand_raw_value, set};
     use txlib::{StateRoot, Tx};
     use vdfpod::VdfPod;
 
-    use super::{api::*, Context, Helper};
+    use super::{Context, Helper, api::*};
 
     const WOOD_POW_DIFFICULTY: u64 = 0x0020_0000_0000_0000;
 
@@ -1161,29 +1161,31 @@ mod tests {
 
         let find_log = Action {
             name: "FindLog",
-            steps: vec![Step::output("log", "Log")
-                .set("blueprint", Arg::literal("Log"))
-                .var(
-                    "work",
-                    Box::new(|ctx| {
-                        let log = ctx.vars.get("log");
-                        let log_raw = log.as_raw();
-                        let (vdf_pod, st_vdf, work) = vdf(ctx, 3, log_raw);
-                        ctx.store("vdf_pod", Box::new(vdf_pod));
-                        ctx.store("st_vdf", Box::new(st_vdf));
-                        work
-                    }),
-                )
-                .condition(
-                    "Vdf(3, {state}, work)",
-                    Box::new(|ctx| {
-                        let vdf_pod: Box<MainPod> = ctx.take("vdf_pod");
-                        let st_vdf: Box<Statement> = ctx.take("st_vdf");
-                        ctx.bld.builder.add_pod(*vdf_pod).unwrap();
-                        *st_vdf
-                    }),
-                )
-                .update("work", Arg::var("work"))],
+            steps: vec![
+                Step::output("log", "Log")
+                    .set("blueprint", Arg::literal("Log"))
+                    .var(
+                        "work",
+                        Box::new(|ctx| {
+                            let log = ctx.vars.get("log");
+                            let log_raw = log.as_raw();
+                            let (vdf_pod, st_vdf, work) = vdf(ctx, 3, log_raw);
+                            ctx.store("vdf_pod", Box::new(vdf_pod));
+                            ctx.store("st_vdf", Box::new(st_vdf));
+                            work
+                        }),
+                    )
+                    .condition(
+                        "Vdf(3, {state}, work)",
+                        Box::new(|ctx| {
+                            let vdf_pod: Box<MainPod> = ctx.take("vdf_pod");
+                            let st_vdf: Box<Statement> = ctx.take("st_vdf");
+                            ctx.bld.builder.add_pod(*vdf_pod).unwrap();
+                            *st_vdf
+                        }),
+                    )
+                    .update("work", Arg::var("work")),
+            ],
         };
 
         let craft_wood = Action {
@@ -1323,8 +1325,10 @@ mod tests {
 
         let use_wood_pick = Action {
             name: "UseWoodPick",
-            steps: vec![Step::mutate("wood_pick", "WoodPick")
-                .snippet(|step| use_pick_details(step, "wood_pick", 10))],
+            steps: vec![
+                Step::mutate("wood_pick", "WoodPick")
+                    .snippet(|step| use_pick_details(step, "wood_pick", 10)),
+            ],
         };
 
         let mine_stone_with_wood_pick = Action {
@@ -1337,8 +1341,10 @@ mod tests {
 
         let use_stone_pick = Action {
             name: "UseStonePick",
-            steps: vec![Step::mutate("stone_pick", "StonePick")
-                .snippet(|step| use_pick_details(step, "stone_pick", 5))],
+            steps: vec![
+                Step::mutate("stone_pick", "StonePick")
+                    .snippet(|step| use_pick_details(step, "stone_pick", 5)),
+            ],
         };
 
         let mine_stone_with_stone_pick = Action {

--- a/synchronizer/src/state_machine.rs
+++ b/synchronizer/src/state_machine.rs
@@ -761,10 +761,10 @@ mod tests {
         let tx_final = tx.dict().commitment();
         let nullifiers: Vec<Hash> = tx
             .nullifiers
-            .set()
             .iter()
-            .map(|v| Hash(v.raw().0))
-            .collect();
+            .map(|v| Ok(Hash(v?.raw().0)))
+            .collect::<Result<_>>()
+            .unwrap();
 
         let payload = Payload {
             proof: PayloadProof::Plonky2(Box::new(compressed_proof)),

--- a/timelib/src/predicates/mod.rs
+++ b/timelib/src/predicates/mod.rs
@@ -18,7 +18,7 @@ mod tests {
     use pod2::{
         backends::plonky2::mock::mainpod::MockProver,
         frontend::MultiPodBuilder,
-        middleware::{containers::Array, Key, Params, VDSet, Value},
+        middleware::{Key, Params, VDSet, Value, containers::Array},
     };
     use pod2utils::{macros::BuildContext, op, set};
 
@@ -61,7 +61,7 @@ mod tests {
     /// GSR₂ (when the lock was established). The transaction is finalized.
     #[test]
     fn prove_lock_and_unlock() {
-        use txlib::{new_obj, StateRoot as TxStateRoot, TxBuilder};
+        use txlib::{StateRoot as TxStateRoot, TxBuilder, new_obj};
 
         let txlib_module = Arc::new(txlib::predicates::module());
         let time_module = Arc::new(module().unwrap());
@@ -179,7 +179,7 @@ mod tests {
     /// takes the expiry-bearing object as an input and proves `NotExpired`.
     #[test]
     fn prove_set_expiry_and_not_expired() {
-        use txlib::{new_obj, StateRoot as TxStateRoot, TxBuilder};
+        use txlib::{StateRoot as TxStateRoot, TxBuilder, new_obj};
 
         let txlib_module = Arc::new(txlib::predicates::module());
         let time_module = Arc::new(module().unwrap());

--- a/timelib/src/predicates/mod.rs
+++ b/timelib/src/predicates/mod.rs
@@ -18,7 +18,7 @@ mod tests {
     use pod2::{
         backends::plonky2::mock::mainpod::MockProver,
         frontend::MultiPodBuilder,
-        middleware::{Key, Params, VDSet, Value, containers::Array},
+        middleware::{containers::Array, Key, Params, VDSet, Value},
     };
     use pod2utils::{macros::BuildContext, op, set};
 
@@ -61,7 +61,7 @@ mod tests {
     /// GSR₂ (when the lock was established). The transaction is finalized.
     #[test]
     fn prove_lock_and_unlock() {
-        use txlib::{StateRoot as TxStateRoot, TxBuilder, new_obj};
+        use txlib::{new_obj, StateRoot as TxStateRoot, TxBuilder};
 
         let txlib_module = Arc::new(txlib::predicates::module());
         let time_module = Arc::new(module().unwrap());
@@ -179,7 +179,7 @@ mod tests {
     /// takes the expiry-bearing object as an input and proves `NotExpired`.
     #[test]
     fn prove_set_expiry_and_not_expired() {
-        use txlib::{StateRoot as TxStateRoot, TxBuilder, new_obj};
+        use txlib::{new_obj, StateRoot as TxStateRoot, TxBuilder};
 
         let txlib_module = Arc::new(txlib::predicates::module());
         let time_module = Arc::new(module().unwrap());
@@ -219,7 +219,7 @@ mod tests {
                 )
                 .unwrap();
                 // Pre-materialise key for TxObjectStateNullified inside mutate.
-                let key = obj.get(&Key::from("key")).unwrap().clone();
+                let key = obj.get(&Key::from("key")).unwrap().unwrap();
                 let _ = ctx
                     .builder
                     .priv_op(op!(DictContains(obj, "key", key)))

--- a/timelib/src/tx_utils.rs
+++ b/timelib/src/tx_utils.rs
@@ -18,7 +18,7 @@ use anyhow::ensure;
 use pod2::{
     frontend::MultiPodError,
     lang::{Module, MultiOperationError},
-    middleware::{containers::Dictionary, hash_values, Key, Statement, Value},
+    middleware::{Key, Statement, Value, containers::Dictionary, hash_values},
 };
 use pod2utils::{macros::BuildContext, op, st_custom};
 use txlib::{StateRoot, Tx};

--- a/timelib/src/tx_utils.rs
+++ b/timelib/src/tx_utils.rs
@@ -220,7 +220,7 @@ pub fn unlock_object(
     let mut idx = None;
     for entry in grounding_gsr.gsrs.iter() {
         let (i, v) = entry?;
-        if &v == &target {
+        if v == target {
             idx = Some(i);
             break;
         }

--- a/timelib/src/tx_utils.rs
+++ b/timelib/src/tx_utils.rs
@@ -18,7 +18,7 @@ use anyhow::ensure;
 use pod2::{
     frontend::MultiPodError,
     lang::{Module, MultiOperationError},
-    middleware::{Key, Statement, Value, containers::Dictionary, hash_values},
+    middleware::{containers::Dictionary, hash_values, Key, Statement, Value},
 };
 use pod2utils::{macros::BuildContext, op, st_custom};
 use txlib::{StateRoot, Tx};
@@ -56,11 +56,11 @@ pub fn not_expired(
     state: Dictionary,
 ) -> anyhow::Result<Statement> {
     let timeout_val = state
-        .get(&Key::from("timeout_block"))
-        .cloned()
-        .map_err(|e| anyhow::anyhow!("{e}: state missing timeout_block field"))?;
-    let timeout_block = i64::try_from(timeout_val.typed())
-        .map_err(|_| anyhow::anyhow!("timeout_block is not an integer"))?;
+        .get(&Key::from("timeout_block"))?
+        .ok_or_else(|| anyhow::anyhow!("state missing timeout_block field"))?;
+    let timeout_block = timeout_val
+        .as_int()
+        .ok_or_else(|| anyhow::anyhow!("timeout_block is not an integer"))?;
     let gsr_block = grounding_gsr.block_number;
     ensure!(
         gsr_block <= timeout_block,
@@ -209,21 +209,24 @@ pub fn unlock_object(
     gsr_when_locked: &StateRoot,
 ) -> anyhow::Result<Dictionary> {
     let lock_duration = locked_obj
-        .get(&Key::from("locked"))
-        .cloned()
-        .map_err(|e| anyhow::anyhow!("{e}: locked_obj missing 'locked' field"))?;
-    let lock_duration = i64::try_from(lock_duration.typed())
-        .map_err(|_| anyhow::anyhow!("'locked' field is not an integer"))?;
+        .get(&Key::from("locked"))?
+        .ok_or_else(|| anyhow::anyhow!("locked_obj missing 'locked' field"))?;
+    let lock_duration = lock_duration
+        .as_int()
+        .ok_or_else(|| anyhow::anyhow!("'locked' field is not an integer"))?;
 
     // Find where gsr_when_locked sits in the current state root's gsrs array.
     let target = Value::from(gsr_when_locked.hash());
-    let idx = grounding_gsr
-        .gsrs
-        .array()
-        .iter()
-        .position(|v| v == &target)
-        .ok_or_else(|| anyhow::anyhow!("gsr_when_locked not found in grounding_gsr.gsrs"))?
-        as i64;
+    let mut idx = None;
+    for entry in grounding_gsr.gsrs.iter() {
+        let (i, v) = entry?;
+        if &v == &target {
+            idx = Some(i);
+            break;
+        }
+    }
+    let idx =
+        idx.ok_or_else(|| anyhow::anyhow!("gsr_when_locked not found in grounding_gsr.gsrs"))?;
 
     let distance = grounding_gsr.block_number - gsr_when_locked.block_number;
     ensure!(
@@ -256,7 +259,7 @@ pub fn unlock_object(
         .builder
         .priv_op(op!(ArrayContains(
             grounding_gsr.gsrs,
-            idx,
+            idx as i64,
             gsr_when_locked.hash()
         )))
         .unwrap();

--- a/txlib/src/lib.rs
+++ b/txlib/src/lib.rs
@@ -5,10 +5,10 @@ use std::{
     sync::Arc,
 };
 
+use anyhow::{anyhow, Result};
 use pod2::middleware::{
-    EMPTY_VALUE, Hash, Key, Statement, Value,
     containers::{Array, Dictionary, Set},
-    hash_values,
+    hash_values, Hash, Key, Statement, Value, EMPTY_VALUE,
 };
 use pod2utils::{dict, dict_define, macros::BuildContext, rand_raw_value, set, st_custom};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -117,11 +117,10 @@ pub fn rekey(obj: &mut Dictionary) {
 
 const OBJECT_NULLIFIER_VERSION: &str = "txlib-nullifier-v1";
 
-pub fn object_key_hash(obj: &Dictionary) -> Result<Hash, String> {
+pub fn object_key_hash(obj: &Dictionary) -> Result<Hash> {
     let key = obj
-        .get(&Key::from("key"))
-        .cloned()
-        .map_err(|err| format!("object missing required key field: {err}"))?;
+        .get(&Key::from("key"))?
+        .ok_or_else(|| anyhow!("object missing required key field"))?;
     Ok(hash_values(&[Value::from(obj.commitment()), key]))
 }
 
@@ -132,7 +131,7 @@ pub fn object_nullifier_from_key_hash(obj_key_hash: Hash) -> Hash {
     ])
 }
 
-pub fn object_nullifier_hash(obj: &Dictionary) -> Result<Hash, String> {
+pub fn object_nullifier_hash(obj: &Dictionary) -> Result<Hash> {
     object_key_hash(obj).map(object_nullifier_from_key_hash)
 }
 
@@ -415,7 +414,7 @@ mod tests {
         obj.delete(&Key::from("key"))
             .expect("deleting key from dictionary should succeed");
         let err = object_nullifier_hash(&obj).expect_err("missing key must fail");
-        assert!(err.contains("missing required key field"));
+        assert!(format!("{err}").contains("missing required key field"));
     }
 
     fn prove(builder: MultiPodBuilder, prover: &dyn MainPodProver) -> MainPod {
@@ -467,8 +466,9 @@ mod tests {
             .transactions
             .insert(&Value::from(tx0.dict()))
             .unwrap();
-        for nullifier in tx0.nullifiers.set() {
-            state_root.transactions.insert(nullifier).unwrap();
+        for nullifier in tx0.nullifiers.iter() {
+            let nullifier = nullifier.unwrap();
+            state_root.transactions.insert(&nullifier).unwrap();
         }
 
         // Mutate
@@ -493,8 +493,9 @@ mod tests {
             .transactions
             .insert(&Value::from(tx1.dict()))
             .unwrap();
-        for nullifier in tx1.nullifiers.set() {
-            state_root.transactions.insert(nullifier).unwrap();
+        for nullifier in tx1.nullifiers.iter() {
+            let nullifier = nullifier.unwrap();
+            state_root.transactions.insert(&nullifier).unwrap();
         }
 
         // Delete
@@ -517,8 +518,9 @@ mod tests {
             .transactions
             .insert(&Value::from(tx2.dict()))
             .unwrap();
-        for nullifier in tx2.nullifiers.set() {
-            state_root.transactions.insert(nullifier).unwrap();
+        for nullifier in tx2.nullifiers.iter() {
+            let nullifier = nullifier.unwrap();
+            state_root.transactions.insert(&nullifier).unwrap();
         }
     }
 }

--- a/txlib/src/lib.rs
+++ b/txlib/src/lib.rs
@@ -5,10 +5,11 @@ use std::{
     sync::Arc,
 };
 
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use pod2::middleware::{
+    EMPTY_VALUE, Hash, Key, Statement, Value,
     containers::{Array, Dictionary, Set},
-    hash_values, Hash, Key, Statement, Value, EMPTY_VALUE,
+    hash_values,
 };
 use pod2utils::{dict, dict_define, macros::BuildContext, rand_raw_value, set, st_custom};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};


### PR DESCRIPTION
I've also changed all String errors in tauri-src to `anyhow::Error` for better ergonomics, this way we can just return any error from functions without manually turning them into strings.  For the `tauri::command` I added a new error that can be serialized and that implements `From<anyhow::Error>`

The changes related to the new Value API look like this:
- Casting a Value.
  - Before: `i64::try_from(value.typed_value())...`
  - After: `value.as_int()`
- Getting the raw from a Value (I think this change could have been done even before)
  - Before `RawValue::from(value)`
  - After: `value.as_raw()`
- Removed all references of `TypedValue` in favor of just `Value`