### PR TITLE
fix: synchronizer misses blocks at slots_behind=0 due to stale head race

### DIFF
--- a/synchronizer/src/sync_loop.rs
+++ b/synchronizer/src/sync_loop.rs
@@ -346,7 +346,7 @@ impl HeadTracker {
         slot: u32,
         shutdown_rx: &mut watch::Receiver<bool>,
     ) -> Result<SlotHeaderState> {
-        if slot <= self.head.slot {
+        if slot < self.head.slot {
             info!(
                 next_slot = slot,
                 head_slot = self.head.slot,


### PR DESCRIPTION
### Bug

When the synchronizer catches up to the beacon head and reaches `slots_behind=0`, it enters the catching-up path which queries the beacon API for the slot by number (`GET /eth/v1/beacon/headers/{slot}`). However, the cached `head.slot` is stale, since it was fetched during a previous iteration. By the time the explicit slot query fires, the beacon node can return 404 if:
- The block hasn't been fully indexed yet (propagation delay on the CL node)
- A brief reorg orphaned the block between the head fetch and the slot query

The synchronizer then incorrectly commits the slot as empty ("No block produced for slot") and skips the execution-layer block entirely, thus permanently missing any transactions in it.

I observed this locally during testing where one of my objects didn't get finalized.

### Root cause
`next_slot_header` uses `slot <= self.head.slot` to enter the catching-up path, which re-queries by slot ID. When `slot == self.head.slot`, this races against beacon node indexing.

The event-based waiting path already handles this correctly via `resolve_slot_from_head`, which returns `Present(self.head.clone())` when `head.slot == slot`, so no extra API call, no race.

### Fix
Change `<=` to `<` in the catching-up guard so that `slot == head.slot falls` through to the event-based path, which uses the cached head directly and avoids the racy slot lookup.