### PR TITLE
Fix pod value parsing

### DIFF
--- a/app-gui/src/features/context/ContextPanel.tsx
+++ b/app-gui/src/features/context/ContextPanel.tsx
@@ -16,6 +16,7 @@ import {
   isLiveObject,
   joinObjectsDirPath,
 } from "../../shared/objectUtils";
+import { isRecord, normalizePod2Value } from "../../shared/pod2utils";
 import type { ContextSelection } from "../../shared/state/store";
 
 interface ContextPanelProps {
@@ -426,54 +427,6 @@ export function ContextPanel({
     return displayPathInObjectsDir(absolutePath, objectsDirPath);
   };
 
-  const normalizePod2Value = (value: unknown): unknown => {
-    if (typeof value === "string") {
-      return value
-        .trim()
-        .replace(/^Raw\((.*)\)$/, "$1")
-        .trim();
-    }
-    if (
-      typeof value === "number" ||
-      typeof value === "boolean" ||
-      typeof value === "bigint" ||
-      value == null
-    ) {
-      return value;
-    }
-    if (Array.isArray(value)) {
-      return value.map((entry) => normalizePod2Value(entry));
-    }
-    if (typeof value === "object") {
-      const record = value as Record<string, unknown>;
-      const keys = Object.keys(record);
-      if (keys.length === 1) {
-        const key = keys[0];
-        const inner = record[key];
-        if (
-          key === "Raw" ||
-          key === "Int" ||
-          key === "PublicKey" ||
-          key === "SecretKey" ||
-          key === "Predicate" ||
-          key === "Root" ||
-          key === "kvs" ||
-          key === "set" ||
-          key === "array"
-        ) {
-          return normalizePod2Value(inner);
-        }
-      }
-      return Object.fromEntries(
-        Object.entries(record).map(([key, entry]) => [
-          key,
-          normalizePod2Value(entry),
-        ]),
-      );
-    }
-    return value;
-  };
-
   const objectValueString = (value: unknown) => {
     const normalized = normalizePod2Value(value);
     if (typeof normalized === "string") return normalized;
@@ -521,16 +474,12 @@ export function ContextPanel({
   };
 
   const renderObjectData = (object: InventoryObject) => {
-    const topLevelEntries = Object.entries(object.obj);
-    const entries = (() => {
-      if (topLevelEntries.length === 1 && topLevelEntries[0][0] === "kvs") {
-        const kvs = topLevelEntries[0][1];
-        if (typeof kvs === "object" && kvs !== null) {
-          return Object.entries(kvs as Record<string, unknown>);
-        }
-      }
-      return topLevelEntries;
-    })().sort(([left], [right]) => left.localeCompare(right));
+    const normalizedObject = normalizePod2Value(object.obj);
+    const entries = isRecord(normalizedObject)
+      ? Object.entries(normalizedObject).sort(([left], [right]) =>
+          left.localeCompare(right),
+        )
+      : [["value", normalizedObject] as const];
 
     if (entries.length === 0) return null;
 

--- a/app-gui/src/shared/api/wireTypes.ts
+++ b/app-gui/src/shared/api/wireTypes.ts
@@ -12,7 +12,7 @@ export interface InventoryObjectPayload {
   nullifier: string | null;
   grounded: boolean;
   description?: string;
-  obj: Record<string, unknown>;
+  obj: unknown;
 }
 
 export interface ActionPayload {

--- a/app-gui/src/shared/pod2utils.ts
+++ b/app-gui/src/shared/pod2utils.ts
@@ -1,0 +1,126 @@
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isPod2IntWrapper(value: unknown): value is { Int: string | number } {
+  return isRecord(value) && Object.keys(value).length === 1 && "Int" in value;
+}
+
+function parsePod2IntWrapper(value: unknown): number | null {
+  if (!isPod2IntWrapper(value)) return null;
+  const raw = value.Int;
+  const parsed = typeof raw === "number" ? raw : Number.parseInt(String(raw), 10);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function normalizePod2ContainerInner(value: unknown): unknown {
+  if (!Array.isArray(value)) {
+    return value;
+  }
+
+  const tupleEntries = value.every(
+    (entry) => Array.isArray(entry) && entry.length >= 1 && entry.length <= 2,
+  )
+    ? (value as unknown[][])
+    : null;
+
+  if (!tupleEntries) {
+    return value.map((entry) => normalizePod2Value(entry));
+  }
+
+  if (tupleEntries.every((entry) => entry.length === 1)) {
+    return tupleEntries.map(([entry]) => normalizePod2Value(entry));
+  }
+
+  if (
+    tupleEntries.every(
+      (entry) => entry.length === 2 && typeof entry[0] === "string",
+    )
+  ) {
+    return Object.fromEntries(
+      tupleEntries.map(([key, entry]) => [key as string, normalizePod2Value(entry)]),
+    );
+  }
+
+  if (
+    tupleEntries.every(
+      (entry) => entry.length === 2 && parsePod2IntWrapper(entry[0]) !== null,
+    )
+  ) {
+    return tupleEntries
+      .map(([index, entry]) => [
+        parsePod2IntWrapper(index) ?? 0,
+        normalizePod2Value(entry),
+      ] as const)
+      .sort((left, right) => left[0] - right[0])
+      .map(([, entry]) => entry);
+  }
+
+  return tupleEntries.map((entry) =>
+    entry.map((item) => normalizePod2Value(item)),
+  );
+}
+
+function normalizePod2Value(value: unknown): unknown {
+  if (typeof value === "string") {
+    return value
+      .trim()
+      .replace(/^Raw\((.*)\)$/, "$1")
+      .trim();
+  }
+
+  if (
+    typeof value === "number" ||
+    typeof value === "boolean" ||
+    typeof value === "bigint" ||
+    value == null
+  ) {
+    return value;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((entry) => normalizePod2Value(entry));
+  }
+
+  if (!isRecord(value)) {
+    return value;
+  }
+
+  const keys = Object.keys(value);
+  if (keys.length === 1) {
+    const key = keys[0];
+    const inner = value[key];
+
+    if (
+      key === "Raw" ||
+      key === "Int" ||
+      key === "PublicKey" ||
+      key === "SecretKey" ||
+      key === "Predicate" ||
+      key === "Root" ||
+      key === "set" ||
+      key === "array"
+    ) {
+      return normalizePod2Value(inner);
+    }
+
+    if (key === "kvs" && isRecord(inner)) {
+      return Object.fromEntries(
+        Object.entries(inner).map(([entryKey, entryValue]) => [
+          entryKey,
+          normalizePod2Value(entryValue),
+        ]),
+      );
+    }
+
+    if (key === "inner") {
+      return normalizePod2ContainerInner(inner);
+    }
+  }
+
+  return Object.fromEntries(
+    Object.entries(value).map(([key, entry]) => [key, normalizePod2Value(entry)]),
+  );
+}
+
+export { isRecord, normalizePod2Value };


### PR DESCRIPTION
pod2 version was bumped in https://github.com/dobjlabs/zk-craft/pull/56, which changed the type of `Dictionary` in pod2. 

This PR updates the frontend parsing code to properly render with the new type. Otherwise, it renders as:

<img width="413" height="234" alt="Screenshot 2026-03-18 at 6 10 28 PM" src="https://github.com/user-attachments/assets/10b35b70-816b-4f27-89d2-4fe0b21549f8" />

Fixed:
<img width="413" height="225" alt="image" src="https://github.com/user-attachments/assets/b1ce0553-953d-4302-addc-195596708e04" />

