### PR TITLE
parallel batch fetch for synchronizer catch-up

### DIFF
--- a/mprocs.yaml
+++ b/mprocs.yaml
@@ -1,7 +1,7 @@
 procs:
   synchronizer:
-    shell: just sync
+    shell: just sync 2>&1 | tee logs/synchronizer.log
   relayer:
-    shell: just relayer
+    shell: just relayer 2>&1 | tee logs/relayer.log
   gui:
-    shell: just gui
+    shell: just gui 2>&1 | tee logs/gui.log

--- a/mprocs.yaml
+++ b/mprocs.yaml
@@ -1,7 +1,7 @@
 procs:
   synchronizer:
-    shell: just sync 2>&1 | tee logs/synchronizer.log
+    shell: just sync
   relayer:
-    shell: just relayer 2>&1 | tee logs/relayer.log
+    shell: just relayer
   gui:
-    shell: just gui 2>&1 | tee logs/gui.log
+    shell: just gui

--- a/synchronizer/.env.example
+++ b/synchronizer/.env.example
@@ -7,7 +7,10 @@ TO_ADDRESS=0x4343434343434343434343434343434343434343
 # HTTP_BIND=127.0.0.1:3000
 # APP_STATE_DB_PATH=data/synchronizer-db
 # SYNC_METADATA_DB_URL=postgres://postgres@localhost:5432/synchronizer
-# SYNC_DELAY_MS=333
 # RPC_RETRIES=6
 # RPC_RETRY_MS=1000
 # INITIAL_START_SLOT=
+
+# Rate-limit-aware defaults (derived from 15 req/s RPC limit):
+# SYNC_DELAY_MS=173          # delay between slots at head; override with caution
+# CATCHUP_BATCH_SIZE=7       # parallel slot fetches during catch-up; override with caution

--- a/synchronizer/README.md
+++ b/synchronizer/README.md
@@ -202,10 +202,13 @@ Hash parsing accepts `0x`-prefixed or raw hex input; responses are normalized to
 - `APP_STATE_DB_PATH` (default: `data/synchronizer-db`)
 - `SYNC_METADATA_DB_URL` (default: `postgres://postgres@localhost:5432/synchronizer`)
 - `HTTP_BIND` (default: `127.0.0.1:3000`)
-- `SYNC_DELAY_MS` (default: `333`)
 - `RPC_RETRIES` (default: `6`)
 - `RPC_RETRY_MS` (default: `1000`)
 - `INITIAL_START_SLOT` (default: unset, meaning start from current head on first run)
+- `SYNC_DELAY_MS` (default: derived from RPC rate limit, currently `173`) — delay in ms between slots when at head. Override with caution to avoid exceeding the RPC rate limit.
+- `CATCHUP_BATCH_SIZE` (default: derived from RPC rate limit, currently `7`) — number of slots fetched concurrently during catch-up. Override with caution to avoid exceeding the RPC rate limit.
+
+The defaults for `SYNC_DELAY_MS` and `CATCHUP_BATCH_SIZE` are computed from the known RPC rate limit (15 req/s) to stay safely under the limit. If either is set via env, a warning is logged as a reminder to check rate limit compliance.
 
 ## Run
 

--- a/synchronizer/src/catchup.rs
+++ b/synchronizer/src/catchup.rs
@@ -1,0 +1,113 @@
+use anyhow::Result;
+use futures_util::future::join_all;
+use tracing::{info, warn};
+
+use crate::clients::beacon::types::{Block, BlockHeader};
+use crate::node::Node;
+
+/// Pre-fetched data for a single slot in a catch-up batch.
+pub enum FetchedSlot {
+    /// Slot had no block produced (skipped slot on beacon chain).
+    Missing { slot: u32 },
+    /// Slot had a block; header and full beacon block are available.
+    Present {
+        slot: u32,
+        header: BlockHeader,
+        block: Block,
+    },
+}
+
+/// Fetch beacon headers and full blocks for a batch of slots concurrently.
+///
+/// Returns results in slot order. Individual slot fetch failures are returned as `Err` entries
+/// so the caller can decide how to handle them (e.g. stop the batch at the first failure).
+pub async fn fetch_batch(node: &Node, slots: &[u32]) -> Vec<Result<FetchedSlot>> {
+    // Phase 1: fetch all headers concurrently.
+    let header_futures: Vec<_> = slots
+        .iter()
+        .map(|&slot| async move {
+            let header = node.get_beacon_slot_header_with_retry(slot).await?;
+            Ok::<_, anyhow::Error>((slot, header))
+        })
+        .collect();
+
+    let header_results = join_all(header_futures).await;
+
+    // Phase 2: for present headers, fetch full beacon blocks concurrently.
+    // Build futures only for slots that have headers.
+    let mut block_futures = Vec::new();
+    let mut slot_states: Vec<Option<Result<FetchedSlot>>> = Vec::with_capacity(slots.len());
+
+    for result in &header_results {
+        match result {
+            Ok((slot, Some(header))) => {
+                let slot = *slot;
+                let root = header.root;
+                let header_clone = header.clone();
+                block_futures.push(async move {
+                    let block = node.get_beacon_block_by_hash_with_retry(slot, root).await?;
+                    Ok::<_, anyhow::Error>((slot, header_clone, block))
+                });
+                // Placeholder — will be filled from block_futures results.
+                slot_states.push(None);
+            }
+            Ok((slot, None)) => {
+                slot_states.push(Some(Ok(FetchedSlot::Missing { slot: *slot })));
+            }
+            Err(err) => {
+                // Propagate the error. We can't move out of the borrowed result, so
+                // re-create an error with the same message.
+                slot_states.push(Some(Err(anyhow::anyhow!("{err:#}"))));
+            }
+        }
+    }
+
+    let block_results = join_all(block_futures).await;
+
+    // Merge block results back into slot_states in order.
+    let mut block_iter = block_results.into_iter();
+    for state in slot_states.iter_mut() {
+        if state.is_none() {
+            // This was a Present slot waiting for its block fetch.
+            let block_result = block_iter.next().expect("block futures count matches");
+            *state = Some(match block_result {
+                Ok((slot, header, block)) => Ok(FetchedSlot::Present {
+                    slot,
+                    header,
+                    block,
+                }),
+                Err(err) => Err(err),
+            });
+        }
+    }
+
+    let batch_size = slots.len();
+    let present_count = slot_states
+        .iter()
+        .filter(|s| matches!(s, Some(Ok(FetchedSlot::Present { .. }))))
+        .count();
+    let missing_count = slot_states
+        .iter()
+        .filter(|s| matches!(s, Some(Ok(FetchedSlot::Missing { .. }))))
+        .count();
+    let error_count = slot_states
+        .iter()
+        .filter(|s| matches!(s, Some(Err(_))))
+        .count();
+
+    info!(
+        batch_size,
+        present_count,
+        missing_count,
+        error_count,
+        first_slot = slots.first().copied().unwrap_or(0),
+        last_slot = slots.last().copied().unwrap_or(0),
+        "Batch fetch complete"
+    );
+
+    if error_count > 0 {
+        warn!(error_count, "Some slots in batch failed to fetch");
+    }
+
+    slot_states.into_iter().map(|s| s.unwrap()).collect()
+}

--- a/synchronizer/src/clients/common.rs
+++ b/synchronizer/src/clients/common.rs
@@ -223,7 +223,8 @@ pub(crate) async fn json_get<ExpectedResponse: DeserializeOwned>(
             tracing::warn!(
                 method = "GET",
                 url = %url,
-                // response = format!("{:?}", text.map(|t| t.as_str())),
+                status = status.as_u16(),
+                body = %text,
                 "Unexpected response from server"
             );
 

--- a/synchronizer/src/config.rs
+++ b/synchronizer/src/config.rs
@@ -9,6 +9,7 @@ const DEFAULT_HTTP_BIND: &str = "127.0.0.1:3000";
 const DEFAULT_SYNC_DELAY_MS: u64 = 333;
 const DEFAULT_RPC_RETRIES: u32 = 6;
 const DEFAULT_RPC_RETRY_MS: u64 = 1_000;
+const DEFAULT_CATCHUP_BATCH_SIZE: usize = 16;
 
 #[derive(Debug)]
 pub struct AppConfig {
@@ -18,6 +19,7 @@ pub struct AppConfig {
     pub sync_delay: Duration,
     pub rpc_retries: u32,
     pub rpc_retry_delay: Duration,
+    pub catchup_batch_size: usize,
     pub initial_start_slot: Option<u32>,
     pub rpc_url: String,
     pub beacon_url: String,
@@ -45,6 +47,10 @@ pub fn load_config() -> Result<AppConfig> {
         .ok()
         .and_then(|v| v.parse::<u64>().ok())
         .unwrap_or(DEFAULT_RPC_RETRY_MS);
+    let catchup_batch_size = dotenvy::var("CATCHUP_BATCH_SIZE")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .unwrap_or(DEFAULT_CATCHUP_BATCH_SIZE);
     let initial_start_slot = dotenvy::var("INITIAL_START_SLOT")
         .ok()
         .and_then(|v| v.parse::<u32>().ok());
@@ -60,6 +66,7 @@ pub fn load_config() -> Result<AppConfig> {
         sync_delay: Duration::from_millis(sync_delay_ms),
         rpc_retries,
         rpc_retry_delay: Duration::from_millis(rpc_retry_ms),
+        catchup_batch_size,
         initial_start_slot,
         rpc_url,
         beacon_url,

--- a/synchronizer/src/config.rs
+++ b/synchronizer/src/config.rs
@@ -2,14 +2,28 @@ use std::{net::SocketAddr, str::FromStr, time::Duration};
 
 use alloy::primitives::Address;
 use anyhow::Result;
+use tracing::warn;
 
 const DEFAULT_APP_STATE_DB_PATH: &str = "data/synchronizer-db";
 const DEFAULT_SYNC_METADATA_DB_URL: &str = "postgres://postgres@localhost:5432/synchronizer";
 const DEFAULT_HTTP_BIND: &str = "127.0.0.1:3000";
-const DEFAULT_SYNC_DELAY_MS: u64 = 333;
 const DEFAULT_RPC_RETRIES: u32 = 6;
 const DEFAULT_RPC_RETRY_MS: u64 = 1_000;
-const DEFAULT_CATCHUP_BATCH_SIZE: usize = 16;
+
+/// Known RPC rate limit. Used to derive safe defaults for batch size and sync delay.
+const RPC_RATE_LIMIT_PER_SEC: u64 = 15;
+
+/// Each slot in a batch makes ~2 RPC calls (header + block). Use half the rate limit to leave
+/// headroom for retries and the single-slot path.
+const fn default_catchup_batch_size() -> usize {
+    (RPC_RATE_LIMIT_PER_SEC as usize) / 2
+}
+
+/// At head, one slot makes ~2 RPC calls. Space them so we stay under the rate limit with margin.
+const fn default_sync_delay_ms() -> u64 {
+    // 2 calls per slot, so min interval = 2000/rate_limit. Add 30% margin.
+    (2 * 1000 * 130) / (RPC_RATE_LIMIT_PER_SEC * 100)
+}
 
 #[derive(Debug)]
 pub struct AppConfig {
@@ -35,10 +49,35 @@ pub fn load_config() -> Result<AppConfig> {
         .unwrap_or_else(|_| DEFAULT_SYNC_METADATA_DB_URL.to_string());
     let http_bind = dotenvy::var("HTTP_BIND").unwrap_or_else(|_| DEFAULT_HTTP_BIND.to_string());
     let http_bind: SocketAddr = http_bind.parse()?;
-    let sync_delay_ms = dotenvy::var("SYNC_DELAY_MS")
-        .ok()
-        .and_then(|v| v.parse::<u64>().ok())
-        .unwrap_or(DEFAULT_SYNC_DELAY_MS);
+
+    let sync_delay_ms = match dotenvy::var("SYNC_DELAY_MS") {
+        Ok(v) => {
+            let ms: u64 = v.parse()?;
+            warn!(
+                sync_delay_ms = ms,
+                rpc_rate_limit = RPC_RATE_LIMIT_PER_SEC,
+                default_ms = default_sync_delay_ms(),
+                "SYNC_DELAY_MS overridden via env; ensure this respects the RPC rate limit"
+            );
+            ms
+        }
+        Err(_) => default_sync_delay_ms(),
+    };
+
+    let catchup_batch_size = match dotenvy::var("CATCHUP_BATCH_SIZE") {
+        Ok(v) => {
+            let size: usize = v.parse()?;
+            warn!(
+                catchup_batch_size = size,
+                rpc_rate_limit = RPC_RATE_LIMIT_PER_SEC,
+                default_size = default_catchup_batch_size(),
+                "CATCHUP_BATCH_SIZE overridden via env; ensure this respects the RPC rate limit"
+            );
+            size
+        }
+        Err(_) => default_catchup_batch_size(),
+    };
+
     let rpc_retries = dotenvy::var("RPC_RETRIES")
         .ok()
         .and_then(|v| v.parse::<u32>().ok())
@@ -47,10 +86,6 @@ pub fn load_config() -> Result<AppConfig> {
         .ok()
         .and_then(|v| v.parse::<u64>().ok())
         .unwrap_or(DEFAULT_RPC_RETRY_MS);
-    let catchup_batch_size = dotenvy::var("CATCHUP_BATCH_SIZE")
-        .ok()
-        .and_then(|v| v.parse::<usize>().ok())
-        .unwrap_or(DEFAULT_CATCHUP_BATCH_SIZE);
     let initial_start_slot = dotenvy::var("INITIAL_START_SLOT")
         .ok()
         .and_then(|v| v.parse::<u32>().ok());

--- a/synchronizer/src/config.rs
+++ b/synchronizer/src/config.rs
@@ -67,6 +67,7 @@ pub fn load_config() -> Result<AppConfig> {
     let catchup_batch_size = match dotenvy::var("CATCHUP_BATCH_SIZE") {
         Ok(v) => {
             let size: usize = v.parse()?;
+            anyhow::ensure!(size > 0, "CATCHUP_BATCH_SIZE must be greater than 0");
             warn!(
                 catchup_batch_size = size,
                 rpc_rate_limit = RPC_RATE_LIMIT_PER_SEC,

--- a/synchronizer/src/main.rs
+++ b/synchronizer/src/main.rs
@@ -7,6 +7,7 @@ use tracing::{error, info};
 
 mod api;
 mod app_db;
+mod catchup;
 mod clients;
 mod config;
 mod head;

--- a/synchronizer/src/node.rs
+++ b/synchronizer/src/node.rs
@@ -307,41 +307,7 @@ impl Node {
         })
     }
 
-    /// Resolve the full consensus+execution context required to derive a present slot.
-    ///
-    /// The caller already has a canonical beacon header for this slot, so failure to load the
-    /// corresponding full beacon block or execution payload is treated as an error rather than as
-    /// an empty slot. This forces the sync loop to retry instead of silently advancing past a real
-    /// slot when the beacon provider is temporarily inconsistent.
-    async fn build_slot_context(&self, beacon_block_header: &BlockHeader) -> Result<SlotContext> {
-        let beacon_block_root = beacon_block_header.root;
-        let slot = beacon_block_header.slot;
-
-        let beacon_block = self
-            .get_beacon_block_by_hash_with_retry(slot, beacon_block_root)
-            .await?;
-
-        let execution_payload = beacon_block.execution_payload.as_ref().ok_or_else(|| {
-            anyhow!("Beacon block {beacon_block_root} for slot {slot} had no execution payload")
-        })?;
-
-        let has_blob_commitments = beacon_block
-            .blob_kzg_commitments
-            .as_ref()
-            .is_some_and(|commitments| !commitments.is_empty());
-
-        Ok(SlotContext {
-            slot,
-            beacon_block_root,
-            parent_root: beacon_block.parent_root,
-            execution_block_hash: execution_payload.block_hash,
-            execution_block_number: execution_payload.block_number,
-            execution_timestamp: execution_payload.timestamp,
-            has_blob_commitments,
-        })
-    }
-
-    /// Build a `SlotContext` from a pre-fetched beacon block without any network calls.
+    /// Build a `SlotContext` from a beacon header and its full block.
     fn slot_context_from_block(
         beacon_block_header: &BlockHeader,
         beacon_block: &Block,
@@ -369,12 +335,23 @@ impl Node {
         })
     }
 
+    /// Fetch the full beacon block for a header, then build the `SlotContext`.
+    async fn fetch_slot_context(&self, beacon_block_header: &BlockHeader) -> Result<SlotContext> {
+        let beacon_block = self
+            .get_beacon_block_by_hash_with_retry(
+                beacon_block_header.slot,
+                beacon_block_header.root,
+            )
+            .await?;
+        Self::slot_context_from_block(beacon_block_header, &beacon_block)
+    }
+
     /// Derive the full per-slot update from beacon/execution data and return it for commit.
     pub async fn derive_slot_update(
         &self,
         beacon_block_header: &BlockHeader,
     ) -> Result<ProcessedSlot> {
-        let slot_ctx = self.build_slot_context(beacon_block_header).await?;
+        let slot_ctx = self.fetch_slot_context(beacon_block_header).await?;
         self.derive_from_context(slot_ctx).await
     }
 

--- a/synchronizer/src/node.rs
+++ b/synchronizer/src/node.rs
@@ -338,10 +338,7 @@ impl Node {
     /// Fetch the full beacon block for a header, then build the `SlotContext`.
     async fn fetch_slot_context(&self, beacon_block_header: &BlockHeader) -> Result<SlotContext> {
         let beacon_block = self
-            .get_beacon_block_by_hash_with_retry(
-                beacon_block_header.slot,
-                beacon_block_header.root,
-            )
+            .get_beacon_block_by_hash_with_retry(beacon_block_header.slot, beacon_block_header.root)
             .await?;
         Self::slot_context_from_block(beacon_block_header, &beacon_block)
     }

--- a/synchronizer/src/node.rs
+++ b/synchronizer/src/node.rs
@@ -308,6 +308,10 @@ impl Node {
     }
 
     /// Build a `SlotContext` from a beacon header and its full block.
+    ///
+    /// Failure to extract the execution payload is treated as an error rather than as an empty
+    /// slot. This forces the sync loop to retry instead of silently advancing past a real slot
+    /// when the beacon provider is temporarily inconsistent.
     fn slot_context_from_block(
         beacon_block_header: &BlockHeader,
         beacon_block: &Block,

--- a/synchronizer/src/node.rs
+++ b/synchronizer/src/node.rs
@@ -341,13 +341,57 @@ impl Node {
         })
     }
 
+    /// Build a `SlotContext` from a pre-fetched beacon block without any network calls.
+    fn slot_context_from_block(
+        beacon_block_header: &BlockHeader,
+        beacon_block: &Block,
+    ) -> Result<SlotContext> {
+        let slot = beacon_block_header.slot;
+        let beacon_block_root = beacon_block_header.root;
+
+        let execution_payload = beacon_block.execution_payload.as_ref().ok_or_else(|| {
+            anyhow!("Beacon block {beacon_block_root} for slot {slot} had no execution payload")
+        })?;
+
+        let has_blob_commitments = beacon_block
+            .blob_kzg_commitments
+            .as_ref()
+            .is_some_and(|commitments| !commitments.is_empty());
+
+        Ok(SlotContext {
+            slot,
+            beacon_block_root,
+            parent_root: beacon_block.parent_root,
+            execution_block_hash: execution_payload.block_hash,
+            execution_block_number: execution_payload.block_number,
+            execution_timestamp: execution_payload.timestamp,
+            has_blob_commitments,
+        })
+    }
+
     /// Derive the full per-slot update from beacon/execution data and return it for commit.
     pub async fn derive_slot_update(
         &self,
         beacon_block_header: &BlockHeader,
     ) -> Result<ProcessedSlot> {
-        let base_head = self.sync_db.current_head().await?;
         let slot_ctx = self.build_slot_context(beacon_block_header).await?;
+        self.derive_from_context(slot_ctx).await
+    }
+
+    /// Like `derive_slot_update`, but uses a pre-fetched beacon block instead of fetching it.
+    pub async fn derive_slot_update_with_block(
+        &self,
+        beacon_block_header: &BlockHeader,
+        beacon_block: &Block,
+    ) -> Result<ProcessedSlot> {
+        let slot_ctx = Self::slot_context_from_block(beacon_block_header, beacon_block)?;
+        self.derive_from_context(slot_ctx).await
+    }
+
+    /// Shared derivation logic: given an already-resolved `SlotContext`, fetch execution data
+    /// as needed, run the state machine, and return the processed slot.
+    async fn derive_from_context(&self, slot_ctx: SlotContext) -> Result<ProcessedSlot> {
+        let base_head = self.sync_db.current_head().await?;
 
         debug!(
             slot = slot_ctx.slot,

--- a/synchronizer/src/sync_loop.rs
+++ b/synchronizer/src/sync_loop.rs
@@ -130,6 +130,10 @@ pub async fn run_sync_loop(
 
         // ── Single-slot path (at or near head) ──────────────────────────
         debug!(slot = next_slot, "Checking slot");
+        // Resolve the target slot against beacon head; may return:
+        // - Missing: canonical empty slot
+        // - Present: canonical block header for this slot
+        // - Shutdown: graceful stop
         let beacon_block_header = match head_tracker
             .next_slot_header(&node, next_slot, &mut shutdown_rx)
             .await?
@@ -152,6 +156,8 @@ pub async fn run_sync_loop(
             SlotHeaderState::Present(header) => header,
         };
 
+        // For present slots, centralize all "did canonical history diverge?" checks
+        // before any write side effects.
         if let Some(rewind_slot) =
             handle_reorgs_for_present_slot(&node, next_slot, &beacon_block_header).await?
         {

--- a/synchronizer/src/sync_loop.rs
+++ b/synchronizer/src/sync_loop.rs
@@ -7,6 +7,7 @@ use reqwest_eventsource::{Event, EventSource};
 use tokio::sync::watch;
 use tracing::{debug, info, warn};
 
+use crate::catchup::{self, FetchedSlot};
 use crate::node::{Node, ProcessedSlot};
 const HEAD_CHECK_INTERVAL: Duration = Duration::from_secs(12);
 
@@ -55,17 +56,80 @@ pub async fn run_sync_loop(
         events: None,
     };
 
+    let batch_size = node.config.catchup_batch_size;
+
     loop {
         if *shutdown_rx.borrow() {
             info!("Sync loop shutting down");
             return Ok(());
         }
 
+        let slots_behind = head_tracker.head.slot.saturating_sub(next_slot);
+
+        // ── Batch catch-up path ──────────────────────────────────────────
+        if slots_behind >= batch_size as u32 {
+            let batch_end = next_slot + batch_size as u32;
+            let slots: Vec<u32> = (next_slot..batch_end).collect();
+            info!(
+                first_slot = next_slot,
+                last_slot = batch_end - 1,
+                slots_behind,
+                batch_size,
+                "Starting batch catch-up"
+            );
+
+            let fetched = catchup::fetch_batch(&node, &slots).await;
+
+            let mut reorg_detected = false;
+            for result in fetched {
+                if *shutdown_rx.borrow() {
+                    info!("Sync loop shutting down");
+                    return Ok(());
+                }
+
+                match result? {
+                    FetchedSlot::Missing { slot } => {
+                        match handle_missing_slot(&node, slot).await? {
+                            MissingSlotAction::Rewound(rewind_slot) => {
+                                next_slot = rewind_slot;
+                                reorg_detected = true;
+                                break;
+                            }
+                            MissingSlotAction::Applied => {
+                                next_slot = slot + 1;
+                            }
+                        }
+                    }
+                    FetchedSlot::Present {
+                        slot,
+                        header,
+                        block,
+                    } => {
+                        if let Some(rewind_slot) =
+                            handle_reorgs_for_present_slot(&node, slot, &header).await?
+                        {
+                            next_slot = rewind_slot;
+                            reorg_detected = true;
+                            break;
+                        }
+
+                        let processed = node.derive_slot_update_with_block(&header, &block).await?;
+                        node.commit_slot(&processed).await?;
+                        next_slot = slot + 1;
+                    }
+                }
+            }
+
+            if reorg_detected {
+                // Re-fetch beacon head before restarting — chain view may have changed.
+                head_tracker.head = node.get_beacon_head_header_with_retry().await?;
+            }
+
+            continue;
+        }
+
+        // ── Single-slot path (at or near head) ──────────────────────────
         debug!(slot = next_slot, "Checking slot");
-        // Resolve the target slot against beacon head; may return:
-        // - Missing: canonical empty slot
-        // - Present: canonical block header for this slot
-        // - Shutdown: graceful stop
         let beacon_block_header = match head_tracker
             .next_slot_header(&node, next_slot, &mut shutdown_rx)
             .await?
@@ -88,8 +152,6 @@ pub async fn run_sync_loop(
             SlotHeaderState::Present(header) => header,
         };
 
-        // For present slots, centralize all "did canonical history diverge?" checks
-        // before any write side effects.
         if let Some(rewind_slot) =
             handle_reorgs_for_present_slot(&node, next_slot, &beacon_block_header).await?
         {


### PR DESCRIPTION
- When the synchronizer is behind the beacon head by more than `batch_size` slots, fetch headers and blocks in parallel batches instead of one-at-a-time, significantly reducing catch-up time
- Batch size and sync delay defaults are derived from the RPC rate limit (15 req/s) to stay within API limits automatically; both remain overridable via `CATCHUP_BATCH_SIZE` and `SYNC_DELAY_MS` env vars