### PR TITLE
fix: find_divergence_slot treats mutually empty slots as common ancestors

### DIFF
--- a/synchronizer/src/sync_loop.rs
+++ b/synchronizer/src/sync_loop.rs
@@ -273,8 +273,13 @@ async fn find_divergence_slot(node: &Node, current_slot: u32) -> Result<u32> {
             .get_beacon_slot_header_with_retry(prev_slot)
             .await?
             .map(|header| header.root);
-        if stored_root == live_root {
-            return Ok(prev_slot + 1);
+        match (stored_root, live_root) {
+            // Both sides agree on an actual block root: true common ancestor.
+            (Some(s), Some(l)) if s == l => return Ok(prev_slot + 1),
+            // Both empty: not a real anchor, keep walking.
+            (None, None) => {}
+            // Otherwise: diverged (roots differ, or one side has a block the other doesn't).
+            _ => {}
         }
         slot = prev_slot;
     }


### PR DESCRIPTION
### Bug
During reorg handling,`find_divergence_slot` walks backward to find the last slot where the local canonical history matches the beacon chain. It compares `stored_root` and `live_root` as `Option<B256>` values and treats equality as a match.

The problem: when both sides have no block for a slot (both `None`), `None == None` evaluates to true, so the function stops walking and declares that empty slot as the common ancestor. But an empty slot carries no block root, ie it doesn't actually anchor the chain. If there's a run of empty slots at the reorg boundary, the rewind stops too early and may not roll back to the true divergence point.

###  Example scenario:

- Slots 94 (block), 95 (empty), 96 (empty), 97 (block) are stored locally
- A reorg replaces slot 97's block
- `find_divergence_slot` walks back from 97: slot 96 is `None == None` → match found, rewind to 97
- But slot 94's block could also have been reorged, so the empty slots at 95-96 don't prove anything about slots before them

### Fix

Only treat a slot as a common ancestor when both sides have an actual block root and they agree (`Some(s) == Some(l)`). Skip mutually empty slots and keep walking backward until a real anchored match is found.