### PR TITLE
match object structure v0 doc

### DIFF
--- a/app-gui/README.md
+++ b/app-gui/README.md
@@ -6,7 +6,7 @@ The app is a Tauri shell around:
 
 - React frontend (`src/`)
 - Rust command layer (`src-tauri/`)
-- local object store (`~/.objects`)
+- local object store (`~/.dobj/objects`)
 
 ## Current architecture
 
@@ -59,7 +59,7 @@ Action execution (`run_action`) does:
 3. Execute the action in `craft_sdk` using that grounding witness.
 4. Submit the proof payload to the relayer.
 5. Wait for relayer confirmation, then wait for the synchronizer to index the new tx.
-6. Write outputs to `~/.objects` and move consumed inputs to `~/.objects/.nullified`.
+6. Write outputs to `~/.dobj/objects` and move consumed inputs to `~/.dobj/objects/.nullified`.
 7. Emit progress events to the UI.
 
 In addition to action runs, UI polling does:

--- a/app-gui/src-tauri/src/bootstrap.rs
+++ b/app-gui/src-tauri/src/bootstrap.rs
@@ -12,7 +12,7 @@ pub struct InventoryObject {
     pub class_name: String,
     pub class_hash: String,
     pub emoji: String,
-    pub nullifier: Option<String>,
+    pub status: driver::ObjectStatus,
     pub grounded: bool,
     pub description: Option<String>,
     pub obj: serde_json::Value,
@@ -66,7 +66,7 @@ pub async fn load_gui_inventory(
                     emoji: class_info
                         .map(|class_info| class_info.emoji.clone())
                         .unwrap_or_else(|| "📦".to_string()),
-                    nullifier: object.nullifier,
+                    status: object.status,
                     grounded: object.grounded.unwrap_or(false),
                     description: class_info.map(|class_info| class_info.description.clone()),
                     obj: serde_json::Value::Object(object.fields.into_iter().collect()),

--- a/app-gui/src-tauri/src/bootstrap.rs
+++ b/app-gui/src-tauri/src/bootstrap.rs
@@ -13,6 +13,7 @@ pub struct InventoryObject {
     pub class_hash: String,
     pub emoji: String,
     pub status: driver::ObjectStatus,
+    pub tx_hash: Option<String>,
     pub grounded: bool,
     pub description: Option<String>,
     pub obj: serde_json::Value,
@@ -67,6 +68,7 @@ pub async fn load_gui_inventory(
                         .map(|class_info| class_info.emoji.clone())
                         .unwrap_or_else(|| "📦".to_string()),
                     status: object.status,
+                    tx_hash: object.tx_hash,
                     grounded: object.grounded.unwrap_or(false),
                     description: class_info.map(|class_info| class_info.description.clone()),
                     obj: serde_json::Value::Object(object.fields.into_iter().collect()),

--- a/app-gui/src-tauri/src/mcp.rs
+++ b/app-gui/src-tauri/src/mcp.rs
@@ -69,6 +69,7 @@ impl CraftOps for AppCraftOps {
             id: object.id,
             class_name: object.class_name,
             status: status_string(object.status),
+            tx_hash: object.tx_hash,
             state: object.fields,
             predicate_source: object.predicate_source,
         })
@@ -139,6 +140,7 @@ impl CraftOps for AppCraftOps {
                     class_name: detail.class_name,
                     file_name: detail.file_name,
                     status: status_string(detail.status),
+                    tx_hash: detail.tx_hash,
                     fields: detail.fields,
                 })
             })
@@ -194,6 +196,7 @@ fn to_mcp_inventory_object(object: ::driver::ObjectSummary) -> mcp::InventoryObj
         class_name: object.class_name,
         file_name: object.file_name,
         status: status_string(object.status),
+        tx_hash: object.tx_hash,
         fields: object.fields,
     }
 }

--- a/app-gui/src-tauri/src/mcp.rs
+++ b/app-gui/src-tauri/src/mcp.rs
@@ -68,7 +68,7 @@ impl CraftOps for AppCraftOps {
         Ok(mcp::ObjectDetail {
             id: object.id,
             class_name: object.class_name,
-            live: object.live,
+            status: status_string(object.status),
             state: object.fields,
             predicate_source: object.predicate_source,
         })
@@ -138,7 +138,7 @@ impl CraftOps for AppCraftOps {
                     id: detail.id,
                     class_name: detail.class_name,
                     file_name: detail.file_name,
-                    live: detail.live,
+                    status: status_string(detail.status),
                     fields: detail.fields,
                 })
             })
@@ -178,12 +178,22 @@ impl CraftOps for AppCraftOps {
     }
 }
 
+fn status_string(status: ::driver::ObjectStatus) -> String {
+    match status {
+        ::driver::ObjectStatus::Unknown => "unknown",
+        ::driver::ObjectStatus::Pending => "pending",
+        ::driver::ObjectStatus::Live => "live",
+        ::driver::ObjectStatus::Nullified => "nullified",
+    }
+    .to_string()
+}
+
 fn to_mcp_inventory_object(object: ::driver::ObjectSummary) -> mcp::InventoryObject {
     mcp::InventoryObject {
         id: object.id,
         class_name: object.class_name,
         file_name: object.file_name,
-        live: object.live,
+        status: status_string(object.status),
         fields: object.fields,
     }
 }

--- a/app-gui/src/App.tsx
+++ b/app-gui/src/App.tsx
@@ -26,7 +26,7 @@ import "./features/actions/ActionGrid.css";
 import "./features/settings/SettingsModal.css";
 
 function App() {
-  const [objectsDirPath, setObjectsDirPath] = useState("~/.objects");
+  const [objectsDirPath, setObjectsDirPath] = useState("~/.dobj/objects");
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [initialHydrationPending, setInitialHydrationPending] = useState(true);
   const inventory = useStore((state) => state.inventory);
@@ -78,7 +78,7 @@ function App() {
         if (!cancelled) setObjectsDirPath(path);
       })
       .catch(() => {
-        if (!cancelled) setObjectsDirPath("~/.objects");
+        if (!cancelled) setObjectsDirPath("~/.dobj/objects");
       });
     return () => {
       cancelled = true;

--- a/app-gui/src/features/context/ContextPanel.css
+++ b/app-gui/src/features/context/ContextPanel.css
@@ -87,6 +87,14 @@
   font-family: "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
 }
 
+.context-inline-hash.unknown {
+  color: var(--text-dim);
+}
+
+.context-inline-hash.pending {
+  color: var(--warn);
+}
+
 .context-inline-hash.live {
   color: var(--good);
 }

--- a/app-gui/src/features/context/ContextPanel.tsx
+++ b/app-gui/src/features/context/ContextPanel.tsx
@@ -14,6 +14,7 @@ import {
   displayPathInObjectsDir,
   displayObjectFileName,
   isLiveObject,
+  isNullifiedObject,
   joinObjectsDirPath,
 } from "../../shared/objectUtils";
 import { isRecord, normalizePod2Value } from "../../shared/pod2utils";
@@ -230,7 +231,7 @@ export function ContextPanel({
     }
 
     const className = parsed.className.trim();
-    const objectIsLive = parsed.status !== "nullified";
+    const objectIsLive = parsed.status === "live";
     const fileLabel = displayObjectFileName(className);
 
     if (!className) {
@@ -422,7 +423,7 @@ export function ContextPanel({
   const displayThingPath = (object: InventoryObject) => {
     const displayName = displayObjectFileName(object.className);
     const absolutePath = joinObjectsDirPath(objectsDirPath, displayName, {
-      nullified: !isLiveObject(object),
+      nullified: isNullifiedObject(object),
     });
     return displayPathInObjectsDir(absolutePath, objectsDirPath);
   };
@@ -523,7 +524,7 @@ export function ContextPanel({
       return <section className="context-panel">Object not found.</section>;
 
     const titleName = object.className;
-    const liveValueRaw = isLiveObject(object)
+    const liveValueRaw = object.status === "live"
       ? object.id
       : object.status;
     const liveValue = truncateDisplayHash(liveValueRaw);
@@ -548,7 +549,7 @@ export function ContextPanel({
           {renderMetaRow(
             "Live",
             <span
-              className={`context-inline-hash ${isLiveObject(object) ? "live" : "nullified"}`}
+              className={`context-inline-hash ${object.status}`}
               title={liveValueRaw}
             >
               {liveValue}

--- a/app-gui/src/features/context/ContextPanel.tsx
+++ b/app-gui/src/features/context/ContextPanel.tsx
@@ -217,7 +217,7 @@ export function ContextPanel({
 
     let parsed: {
       className: string;
-      nullifier: string | null;
+      status: string;
     };
     try {
       parsed = await readDobjFile(selectedPath);
@@ -230,7 +230,7 @@ export function ContextPanel({
     }
 
     const className = parsed.className.trim();
-    const objectIsLive = parsed.nullifier === null;
+    const objectIsLive = parsed.status !== "nullified";
     const fileLabel = displayObjectFileName(className);
 
     if (!className) {
@@ -525,7 +525,7 @@ export function ContextPanel({
     const titleName = object.className;
     const liveValueRaw = isLiveObject(object)
       ? object.id
-      : (object.nullifier ?? "nullified");
+      : object.status;
     const liveValue = truncateDisplayHash(liveValueRaw);
 
     return (

--- a/app-gui/src/features/inventory/InventoryPanel.css
+++ b/app-gui/src/features/inventory/InventoryPanel.css
@@ -114,12 +114,16 @@
   flex-shrink: 0;
 }
 
-.inventory-dot.live {
-  background: var(--good);
+.inventory-dot.unknown {
+  background: var(--text-dim);
 }
 
 .inventory-dot.pending {
   background: var(--warn);
+}
+
+.inventory-dot.live {
+  background: var(--good);
 }
 
 .inventory-dot.nullified {

--- a/app-gui/src/features/inventory/InventoryPanel.tsx
+++ b/app-gui/src/features/inventory/InventoryPanel.tsx
@@ -6,6 +6,7 @@ import {
   displayPathInObjectsDir,
   displayObjectFileName,
   isLiveObject,
+  isNullifiedObject,
   joinObjectsDirPath,
 } from "../../shared/objectUtils";
 
@@ -30,8 +31,7 @@ export function InventoryPanel({
 }: InventoryPanelProps) {
   const isDraggingRef = useRef(false);
 
-  const isUsable = (object: InventoryObject) =>
-    isLiveObject(object) && object.grounded;
+  const isUsable = (object: InventoryObject) => isLiveObject(object);
 
   const handleDragStart = (
     event: DragEvent<HTMLButtonElement>,
@@ -65,12 +65,12 @@ export function InventoryPanel({
     onSelectObject(objectId);
   };
 
-  const liveObjects = inventory.filter((object) => isLiveObject(object));
-  const nullifiedObjects = inventory.filter((object) => !isLiveObject(object));
+  const activeObjects = inventory.filter((object) => !isNullifiedObject(object));
+  const nullifiedObjects = inventory.filter((object) => isNullifiedObject(object));
 
   const renderInventoryObject = (object: InventoryObject) => {
     const displayName = displayObjectFileName(object.className);
-    const hashLineRaw = isLiveObject(object)
+    const hashLineRaw = object.status === "live"
       ? object.id
       : object.status;
     const hashLine = truncateDisplayHash(hashLineRaw);
@@ -94,8 +94,8 @@ export function InventoryPanel({
           </span>
         </span>
         <span
-          className={`inventory-dot ${!isLiveObject(object) ? "nullified" : object.grounded ? "live" : "pending"}`}
-          title={isLiveObject(object) && !object.grounded ? "pending confirmation" : undefined}
+          className={`inventory-dot ${object.status}`}
+          title={object.status !== "live" && object.status !== "nullified" ? object.status : undefined}
         />
       </button>
     );
@@ -113,7 +113,7 @@ export function InventoryPanel({
       </button>
 
       <div className="inventory-list">
-        {liveObjects.map(renderInventoryObject)}
+        {activeObjects.map(renderInventoryObject)}
 
         {nullifiedObjects.length > 0 && (
           <div className="nullified-section">

--- a/app-gui/src/features/inventory/InventoryPanel.tsx
+++ b/app-gui/src/features/inventory/InventoryPanel.tsx
@@ -72,7 +72,7 @@ export function InventoryPanel({
     const displayName = displayObjectFileName(object.className);
     const hashLineRaw = isLiveObject(object)
       ? object.id
-      : (object.nullifier ?? "nullified");
+      : object.status;
     const hashLine = truncateDisplayHash(hashLineRaw);
     return (
       <button

--- a/app-gui/src/shared/api/wireTypes.ts
+++ b/app-gui/src/shared/api/wireTypes.ts
@@ -12,6 +12,7 @@ export interface InventoryObjectPayload {
   classHash: string;
   emoji: string;
   status: ObjectStatus;
+  txHash: string | null;
   grounded: boolean;
   description?: string;
   obj: unknown;
@@ -50,6 +51,7 @@ export interface ObjectRecordPayload {
   id: string;
   className: ClassName;
   status: ObjectStatus;
+  txHash: string | null;
   pod: unknown;
   obj: unknown;
   tx: unknown;

--- a/app-gui/src/shared/api/wireTypes.ts
+++ b/app-gui/src/shared/api/wireTypes.ts
@@ -3,13 +3,15 @@ import type { ActionId, ClassName } from "../generated/ids";
 export type ProofPhase = "generateProof" | "commit";
 export type ProofProgressStatus = "running" | "done";
 
+export type ObjectStatus = "unknown" | "pending" | "live" | "nullified";
+
 export interface InventoryObjectPayload {
   id: string;
   fileName: string;
   className: ClassName;
   classHash: string;
   emoji: string;
-  nullifier: string | null;
+  status: ObjectStatus;
   grounded: boolean;
   description?: string;
   obj: unknown;
@@ -47,8 +49,7 @@ export interface RunActionResult {
 export interface ObjectRecordPayload {
   id: string;
   className: ClassName;
-  sourceAction: ActionId;
-  nullifier: string | null;
+  status: ObjectStatus;
   pod: unknown;
   obj: unknown;
   tx: unknown;

--- a/app-gui/src/shared/objectUtils.ts
+++ b/app-gui/src/shared/objectUtils.ts
@@ -3,7 +3,11 @@ interface ObjectLike {
 }
 
 export function isLiveObject(object: ObjectLike): boolean {
-  return object.status !== "nullified";
+  return object.status === "live";
+}
+
+export function isNullifiedObject(object: ObjectLike): boolean {
+  return object.status === "nullified";
 }
 
 export function displayObjectFileName(className: string): string {

--- a/app-gui/src/shared/objectUtils.ts
+++ b/app-gui/src/shared/objectUtils.ts
@@ -1,9 +1,9 @@
 interface ObjectLike {
-  nullifier: string | null;
+  status: string;
 }
 
 export function isLiveObject(object: ObjectLike): boolean {
-  return object.nullifier == null;
+  return object.status !== "nullified";
 }
 
 export function displayObjectFileName(className: string): string {

--- a/app-gui/src/styles/shared.css
+++ b/app-gui/src/styles/shared.css
@@ -26,7 +26,7 @@
 }
 
 .panel-header-button::after {
-  content: "open ~/.objects/";
+  content: "open ~/.dobj/objects/";
   position: absolute;
   left: 12px;
   top: calc(100% + 4px);

--- a/driver/README.md
+++ b/driver/README.md
@@ -4,7 +4,7 @@ Headless Rust library for working with local digital objects.
 
 This crate is the non-Tauri backend used by `app-gui`. It owns:
 
-- local object storage under `~/.objects`
+- local object storage under `~/.dobj/objects`
 - settings loading/saving
 - the built-in action and class catalog
 - synchronizer and relayer HTTP integration
@@ -84,9 +84,9 @@ Important public types are defined in [`src/types.rs`](src/types.rs):
 
 Default paths are defined in [`src/paths.rs`](src/paths.rs).
 
-- settings file: `dirs::config_dir()/com.dobjlabs.zk-craft/settings.json`
-- objects dir: `~/.objects`
-- nullified dir: `~/.objects/.nullified`
+- settings file: `~/.dobj/settings.json`
+- objects dir: `~/.dobj/objects`
+- nullified dir: `~/.dobj/objects/.nullified`
 
 Current settings are intentionally small:
 
@@ -119,11 +119,11 @@ Object files stay backward-compatible with the existing `.dobj` JSON schema. The
 
 Live objects are stored in:
 
-- `~/.objects`
+- `~/.dobj/objects`
 
 Consumed objects are moved to:
 
-- `~/.objects/.nullified`
+- `~/.dobj/objects/.nullified`
 
 File names are preserved as:
 

--- a/driver/src/clients/relayer_client.rs
+++ b/driver/src/clients/relayer_client.rs
@@ -22,6 +22,14 @@ pub trait RelayerClient: Send + Sync {
         payload_bytes: &[u8],
         client_ref: Option<String>,
     ) -> Result<SubmitProofResponse>;
+    /// Poll until the relayer has broadcast the transaction and a tx_hash is available.
+    fn wait_for_tx_hash(
+        &self,
+        relayer_api_url: &str,
+        job_id: &str,
+        timeout_secs: u64,
+        poll_interval_ms: u64,
+    ) -> Result<String>;
     fn wait_for_confirmation(
         &self,
         relayer_api_url: &str,
@@ -103,6 +111,42 @@ impl RelayerClient for HttpRelayerClient {
 
         serde_json::from_str::<SubmitProofResponse>(&body)
             .map_err(|err| anyhow!("failed to decode relayer submit response: {err}; body={body}"))
+    }
+
+    fn wait_for_tx_hash(
+        &self,
+        relayer_api_url: &str,
+        job_id: &str,
+        timeout_secs: u64,
+        poll_interval_ms: u64,
+    ) -> Result<String> {
+        let timeout = Duration::from_secs(timeout_secs);
+        let poll_interval = Duration::from_millis(poll_interval_ms);
+        let start = Instant::now();
+
+        loop {
+            let status = self.fetch_job_status(relayer_api_url, job_id)?;
+            if let Some(tx_hash) = status.tx_hash {
+                return Ok(tx_hash);
+            }
+            if status.status == JobStatus::Failed {
+                return Err(anyhow!(
+                    "relayer job {} failed before broadcast: {}",
+                    status.job_id,
+                    status
+                        .last_error
+                        .unwrap_or_else(|| "unknown error".to_string())
+                ));
+            }
+            if start.elapsed() >= timeout {
+                return Err(anyhow!(
+                    "timed out waiting for tx hash on relayer job {} after {}s",
+                    job_id,
+                    timeout_secs
+                ));
+            }
+            std::thread::sleep(poll_interval);
+        }
     }
 
     fn wait_for_confirmation(

--- a/driver/src/driver.rs
+++ b/driver/src/driver.rs
@@ -144,16 +144,15 @@ impl Driver {
             .iter()
             .map(|entry| entry.record.spendable().tx.dict().commitment())
             .collect::<HashSet<_>>();
-        let live_nullifiers = entries
+        let all_nullifiers = entries
             .iter()
-            .filter(|entry| !entry.record.is_nullified())
             .filter_map(|entry| object_nullifier_hash(&entry.record.obj).ok())
             .collect::<HashSet<_>>();
 
         let membership = self.deps.synchronizer.fetch_membership_with_nullifiers(
             &settings.synchronizer_api_url,
             &source_tx_hashes.iter().copied().collect::<Vec<_>>(),
-            &live_nullifiers.iter().copied().collect::<Vec<_>>(),
+            &all_nullifiers.iter().copied().collect::<Vec<_>>(),
         )?;
 
         reconcile_objects(

--- a/driver/src/driver.rs
+++ b/driver/src/driver.rs
@@ -367,25 +367,31 @@ impl Driver {
         };
 
         // Past this point the proof has been accepted by the relayer and may
-        // land on-chain at any moment. The output
-        // files stay as `unknown` and the inputs stay nullified. The next
-        // `sync_inventory` call will reconcile once the tx is observed.
+        // land on-chain at any moment. Output files stay as Unknown until the
+        // relayer broadcasts and we have a tx_hash.
         let waiting_label = format!("Waiting for relayer job {}", submit_response.job_id);
         reporter.on_step(ExecutionPhase::Commit, &waiting_label, &commit_ctx);
-        let confirmation = self.deps.relayer.wait_for_confirmation(
+
+        // Poll until the relayer has broadcast the tx and we have a tx_hash,
+        // then mark output files as Pending.
+        let eth_tx_hash = self.deps.relayer.wait_for_tx_hash(
             &settings.relayer_api_url,
             &submit_response.job_id,
             RELAYER_POLL_TIMEOUT_SECS,
             RELAYER_POLL_INTERVAL_MS,
         )?;
-
-        // Confirmation returned an Ethereum tx hash — update outputs to Pending.
-        let eth_tx_hash = confirmation.tx_hash.as_deref();
         update_output_files(
             &self.paths,
             &saved.output_files,
             ObjectStatus::Pending,
-            eth_tx_hash,
+            Some(&eth_tx_hash),
+        )?;
+
+        let confirmation = self.deps.relayer.wait_for_confirmation(
+            &settings.relayer_api_url,
+            &submit_response.job_id,
+            RELAYER_POLL_TIMEOUT_SECS,
+            RELAYER_POLL_INTERVAL_MS,
         )?;
 
         reporter.on_step(
@@ -408,7 +414,7 @@ impl Driver {
                     &self.paths,
                     &saved.output_files,
                     ObjectStatus::Unknown,
-                    eth_tx_hash,
+                    Some(&eth_tx_hash),
                 )?;
                 return Err(err);
             }
@@ -419,7 +425,7 @@ impl Driver {
             &self.paths,
             &saved.output_files,
             ObjectStatus::Live,
-            eth_tx_hash,
+            Some(&eth_tx_hash),
         )?;
 
         let result = ExecuteActionResult {
@@ -428,7 +434,7 @@ impl Driver {
             output_files: saved.output_files.clone(),
             nullified_files: saved.nullified_files.clone(),
             relayer_job_id: confirmation.job_id,
-            tx_hash: confirmation.tx_hash,
+            tx_hash: Some(eth_tx_hash),
             block_number: confirmation.block_number,
         };
         reporter.on_done(ExecutionPhase::Commit, Some(&result));

--- a/driver/src/driver.rs
+++ b/driver/src/driver.rs
@@ -338,65 +338,65 @@ impl Driver {
             &spendable_outputs,
         )?;
 
-        let commit_result: Result<ExecuteActionResult> = (|| {
-            reporter.on_step(
-                ExecutionPhase::Commit,
-                "Submitting proof to relayer",
-                &commit_ctx,
-            );
-            let submit_response = self.deps.relayer.submit_proof(
-                &settings.relayer_api_url,
-                &payload_bytes,
-                Some(format!("driver:{}", input.action_id)),
-            )?;
-            if submit_response.status == relayer::api_types::JobStatus::Failed {
-                return Err(anyhow!(
-                    "relayer rejected job {} immediately",
-                    submit_response.job_id
-                ));
+        // Submit to relayer. If submission fails before the relayer accepts the
+        // job, we can safely roll back — nothing was sent on-chain.
+        reporter.on_step(
+            ExecutionPhase::Commit,
+            "Submitting proof to relayer",
+            &commit_ctx,
+        );
+        let submit_response = match self.deps.relayer.submit_proof(
+            &settings.relayer_api_url,
+            &payload_bytes,
+            Some(format!("driver:{}", input.action_id)),
+        ) {
+            Ok(resp) if resp.status == relayer::api_types::JobStatus::Failed => {
+                rollback_results(&self.paths, &resolved_inputs, &saved);
+                return Err(anyhow!("relayer rejected job {} immediately", resp.job_id));
             }
-
-            let waiting_label = format!("Waiting for relayer job {}", submit_response.job_id);
-            reporter.on_step(ExecutionPhase::Commit, &waiting_label, &commit_ctx);
-            let confirmation = self.deps.relayer.wait_for_confirmation(
-                &settings.relayer_api_url,
-                &submit_response.job_id,
-                RELAYER_POLL_TIMEOUT_SECS,
-                RELAYER_POLL_INTERVAL_MS,
-            )?;
-
-            reporter.on_step(
-                ExecutionPhase::Commit,
-                "Waiting for synchronizer to observe commit",
-                &commit_ctx,
-            );
-            let sync_head = self.deps.synchronizer.wait_for_tx(
-                &settings.synchronizer_api_url,
-                expected_tx_final,
-                SYNCHRONIZER_POLL_TIMEOUT_SECS,
-                SYNCHRONIZER_POLL_INTERVAL_MS,
-            )?;
-            Ok(ExecuteActionResult {
-                old_root,
-                new_root: encode_hash_hex(&sync_head.current_gsr),
-                output_files: saved.output_files.clone(),
-                nullified_files: saved.nullified_files.clone(),
-                relayer_job_id: confirmation.job_id,
-                tx_hash: confirmation.tx_hash,
-                block_number: confirmation.block_number,
-            })
-        })();
-
-        match commit_result {
-            Ok(result) => {
-                reporter.on_done(ExecutionPhase::Commit, Some(&result));
-                Ok(result)
-            }
+            Ok(resp) => resp,
             Err(err) => {
                 rollback_results(&self.paths, &resolved_inputs, &saved);
-                Err(err)
+                return Err(err);
             }
-        }
+        };
+
+        // Past this point the proof has been accepted by the relayer and may
+        // land on-chain at any moment. We must NOT roll back — the output
+        // files stay as `pending` and the inputs stay nullified. The next
+        // `sync_inventory` call will reconcile once the tx is observed.
+        let waiting_label = format!("Waiting for relayer job {}", submit_response.job_id);
+        reporter.on_step(ExecutionPhase::Commit, &waiting_label, &commit_ctx);
+        let confirmation = self.deps.relayer.wait_for_confirmation(
+            &settings.relayer_api_url,
+            &submit_response.job_id,
+            RELAYER_POLL_TIMEOUT_SECS,
+            RELAYER_POLL_INTERVAL_MS,
+        )?;
+
+        reporter.on_step(
+            ExecutionPhase::Commit,
+            "Waiting for synchronizer to observe commit",
+            &commit_ctx,
+        );
+        let sync_head = self.deps.synchronizer.wait_for_tx(
+            &settings.synchronizer_api_url,
+            expected_tx_final,
+            SYNCHRONIZER_POLL_TIMEOUT_SECS,
+            SYNCHRONIZER_POLL_INTERVAL_MS,
+        )?;
+
+        let result = ExecuteActionResult {
+            old_root,
+            new_root: encode_hash_hex(&sync_head.current_gsr),
+            output_files: saved.output_files.clone(),
+            nullified_files: saved.nullified_files.clone(),
+            relayer_job_id: confirmation.job_id,
+            tx_hash: confirmation.tx_hash,
+            block_number: confirmation.block_number,
+        };
+        reporter.on_done(ExecutionPhase::Commit, Some(&result));
+        Ok(result)
     }
 
     pub fn generated_podlang(&self) -> Option<String> {

--- a/driver/src/driver.rs
+++ b/driver/src/driver.rs
@@ -198,7 +198,7 @@ impl Driver {
     pub fn list_classes(&self) -> Result<Vec<ClassSummary>> {
         let live_objects = load_object_files(&self.paths)?
             .into_iter()
-            .filter(|entry| !entry.record.is_nullified())
+            .filter(|entry| entry.record.status == ObjectStatus::Live)
             .collect::<Vec<_>>();
         Ok(self
             .deps
@@ -223,7 +223,9 @@ impl Driver {
             .ok_or_else(|| anyhow!("unknown class: {class_name}"))?;
         let live_count = load_object_files(&self.paths)?
             .into_iter()
-            .filter(|entry| !entry.record.is_nullified() && entry.record.class_name == class_name)
+            .filter(|entry| {
+                entry.record.status == ObjectStatus::Live && entry.record.class_name == class_name
+            })
             .count();
         Ok(ClassSummary {
             live_count,
@@ -240,7 +242,7 @@ impl Driver {
         let entries = load_object_files(&self.paths)?;
         let live_objects = entries
             .iter()
-            .filter(|entry| !entry.record.is_nullified())
+            .filter(|entry| entry.record.status == ObjectStatus::Live)
             .collect::<Vec<_>>();
 
         let mut available = Vec::new();

--- a/driver/src/driver.rs
+++ b/driver/src/driver.rs
@@ -415,9 +415,7 @@ impl Driver {
             file_name: entry.file_name.clone(),
             class_name: entry.record.class_name.clone(),
             class_hash,
-            source_action: entry.record.source_action.clone(),
-            live: !entry.record.is_nullified(),
-            nullifier: entry.record.nullifier.clone(),
+            status: entry.record.status,
             grounded,
             fields: entry.record.fields_map(),
         }
@@ -433,9 +431,7 @@ impl Driver {
                 .as_ref()
                 .map(|class_info| class_info.hash.clone())
                 .unwrap_or_default(),
-            source_action: entry.record.source_action.clone(),
-            live: !entry.record.is_nullified(),
-            nullifier: entry.record.nullifier.clone(),
+            status: entry.record.status,
             grounded,
             fields: entry.record.fields_map(),
             predicate_source: class_info

--- a/driver/src/driver.rs
+++ b/driver/src/driver.rs
@@ -16,8 +16,8 @@ use crate::clients::{
     SynchronizerClient,
 };
 use crate::execute::{
-    build_relayer_payload, reconcile_objects, resolve_inputs, rollback_results, save_results,
-    update_output_files, validate_execute_request,
+    build_relayer_payload, reconcile_objects, resolve_inputs, save_results, update_output_files,
+    validate_execute_request,
 };
 use crate::object_record::ObjectStatus;
 use crate::object_record::parse_object_record_file;
@@ -345,8 +345,8 @@ impl Driver {
             &spendable_outputs,
         )?;
 
-        // Submit to relayer. If submission fails before the relayer accepts the
-        // job, we can safely roll back — nothing was sent on-chain.
+        // Submit to relayer. Output files are kept as Unknown on failure so
+        // the user can retry submission later without regenerating proofs.
         reporter.on_step(
             ExecutionPhase::Commit,
             "Submitting proof to relayer",
@@ -358,18 +358,16 @@ impl Driver {
             Some(format!("driver:{}", input.action_id)),
         ) {
             Ok(resp) if resp.status == relayer::api_types::JobStatus::Failed => {
-                rollback_results(&self.paths, &resolved_inputs, &saved);
                 return Err(anyhow!("relayer rejected job {} immediately", resp.job_id));
             }
             Ok(resp) => resp,
             Err(err) => {
-                rollback_results(&self.paths, &resolved_inputs, &saved);
                 return Err(err);
             }
         };
 
         // Past this point the proof has been accepted by the relayer and may
-        // land on-chain at any moment. We must NOT roll back — the output
+        // land on-chain at any moment. The output
         // files stay as `unknown` and the inputs stay nullified. The next
         // `sync_inventory` call will reconcile once the tx is observed.
         let waiting_label = format!("Waiting for relayer job {}", submit_response.job_id);

--- a/driver/src/driver.rs
+++ b/driver/src/driver.rs
@@ -160,7 +160,7 @@ impl Driver {
             &mut entries,
             &membership.grounded_txs,
             &membership.on_chain_nullifiers,
-        );
+        )?;
 
         Ok(entries
             .iter()
@@ -381,14 +381,12 @@ impl Driver {
 
         // Confirmation returned an Ethereum tx hash — update outputs to Pending.
         let eth_tx_hash = confirmation.tx_hash.as_deref();
-        if let Err(err) = update_output_files(
+        update_output_files(
             &self.paths,
             &saved.output_files,
             ObjectStatus::Pending,
             eth_tx_hash,
-        ) {
-            eprintln!("zk-craft: failed to update output status to pending: {err}");
-        }
+        )?;
 
         reporter.on_step(
             ExecutionPhase::Commit,
@@ -406,27 +404,23 @@ impl Driver {
                 // Sync failed or timed out — revert outputs to Unknown but
                 // keep the txHash so the chain submission can be inspected.
                 // The next sync_inventory will reconcile if the tx lands later.
-                if let Err(update_err) = update_output_files(
+                update_output_files(
                     &self.paths,
                     &saved.output_files,
                     ObjectStatus::Unknown,
                     eth_tx_hash,
-                ) {
-                    eprintln!("zk-craft: failed to revert output status to unknown: {update_err}");
-                }
+                )?;
                 return Err(err);
             }
         };
 
         // Sync confirmed the tx — update output files to Live.
-        if let Err(err) = update_output_files(
+        update_output_files(
             &self.paths,
             &saved.output_files,
             ObjectStatus::Live,
             eth_tx_hash,
-        ) {
-            eprintln!("zk-craft: failed to update output status to live: {err}");
-        }
+        )?;
 
         let result = ExecuteActionResult {
             old_root,

--- a/driver/src/driver.rs
+++ b/driver/src/driver.rs
@@ -17,8 +17,9 @@ use crate::clients::{
 };
 use crate::execute::{
     build_relayer_payload, reconcile_objects, resolve_inputs, rollback_results, save_results,
-    validate_execute_request,
+    update_output_files, validate_execute_request,
 };
+use crate::object_record::ObjectStatus;
 use crate::object_record::parse_object_record_file;
 use crate::object_store::{
     ObjectFileEntry, ensure_store_dirs, load_object_files, matches_query, select_object,
@@ -155,7 +156,12 @@ impl Driver {
             &live_nullifiers.iter().copied().collect::<Vec<_>>(),
         )?;
 
-        reconcile_objects(&self.paths, &mut entries, &membership.on_chain_nullifiers);
+        reconcile_objects(
+            &self.paths,
+            &mut entries,
+            &membership.grounded_txs,
+            &membership.on_chain_nullifiers,
+        );
 
         Ok(entries
             .iter()
@@ -363,7 +369,7 @@ impl Driver {
 
         // Past this point the proof has been accepted by the relayer and may
         // land on-chain at any moment. We must NOT roll back — the output
-        // files stay as `pending` and the inputs stay nullified. The next
+        // files stay as `unknown` and the inputs stay nullified. The next
         // `sync_inventory` call will reconcile once the tx is observed.
         let waiting_label = format!("Waiting for relayer job {}", submit_response.job_id);
         reporter.on_step(ExecutionPhase::Commit, &waiting_label, &commit_ctx);
@@ -374,17 +380,54 @@ impl Driver {
             RELAYER_POLL_INTERVAL_MS,
         )?;
 
+        // Confirmation returned an Ethereum tx hash — update outputs to Pending.
+        let eth_tx_hash = confirmation.tx_hash.as_deref();
+        if let Err(err) = update_output_files(
+            &self.paths,
+            &saved.output_files,
+            ObjectStatus::Pending,
+            eth_tx_hash,
+        ) {
+            eprintln!("zk-craft: failed to update output status to pending: {err}");
+        }
+
         reporter.on_step(
             ExecutionPhase::Commit,
             "Waiting for synchronizer to observe commit",
             &commit_ctx,
         );
-        let sync_head = self.deps.synchronizer.wait_for_tx(
+        let sync_head = match self.deps.synchronizer.wait_for_tx(
             &settings.synchronizer_api_url,
             expected_tx_final,
             SYNCHRONIZER_POLL_TIMEOUT_SECS,
             SYNCHRONIZER_POLL_INTERVAL_MS,
-        )?;
+        ) {
+            Ok(head) => head,
+            Err(err) => {
+                // Sync failed or timed out — revert outputs to Unknown but
+                // keep the txHash so the chain submission can be inspected.
+                // The next sync_inventory will reconcile if the tx lands later.
+                if let Err(update_err) = update_output_files(
+                    &self.paths,
+                    &saved.output_files,
+                    ObjectStatus::Unknown,
+                    eth_tx_hash,
+                ) {
+                    eprintln!("zk-craft: failed to revert output status to unknown: {update_err}");
+                }
+                return Err(err);
+            }
+        };
+
+        // Sync confirmed the tx — update output files to Live.
+        if let Err(err) = update_output_files(
+            &self.paths,
+            &saved.output_files,
+            ObjectStatus::Live,
+            eth_tx_hash,
+        ) {
+            eprintln!("zk-craft: failed to update output status to live: {err}");
+        }
 
         let result = ExecuteActionResult {
             old_root,
@@ -416,6 +459,7 @@ impl Driver {
             class_name: entry.record.class_name.clone(),
             class_hash,
             status: entry.record.status,
+            tx_hash: entry.record.tx_hash.clone(),
             grounded,
             fields: entry.record.fields_map(),
         }
@@ -432,6 +476,7 @@ impl Driver {
                 .map(|class_info| class_info.hash.clone())
                 .unwrap_or_default(),
             status: entry.record.status,
+            tx_hash: entry.record.tx_hash.clone(),
             grounded,
             fields: entry.record.fields_map(),
             predicate_source: class_info

--- a/driver/src/execute.rs
+++ b/driver/src/execute.rs
@@ -16,8 +16,10 @@ use crate::types::{ActionSummary, DriverPaths, ExecuteActionInput, ObjectSelecto
 pub(crate) fn reconcile_objects(
     paths: &DriverPaths,
     objects: &mut [ObjectFileEntry],
+    grounded_txs: &HashSet<Hash>,
     on_chain_nullifiers: &HashSet<Hash>,
 ) {
+    // First pass: nullify objects whose nullifiers appear on-chain.
     for entry in objects.iter_mut() {
         if entry.record.is_nullified() {
             continue;
@@ -30,12 +32,8 @@ pub(crate) fn reconcile_objects(
             continue;
         }
         let nullified_record = StoredObjectRecord {
-            id: entry.record.id.clone(),
-            class_name: entry.record.class_name.clone(),
             status: ObjectStatus::Nullified,
-            pod: entry.record.pod.clone(),
-            obj: entry.record.obj.clone(),
-            tx: entry.record.tx.clone(),
+            ..entry.record.clone()
         };
         if let Err(err) = write_object_file(paths, &nullified_record, &entry.file_name) {
             eprintln!(
@@ -45,6 +43,30 @@ pub(crate) fn reconcile_objects(
             continue;
         }
         entry.record = nullified_record;
+    }
+
+    // Second pass: mark non-nullified objects as Live when their source tx
+    // is in the canonical grounded set.
+    for entry in objects.iter_mut() {
+        if entry.record.is_nullified() || entry.record.status == ObjectStatus::Live {
+            continue;
+        }
+        let source_tx_hash = entry.record.tx.dict().commitment();
+        if !grounded_txs.contains(&source_tx_hash) {
+            continue;
+        }
+        let live_record = StoredObjectRecord {
+            status: ObjectStatus::Live,
+            ..entry.record.clone()
+        };
+        if let Err(err) = write_object_file(paths, &live_record, &entry.file_name) {
+            eprintln!(
+                "zk-craft: reconcile failed to mark {} as live: {err}",
+                entry.file_name
+            );
+            continue;
+        }
+        entry.record = live_record;
     }
 }
 
@@ -126,14 +148,9 @@ pub(crate) fn save_results(
 ) -> Result<SavedFiles> {
     let mut nullified_files = Vec::new();
     for input in resolved_inputs {
-        let input_record = &input.record;
         let nullified_record = StoredObjectRecord {
-            id: input_record.id.clone(),
-            class_name: input_record.class_name.clone(),
             status: ObjectStatus::Nullified,
-            pod: input_record.pod.clone(),
-            obj: input_record.obj.clone(),
-            tx: input_record.tx.clone(),
+            ..input.record.clone()
         };
         write_object_file(paths, &nullified_record, &input.file_name)?;
         nullified_files.push(input.file_name.clone());
@@ -162,7 +179,8 @@ pub(crate) fn save_results(
         let live_record = StoredObjectRecord {
             id: object_id,
             class_name: class_name.clone(),
-            status: ObjectStatus::Pending,
+            status: ObjectStatus::Unknown,
+            tx_hash: None,
             pod: spendable.pod,
             obj: spendable.obj,
             tx: spendable.tx,
@@ -181,16 +199,9 @@ pub(crate) fn rollback_results(
     resolved_inputs: &[ResolvedInput],
     saved: &SavedFiles,
 ) {
+    // Restore each input to its original state (preserves original status and tx_hash).
     for input in resolved_inputs {
-        let live_record = StoredObjectRecord {
-            id: input.record.id.clone(),
-            class_name: input.record.class_name.clone(),
-            status: input.record.status,
-            pod: input.record.pod.clone(),
-            obj: input.record.obj.clone(),
-            tx: input.record.tx.clone(),
-        };
-        if let Err(err) = write_object_file(paths, &live_record, &input.file_name) {
+        if let Err(err) = write_object_file(paths, &input.record, &input.file_name) {
             eprintln!("zk-craft: rollback failed for {}: {err}", input.file_name);
         }
     }
@@ -204,6 +215,26 @@ pub(crate) fn rollback_results(
             }
         }
     }
+}
+
+/// Update the status and tx_hash of previously saved output files on disk.
+pub(crate) fn update_output_files(
+    paths: &DriverPaths,
+    output_files: &[String],
+    status: ObjectStatus,
+    tx_hash: Option<&str>,
+) -> Result<()> {
+    for file_name in output_files {
+        let file_path = paths.objects_dir.join(file_name);
+        let contents = std::fs::read_to_string(&file_path)
+            .map_err(|err| anyhow!("failed to read {file_name} for status update: {err}"))?;
+        let mut record: StoredObjectRecord = serde_json::from_str(&contents)
+            .map_err(|err| anyhow!("failed to parse {file_name} for status update: {err}"))?;
+        record.status = status;
+        record.tx_hash = tx_hash.map(|s| s.to_string());
+        write_object_file(paths, &record, file_name)?;
+    }
+    Ok(())
 }
 
 pub(crate) fn build_relayer_payload(

--- a/driver/src/execute.rs
+++ b/driver/src/execute.rs
@@ -18,7 +18,9 @@ pub(crate) fn reconcile_objects(
     objects: &mut [ObjectFileEntry],
     grounded_txs: &HashSet<Hash>,
     on_chain_nullifiers: &HashSet<Hash>,
-) {
+) -> Result<()> {
+    let mut errors: Vec<String> = Vec::new();
+
     // First pass: nullify objects whose nullifiers appear on-chain.
     for entry in objects.iter_mut() {
         if entry.record.is_nullified() {
@@ -36,10 +38,7 @@ pub(crate) fn reconcile_objects(
             ..entry.record.clone()
         };
         if let Err(err) = write_object_file(paths, &nullified_record, &entry.file_name) {
-            eprintln!(
-                "zk-craft: reconcile failed to nullify {}: {err}",
-                entry.file_name
-            );
+            errors.push(format!("failed to nullify {}: {err}", entry.file_name));
             continue;
         }
         entry.record = nullified_record;
@@ -66,10 +65,7 @@ pub(crate) fn reconcile_objects(
             ..entry.record.clone()
         };
         if let Err(err) = write_object_file(paths, &restored_record, &entry.file_name) {
-            eprintln!(
-                "zk-craft: reconcile failed to restore {}: {err}",
-                entry.file_name
-            );
+            errors.push(format!("failed to restore {}: {err}", entry.file_name));
             continue;
         }
         entry.record = restored_record;
@@ -90,13 +86,20 @@ pub(crate) fn reconcile_objects(
             ..entry.record.clone()
         };
         if let Err(err) = write_object_file(paths, &live_record, &entry.file_name) {
-            eprintln!(
-                "zk-craft: reconcile failed to mark {} as live: {err}",
-                entry.file_name
-            );
+            errors.push(format!("failed to mark {} as live: {err}", entry.file_name));
             continue;
         }
         entry.record = live_record;
+    }
+
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        Err(anyhow!(
+            "reconcile encountered {} error(s): {}",
+            errors.len(),
+            errors.join("; ")
+        ))
     }
 }
 

--- a/driver/src/execute.rs
+++ b/driver/src/execute.rs
@@ -180,15 +180,10 @@ pub(crate) fn save_results(
     resolved_inputs: &[ResolvedInput],
     spendable_outputs: &SpendableObjects,
 ) -> Result<SavedFiles> {
-    let mut nullified_files = Vec::new();
-    for input in resolved_inputs {
-        let nullified_record = StoredObjectRecord {
-            status: ObjectStatus::Nullified,
-            ..input.record.clone()
-        };
-        write_object_file(paths, &nullified_record, &input.file_name)?;
-        nullified_files.push(input.file_name.clone());
-    }
+    let nullified_files = resolved_inputs
+        .iter()
+        .map(|input| input.file_name.clone())
+        .collect();
 
     if spendable_outputs.objs.len() != action.output_classes.len() {
         return Err(anyhow!(
@@ -226,29 +221,6 @@ pub(crate) fn save_results(
         output_files,
         nullified_files,
     })
-}
-
-pub(crate) fn rollback_results(
-    paths: &DriverPaths,
-    resolved_inputs: &[ResolvedInput],
-    saved: &SavedFiles,
-) {
-    // Restore each input to its original state (preserves original status and tx_hash).
-    for input in resolved_inputs {
-        if let Err(err) = write_object_file(paths, &input.record, &input.file_name) {
-            eprintln!("zk-craft: rollback failed for {}: {err}", input.file_name);
-        }
-    }
-    for file_name in &saved.output_files {
-        let path = paths.objects_dir.join(file_name);
-        match std::fs::remove_file(&path) {
-            Ok(_) => {}
-            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
-            Err(err) => {
-                eprintln!("zk-craft: rollback failed to remove {file_name}: {err}");
-            }
-        }
-    }
 }
 
 /// Update the status and tx_hash of previously saved output files on disk.

--- a/driver/src/execute.rs
+++ b/driver/src/execute.rs
@@ -45,7 +45,37 @@ pub(crate) fn reconcile_objects(
         entry.record = nullified_record;
     }
 
-    // Second pass: mark non-nullified objects as Live when their source tx
+    // Second pass: restore locally-nullified objects whose nullifiers are
+    // NOT in the on-chain set. This handles the case where a consuming
+    // action's proof failed and the nullifier never landed. The object
+    // is set to Unknown — it cannot be used as an action input until a
+    // subsequent sync promotes it back to Live.
+    for entry in objects.iter_mut() {
+        if !entry.record.is_nullified() {
+            continue;
+        }
+        let nullifier_hash = match object_nullifier_hash(&entry.record.obj) {
+            Ok(hash) => hash,
+            Err(_) => continue,
+        };
+        if on_chain_nullifiers.contains(&nullifier_hash) {
+            continue; // Confirmed nullified on-chain, keep as is.
+        }
+        let restored_record = StoredObjectRecord {
+            status: ObjectStatus::Unknown,
+            ..entry.record.clone()
+        };
+        if let Err(err) = write_object_file(paths, &restored_record, &entry.file_name) {
+            eprintln!(
+                "zk-craft: reconcile failed to restore {}: {err}",
+                entry.file_name
+            );
+            continue;
+        }
+        entry.record = restored_record;
+    }
+
+    // Third pass: mark non-nullified objects as Live when their source tx
     // is in the canonical grounded set.
     for entry in objects.iter_mut() {
         if entry.record.is_nullified() || entry.record.status == ObjectStatus::Live {

--- a/driver/src/execute.rs
+++ b/driver/src/execute.rs
@@ -114,8 +114,12 @@ pub(crate) fn resolve_inputs(
     for (slot, selector) in input.input_objects.iter().enumerate() {
         let expected_class = action.input_classes[slot].as_str();
         let entry = select_object(entries, selector)?;
-        if entry.record.is_nullified() {
-            return Err(anyhow!("input object is not live: {}", entry.record.id));
+        if entry.record.status != ObjectStatus::Live {
+            return Err(anyhow!(
+                "input object is not live (status: {:?}): {}",
+                entry.record.status,
+                entry.record.id
+            ));
         }
         if entry.record.class_name != expected_class {
             return Err(anyhow!(

--- a/driver/src/execute.rs
+++ b/driver/src/execute.rs
@@ -2,7 +2,6 @@ use std::collections::HashSet;
 
 use anyhow::{Result, anyhow};
 use common::{
-    encode_hash_hex,
     payload::{Payload, PayloadProof},
     shrink::{ShrunkMainPodSetup, shrink_compress_pod},
 };
@@ -10,7 +9,7 @@ use craft_sdk::SpendableObjects;
 use pod2::middleware::{Hash, Params};
 use txlib::object_nullifier_hash;
 
-use crate::object_record::ObjectRecord as StoredObjectRecord;
+use crate::object_record::{ObjectRecord as StoredObjectRecord, ObjectStatus};
 use crate::object_store::{ObjectFileEntry, select_object, write_object_file};
 use crate::types::{ActionSummary, DriverPaths, ExecuteActionInput, ObjectSelector};
 
@@ -33,8 +32,7 @@ pub(crate) fn reconcile_objects(
         let nullified_record = StoredObjectRecord {
             id: entry.record.id.clone(),
             class_name: entry.record.class_name.clone(),
-            source_action: entry.record.source_action.clone(),
-            nullifier: Some(encode_hash_hex(&nullifier_hash)),
+            status: ObjectStatus::Nullified,
             pod: entry.record.pod.clone(),
             obj: entry.record.obj.clone(),
             tx: entry.record.tx.clone(),
@@ -129,20 +127,10 @@ pub(crate) fn save_results(
     let mut nullified_files = Vec::new();
     for input in resolved_inputs {
         let input_record = &input.record;
-        let spendable = input_record.spendable();
-        let nullifier_hash = object_nullifier_hash(&spendable.obj).map_err(|err| {
-            anyhow!(
-                "failed to compute input nullifier for {}: {err}",
-                input_record.id
-            )
-        })?;
-        let input_nullifier = encode_hash_hex(&nullifier_hash);
-
         let nullified_record = StoredObjectRecord {
             id: input_record.id.clone(),
             class_name: input_record.class_name.clone(),
-            source_action: input_record.source_action.clone(),
-            nullifier: Some(input_nullifier),
+            status: ObjectStatus::Nullified,
             pod: input_record.pod.clone(),
             obj: input_record.obj.clone(),
             tx: input_record.tx.clone(),
@@ -174,8 +162,7 @@ pub(crate) fn save_results(
         let live_record = StoredObjectRecord {
             id: object_id,
             class_name: class_name.clone(),
-            source_action: action_id.to_string(),
-            nullifier: None,
+            status: ObjectStatus::Pending,
             pod: spendable.pod,
             obj: spendable.obj,
             tx: spendable.tx,
@@ -198,8 +185,7 @@ pub(crate) fn rollback_results(
         let live_record = StoredObjectRecord {
             id: input.record.id.clone(),
             class_name: input.record.class_name.clone(),
-            source_action: input.record.source_action.clone(),
-            nullifier: None,
+            status: input.record.status,
             pod: input.record.pod.clone(),
             obj: input.record.obj.clone(),
             tx: input.record.tx.clone(),

--- a/driver/src/lib.rs
+++ b/driver/src/lib.rs
@@ -20,8 +20,8 @@ pub use crate::clients::{
     SYNCHRONIZER_POLL_TIMEOUT_SECS,
 };
 pub use crate::driver::{Driver, DriverDeps, PayloadBuilder};
-pub use crate::object_record::{ObjectRecord, ObjectStatus};
 pub use crate::object_record::parse_object_record_file;
+pub use crate::object_record::{ObjectRecord, ObjectStatus};
 pub use crate::types::{
     ActionQuery, ActionSummary, CheckActionCandidate, CheckActionReport, ClassSummary, DriverPaths,
     DriverSettings, ExecuteActionInput, ExecuteActionResult, ExecutionPhase, ExecutionReporter,

--- a/driver/src/lib.rs
+++ b/driver/src/lib.rs
@@ -20,7 +20,7 @@ pub use crate::clients::{
     SYNCHRONIZER_POLL_TIMEOUT_SECS,
 };
 pub use crate::driver::{Driver, DriverDeps, PayloadBuilder};
-pub use crate::object_record::ObjectRecord;
+pub use crate::object_record::{ObjectRecord, ObjectStatus};
 pub use crate::object_record::parse_object_record_file;
 pub use crate::types::{
     ActionQuery, ActionSummary, CheckActionCandidate, CheckActionReport, ClassSummary, DriverPaths,

--- a/driver/src/object_record.rs
+++ b/driver/src/object_record.rs
@@ -43,7 +43,6 @@ fn parse_required_field<T: DeserializeOwned>(
     serde_json::from_value(value).map_err(|err| format!("failed to deserialize {context}: {err}"))
 }
 
-
 impl ObjectRecord {
     pub(crate) fn is_nullified(&self) -> bool {
         self.status == ObjectStatus::Nullified
@@ -78,7 +77,7 @@ impl ObjectRecord {
         );
         fields.insert(
             "status".to_string(),
-            serde_json::to_value(&self.status)
+            serde_json::to_value(self.status)
                 .map_err(|err| format!("failed to serialize status: {err}"))?,
         );
         fields.insert(

--- a/driver/src/object_record.rs
+++ b/driver/src/object_record.rs
@@ -23,6 +23,9 @@ pub struct ObjectRecord {
     pub class_name: String,
     /// Lifecycle status of this object.
     pub status: ObjectStatus,
+    /// Optional Ethereum transaction hash for the blob that anchored this object.
+    /// Set once the relayer confirms on-chain inclusion.
+    pub tx_hash: Option<String>,
     /// Pod proof for this object
     pub pod: MainPod,
     /// Object payload dictionary
@@ -80,6 +83,9 @@ impl ObjectRecord {
             serde_json::to_value(self.status)
                 .map_err(|err| format!("failed to serialize status: {err}"))?,
         );
+        if let Some(ref hash) = self.tx_hash {
+            fields.insert("txHash".to_string(), Value::String(hash.clone()));
+        }
         fields.insert(
             "pod".to_string(),
             serde_json::to_value(&self.pod)
@@ -105,6 +111,10 @@ impl ObjectRecord {
         let id = parse_required_field::<String>(fields, "id", "id")?;
         let class_name = parse_required_field::<String>(fields, "className", "className")?;
         let status = parse_required_field::<ObjectStatus>(fields, "status", "status")?;
+        let tx_hash: Option<String> = match fields.get("txHash") {
+            Some(Value::String(s)) => Some(s.clone()),
+            _ => None,
+        };
         let pod = parse_required_field::<MainPod>(fields, "pod", "spendable.pod")?;
         let obj = parse_required_field::<Dictionary>(fields, "obj", "spendable.obj")?;
         let tx = parse_required_field::<Tx>(fields, "tx", "spendable.tx")?;
@@ -113,6 +123,7 @@ impl ObjectRecord {
             id,
             class_name,
             status,
+            tx_hash,
             pod,
             obj,
             tx,

--- a/driver/src/object_record.rs
+++ b/driver/src/object_record.rs
@@ -7,15 +7,22 @@ use serde_json::Value;
 use std::{fs, path::Path};
 use txlib::Tx;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ObjectStatus {
+    Unknown,
+    Pending,
+    Live,
+    Nullified,
+}
+
 #[derive(Debug, Clone)]
 pub struct ObjectRecord {
     pub id: String,
     /// Object class/type name
     pub class_name: String,
-    /// Action that produced this object.
-    pub source_action: String,
-    /// Nullifier value once object is consumed.
-    pub nullifier: Option<String>,
+    /// Lifecycle status of this object.
+    pub status: ObjectStatus,
     /// Pod proof for this object
     pub pod: MainPod,
     /// Object payload dictionary
@@ -36,22 +43,10 @@ fn parse_required_field<T: DeserializeOwned>(
     serde_json::from_value(value).map_err(|err| format!("failed to deserialize {context}: {err}"))
 }
 
-fn parse_optional_field<T: DeserializeOwned>(
-    fields: &serde_json::Map<String, Value>,
-    key: &str,
-    context: &str,
-) -> Result<Option<T>, String> {
-    match fields.get(key) {
-        None | Some(Value::Null) => Ok(None),
-        Some(value) => serde_json::from_value(value.clone())
-            .map(Some)
-            .map_err(|err| format!("failed to deserialize {context}: {err}")),
-    }
-}
 
 impl ObjectRecord {
     pub(crate) fn is_nullified(&self) -> bool {
-        self.nullifier.is_some()
+        self.status == ObjectStatus::Nullified
     }
 
     pub(crate) fn spendable(&self) -> SpendableObject {
@@ -82,15 +77,9 @@ impl ObjectRecord {
             Value::String(self.class_name.clone()),
         );
         fields.insert(
-            "sourceAction".to_string(),
-            Value::String(self.source_action.clone()),
-        );
-        fields.insert(
-            "nullifier".to_string(),
-            self.nullifier
-                .clone()
-                .map(Value::String)
-                .unwrap_or(Value::Null),
+            "status".to_string(),
+            serde_json::to_value(&self.status)
+                .map_err(|err| format!("failed to serialize status: {err}"))?,
         );
         fields.insert(
             "pod".to_string(),
@@ -116,8 +105,7 @@ impl ObjectRecord {
             .ok_or_else(|| "invalid object file: expected JSON object".to_string())?;
         let id = parse_required_field::<String>(fields, "id", "id")?;
         let class_name = parse_required_field::<String>(fields, "className", "className")?;
-        let source_action = parse_required_field::<String>(fields, "sourceAction", "sourceAction")?;
-        let nullifier = parse_optional_field::<String>(fields, "nullifier", "nullifier")?;
+        let status = parse_required_field::<ObjectStatus>(fields, "status", "status")?;
         let pod = parse_required_field::<MainPod>(fields, "pod", "spendable.pod")?;
         let obj = parse_required_field::<Dictionary>(fields, "obj", "spendable.obj")?;
         let tx = parse_required_field::<Tx>(fields, "tx", "spendable.tx")?;
@@ -125,8 +113,7 @@ impl ObjectRecord {
         Ok(Self {
             id,
             class_name,
-            source_action,
-            nullifier,
+            status,
             pod,
             obj,
             tx,

--- a/driver/src/object_store.rs
+++ b/driver/src/object_store.rs
@@ -176,11 +176,6 @@ pub(crate) fn matches_query(entry: &ObjectFileEntry, query: &ObjectQuery) -> boo
     {
         return false;
     }
-    if let Some(source_action) = &query.source_action
-        && &entry.record.source_action != source_action
-    {
-        return false;
-    }
     if let Some(id) = &query.id
         && &entry.record.id != id
     {
@@ -209,7 +204,8 @@ mod tests {
 
     use super::{load_object_files, write_object_file};
     use crate::object_record::{
-        ObjectRecord, ensure_extra_pod_deserializers_registered, parse_object_record_file,
+        ObjectRecord, ObjectStatus, ensure_extra_pod_deserializers_registered,
+        parse_object_record_file,
     };
 
     fn temp_paths() -> DriverPaths {
@@ -246,8 +242,7 @@ mod tests {
         ObjectRecord {
             id: format!("{:#}", spendable.obj.commitment()),
             class_name: "Log".to_string(),
-            source_action: "FindLog".to_string(),
-            nullifier: None,
+            status: ObjectStatus::Live,
             pod: spendable.pod,
             obj: spendable.obj,
             tx: spendable.tx,

--- a/driver/src/object_store.rs
+++ b/driver/src/object_store.rs
@@ -211,8 +211,8 @@ mod tests {
     fn temp_paths() -> DriverPaths {
         let dir = tempdir().unwrap();
         let root = dir.keep();
-        let settings_path = root.join("config/com.dobjlabs.zk-craft/settings.json");
-        let objects_dir = root.join(".objects");
+        let settings_path = root.join("settings.json");
+        let objects_dir = root.join("objects");
         let nullified_objects_dir = objects_dir.join(".nullified");
         DriverPaths {
             settings_path,

--- a/driver/src/object_store.rs
+++ b/driver/src/object_store.rs
@@ -243,6 +243,7 @@ mod tests {
             id: format!("{:#}", spendable.obj.commitment()),
             class_name: "Log".to_string(),
             status: ObjectStatus::Live,
+            tx_hash: None,
             pod: spendable.pod,
             obj: spendable.obj,
             tx: spendable.tx,

--- a/driver/src/paths.rs
+++ b/driver/src/paths.rs
@@ -2,16 +2,12 @@ use anyhow::{Result, anyhow};
 
 use crate::types::DriverPaths;
 
-const APP_IDENTIFIER: &str = "com.dobjlabs.zk-craft";
-
 pub fn default_paths() -> Result<DriverPaths> {
-    let settings_path = dirs::config_dir()
-        .ok_or_else(|| anyhow!("failed to resolve config directory"))?
-        .join(APP_IDENTIFIER)
-        .join("settings.json");
-    let objects_dir = dirs::home_dir()
+    let root = dirs::home_dir()
         .ok_or_else(|| anyhow!("failed to resolve home directory"))?
-        .join(".objects");
+        .join(".dobj");
+    let settings_path = root.join("settings.json");
+    let objects_dir = root.join("objects");
     let nullified_objects_dir = objects_dir.join(".nullified");
     Ok(DriverPaths {
         settings_path,
@@ -27,12 +23,12 @@ mod tests {
     #[test]
     fn test_default_paths_shape() {
         let paths = default_paths().unwrap();
+        assert!(paths.settings_path.ends_with(".dobj/settings.json"));
+        assert!(paths.objects_dir.ends_with(".dobj/objects"));
         assert!(
             paths
-                .settings_path
-                .ends_with("com.dobjlabs.zk-craft/settings.json")
+                .nullified_objects_dir
+                .ends_with(".dobj/objects/.nullified")
         );
-        assert!(paths.objects_dir.ends_with(".objects"));
-        assert!(paths.nullified_objects_dir.ends_with(".objects/.nullified"));
     }
 }

--- a/driver/src/settings.rs
+++ b/driver/src/settings.rs
@@ -70,8 +70,8 @@ mod tests {
     fn temp_paths() -> DriverPaths {
         let dir = tempdir().unwrap();
         let root = dir.keep();
-        let settings_path = root.join("config/com.dobjlabs.zk-craft/settings.json");
-        let objects_dir = root.join(".objects");
+        let settings_path = root.join("settings.json");
+        let objects_dir = root.join("objects");
         let nullified_objects_dir = objects_dir.join(".nullified");
         DriverPaths {
             settings_path,

--- a/driver/src/tests.rs
+++ b/driver/src/tests.rs
@@ -304,12 +304,20 @@ fn test_execute_rolls_back_on_relayer_submit_failure() {
         .unwrap_err();
     assert!(err.to_string().contains("relayer submit failed"));
 
-    // Submission never reached the relayer, so rollback restores the input
-    // and deletes the output.
+    // Submission never reached the relayer. Output files are kept as Unknown
+    // so the user can retry submission without regenerating proofs.
     let remaining = load_object_files(&paths).unwrap();
-    assert_eq!(remaining.len(), 1);
-    assert_eq!(remaining[0].file_name, "log_1.dobj");
-    assert!(!remaining[0].record.is_nullified());
+    assert_eq!(remaining.len(), 2);
+    let input = remaining
+        .iter()
+        .find(|e| e.file_name == "log_1.dobj")
+        .unwrap();
+    assert!(!input.record.is_nullified());
+    let output = remaining
+        .iter()
+        .find(|e| e.file_name != "log_1.dobj")
+        .unwrap();
+    assert_eq!(output.record.status, ObjectStatus::Unknown);
 }
 
 #[test]
@@ -333,20 +341,17 @@ fn test_execute_keeps_files_after_relayer_accepts() {
     assert!(err.to_string().contains("relayer timeout"));
 
     // The relayer accepted the job, so files must NOT be rolled back.
-    // Input stays nullified, output stays as pending.
+    // Input stays live (not nullified on disk), output stays as Unknown.
     let remaining = load_object_files(&paths).unwrap();
     assert_eq!(remaining.len(), 2);
     let input = remaining
         .iter()
         .find(|e| e.file_name == "log_1.dobj")
         .unwrap();
-    assert!(input.record.is_nullified());
+    assert!(!input.record.is_nullified());
     let output = remaining
         .iter()
         .find(|e| e.file_name != "log_1.dobj")
         .unwrap();
-    // Relayer accepted but confirmation timed out — no Ethereum tx hash yet,
-    // so the output stays Unknown (pending requires a tx hash).
     assert_eq!(output.record.status, ObjectStatus::Unknown);
-    assert!(output.record.tx_hash.is_none());
 }

--- a/driver/src/tests.rs
+++ b/driver/src/tests.rs
@@ -15,7 +15,7 @@ use crate::clients::{
     SynchronizerMembership,
 };
 use crate::driver::{Driver, DriverDeps, PayloadBuilder};
-use crate::object_record::{ObjectRecord, ensure_extra_pod_deserializers_registered};
+use crate::object_record::{ObjectRecord, ObjectStatus, ensure_extra_pod_deserializers_registered};
 use crate::object_store::{
     ObjectFileEntry, ensure_store_dirs, load_object_files, write_object_file,
 };
@@ -92,8 +92,7 @@ fn make_input_record(file_name: &str) -> (ObjectFileEntry, DriverDeps) {
     let record = ObjectRecord {
         id,
         class_name: "Log".to_string(),
-        source_action: "FindLog".to_string(),
-        nullifier: None,
+        status: ObjectStatus::Live,
         pod: spendable.pod,
         obj: spendable.obj,
         tx: spendable.tx,

--- a/driver/src/tests.rs
+++ b/driver/src/tests.rs
@@ -250,6 +250,19 @@ impl RelayerClient for MockRelayer {
         })
     }
 
+    fn wait_for_tx_hash(
+        &self,
+        _relayer_api_url: &str,
+        _job_id: &str,
+        _timeout_secs: u64,
+        _poll_interval_ms: u64,
+    ) -> Result<String> {
+        if self.fail_wait {
+            return Err(anyhow!("relayer timeout"));
+        }
+        Ok("0xtx".to_string())
+    }
+
     fn wait_for_confirmation(
         &self,
         _relayer_api_url: &str,
@@ -340,8 +353,9 @@ fn test_execute_keeps_files_after_relayer_accepts() {
         .unwrap_err();
     assert!(err.to_string().contains("relayer timeout"));
 
-    // The relayer accepted the job, so files must NOT be rolled back.
-    // Input stays live (not nullified on disk), output stays as Unknown.
+    // The relayer accepted the job but wait_for_tx_hash failed, so outputs
+    // stay as Unknown (Pending requires a tx_hash). Files are kept so the
+    // next sync_inventory can reconcile.
     let remaining = load_object_files(&paths).unwrap();
     assert_eq!(remaining.len(), 2);
     let input = remaining

--- a/driver/src/tests.rs
+++ b/driver/src/tests.rs
@@ -225,6 +225,7 @@ impl SynchronizerClient for MockSynchronizer {
 
 #[derive(Default)]
 struct MockRelayer {
+    fail_submit: bool,
     fail_wait: bool,
 }
 
@@ -235,6 +236,9 @@ impl RelayerClient for MockRelayer {
         _payload_bytes: &[u8],
         _client_ref: Option<String>,
     ) -> Result<relayer::api_types::SubmitProofResponse> {
+        if self.fail_submit {
+            return Err(anyhow!("relayer submit failed"));
+        }
         Ok(relayer::api_types::SubmitProofResponse {
             job_id: "job-1".to_string(),
             status: relayer::api_types::JobStatus::Queued,
@@ -280,9 +284,40 @@ fn test_list_actions_filters_by_input_class() {
 }
 
 #[test]
-fn test_execute_rolls_back_outputs_on_relayer_failure() {
+fn test_execute_rolls_back_on_relayer_submit_failure() {
     let (entry, mut deps) = make_input_record("log_1.dobj");
-    deps.relayer = Arc::new(MockRelayer { fail_wait: true });
+    deps.relayer = Arc::new(MockRelayer {
+        fail_submit: true,
+        ..MockRelayer::default()
+    });
+    let paths = temp_paths();
+    ensure_store_dirs(&paths).unwrap();
+    write_object_file(&paths, &entry.record, &entry.file_name).unwrap();
+    let driver = Driver::open(paths.clone(), deps).unwrap();
+
+    let err = driver
+        .execute(ExecuteActionInput {
+            action_id: "CraftWood".to_string(),
+            input_objects: vec![ObjectSelector::FileName("log_1.dobj".to_string())],
+        })
+        .unwrap_err();
+    assert!(err.to_string().contains("relayer submit failed"));
+
+    // Submission never reached the relayer, so rollback restores the input
+    // and deletes the output.
+    let remaining = load_object_files(&paths).unwrap();
+    assert_eq!(remaining.len(), 1);
+    assert_eq!(remaining[0].file_name, "log_1.dobj");
+    assert!(!remaining[0].record.is_nullified());
+}
+
+#[test]
+fn test_execute_keeps_files_after_relayer_accepts() {
+    let (entry, mut deps) = make_input_record("log_1.dobj");
+    deps.relayer = Arc::new(MockRelayer {
+        fail_wait: true,
+        ..MockRelayer::default()
+    });
     let paths = temp_paths();
     ensure_store_dirs(&paths).unwrap();
     write_object_file(&paths, &entry.record, &entry.file_name).unwrap();
@@ -296,8 +331,18 @@ fn test_execute_rolls_back_outputs_on_relayer_failure() {
         .unwrap_err();
     assert!(err.to_string().contains("relayer timeout"));
 
+    // The relayer accepted the job, so files must NOT be rolled back.
+    // Input stays nullified, output stays as pending.
     let remaining = load_object_files(&paths).unwrap();
-    assert_eq!(remaining.len(), 1);
-    assert_eq!(remaining[0].file_name, "log_1.dobj");
-    assert!(!remaining[0].record.is_nullified());
+    assert_eq!(remaining.len(), 2);
+    let input = remaining
+        .iter()
+        .find(|e| e.file_name == "log_1.dobj")
+        .unwrap();
+    assert!(input.record.is_nullified());
+    let output = remaining
+        .iter()
+        .find(|e| e.file_name != "log_1.dobj")
+        .unwrap();
+    assert_eq!(output.record.status, ObjectStatus::Pending);
 }

--- a/driver/src/tests.rs
+++ b/driver/src/tests.rs
@@ -24,8 +24,8 @@ use crate::{ActionQuery, BuiltinActionCatalog, DriverPaths, ExecuteActionInput, 
 fn temp_paths() -> DriverPaths {
     let dir = tempdir().unwrap();
     let root = dir.keep();
-    let settings_path = root.join("config/com.dobjlabs.zk-craft/settings.json");
-    let objects_dir = root.join(".objects");
+    let settings_path = root.join("settings.json");
+    let objects_dir = root.join("objects");
     let nullified_objects_dir = objects_dir.join(".nullified");
     DriverPaths {
         settings_path,

--- a/driver/src/tests.rs
+++ b/driver/src/tests.rs
@@ -93,6 +93,7 @@ fn make_input_record(file_name: &str) -> (ObjectFileEntry, DriverDeps) {
         id,
         class_name: "Log".to_string(),
         status: ObjectStatus::Live,
+        tx_hash: None,
         pod: spendable.pod,
         obj: spendable.obj,
         tx: spendable.tx,
@@ -344,5 +345,8 @@ fn test_execute_keeps_files_after_relayer_accepts() {
         .iter()
         .find(|e| e.file_name != "log_1.dobj")
         .unwrap();
-    assert_eq!(output.record.status, ObjectStatus::Pending);
+    // Relayer accepted but confirmation timed out — no Ethereum tx hash yet,
+    // so the output stays Unknown (pending requires a tx hash).
+    assert_eq!(output.record.status, ObjectStatus::Unknown);
+    assert!(output.record.tx_hash.is_none());
 }

--- a/driver/src/types.rs
+++ b/driver/src/types.rs
@@ -48,6 +48,7 @@ pub struct ObjectSummary {
     pub class_name: String,
     pub class_hash: String,
     pub status: ObjectStatus,
+    pub tx_hash: Option<String>,
     pub grounded: Option<bool>,
     pub fields: HashMap<String, serde_json::Value>,
 }
@@ -60,6 +61,7 @@ pub struct ObjectDetail {
     pub class_name: String,
     pub class_hash: String,
     pub status: ObjectStatus,
+    pub tx_hash: Option<String>,
     pub grounded: Option<bool>,
     pub fields: HashMap<String, serde_json::Value>,
     pub predicate_source: String,

--- a/driver/src/types.rs
+++ b/driver/src/types.rs
@@ -3,6 +3,8 @@ use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
 
+use crate::object_record::ObjectStatus;
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DriverPaths {
     pub settings_path: PathBuf,
@@ -27,7 +29,6 @@ pub enum ObjectSelector {
 pub struct ObjectQuery {
     pub class_name: Option<String>,
     pub live: Option<bool>,
-    pub source_action: Option<String>,
     pub id: Option<String>,
     pub file_name: Option<String>,
 }
@@ -46,9 +47,7 @@ pub struct ObjectSummary {
     pub file_name: String,
     pub class_name: String,
     pub class_hash: String,
-    pub source_action: String,
-    pub live: bool,
-    pub nullifier: Option<String>,
+    pub status: ObjectStatus,
     pub grounded: Option<bool>,
     pub fields: HashMap<String, serde_json::Value>,
 }
@@ -60,9 +59,7 @@ pub struct ObjectDetail {
     pub file_name: String,
     pub class_name: String,
     pub class_hash: String,
-    pub source_action: String,
-    pub live: bool,
-    pub nullifier: Option<String>,
+    pub status: ObjectStatus,
     pub grounded: Option<bool>,
     pub fields: HashMap<String, serde_json::Value>,
     pub predicate_source: String,

--- a/justfile
+++ b/justfile
@@ -20,7 +20,7 @@ dev:
 
 # Wipe local state (RocksDB + local Postgres DBs + objects)
 reset:
-    rm -rf data/ ~/.objects
+    rm -rf data/ ~/.dobj
     psql postgres://postgres@localhost:5432/postgres -c 'DROP DATABASE IF EXISTS synchronizer;'
     psql postgres://postgres@localhost:5432/postgres -c 'DROP DATABASE IF EXISTS relayer;'
 

--- a/mcp/src/mock.rs
+++ b/mcp/src/mock.rs
@@ -102,6 +102,7 @@ impl CraftOps for MockCraftOps {
             id: obj.id.clone(),
             class_name: obj.class_name.clone(),
             status: obj.status.clone(),
+            tx_hash: obj.tx_hash.clone(),
             state: obj.fields.clone(),
             predicate_source: predicate_source_for(&obj.class_name),
         })
@@ -155,6 +156,7 @@ impl CraftOps for MockCraftOps {
                 class_name: "Wood".to_string(),
                 file_name: "Wood.dobj".to_string(),
                 status: "live".to_string(),
+                tx_hash: Some("0xmocktxnew12345678".to_string()),
                 fields: HashMap::from([
                     (
                         "blueprint".to_string(),
@@ -212,6 +214,7 @@ fn default_inventory() -> Vec<InventoryObject> {
             class_name: "Log".to_string(),
             file_name: "Log.dobj".to_string(),
             status: "live".to_string(),
+            tx_hash: Some("0xmocktx1111111111".to_string()),
             fields: HashMap::from([
                 (
                     "blueprint".to_string(),
@@ -228,6 +231,7 @@ fn default_inventory() -> Vec<InventoryObject> {
             class_name: "Wood".to_string(),
             file_name: "Wood.dobj".to_string(),
             status: "live".to_string(),
+            tx_hash: Some("0xmocktx2222222222".to_string()),
             fields: HashMap::from([
                 (
                     "blueprint".to_string(),
@@ -244,6 +248,7 @@ fn default_inventory() -> Vec<InventoryObject> {
             class_name: "Stick".to_string(),
             file_name: "Stick.dobj".to_string(),
             status: "live".to_string(),
+            tx_hash: Some("0xmocktx3333333333".to_string()),
             fields: HashMap::from([
                 (
                     "blueprint".to_string(),
@@ -260,6 +265,7 @@ fn default_inventory() -> Vec<InventoryObject> {
             class_name: "WoodPick".to_string(),
             file_name: "WoodPick.dobj".to_string(),
             status: "live".to_string(),
+            tx_hash: Some("0xmocktx4444444444".to_string()),
             fields: HashMap::from([
                 (
                     "blueprint".to_string(),
@@ -280,6 +286,7 @@ fn default_inventory() -> Vec<InventoryObject> {
             class_name: "Stone".to_string(),
             file_name: "Stone.dobj".to_string(),
             status: "live".to_string(),
+            tx_hash: Some("0xmocktx5555555555".to_string()),
             fields: HashMap::from([
                 (
                     "blueprint".to_string(),
@@ -297,6 +304,7 @@ fn default_inventory() -> Vec<InventoryObject> {
             class_name: "Log".to_string(),
             file_name: "Log_old.dobj".to_string(),
             status: "nullified".to_string(),
+            tx_hash: Some("0xmocktxdead000000".to_string()),
             fields: HashMap::from([(
                 "blueprint".to_string(),
                 serde_json::Value::String("Log".to_string()),

--- a/mcp/src/mock.rs
+++ b/mcp/src/mock.rs
@@ -61,7 +61,7 @@ impl CraftOps for MockCraftOps {
                 let live_count = self
                     .inventory
                     .iter()
-                    .filter(|o| o.class_name == name && o.live)
+                    .filter(|o| o.class_name == name && o.status == "live")
                     .count();
                 let produced_by = self
                     .actions
@@ -101,7 +101,7 @@ impl CraftOps for MockCraftOps {
         Ok(ObjectDetail {
             id: obj.id.clone(),
             class_name: obj.class_name.clone(),
-            live: obj.live,
+            status: obj.status.clone(),
             state: obj.fields.clone(),
             predicate_source: predicate_source_for(&obj.class_name),
         })
@@ -154,7 +154,7 @@ impl CraftOps for MockCraftOps {
                 id: "0xnew1234567890abcdef".to_string(),
                 class_name: "Wood".to_string(),
                 file_name: "Wood.dobj".to_string(),
-                live: true,
+                status: "live".to_string(),
                 fields: HashMap::from([
                     (
                         "blueprint".to_string(),
@@ -184,7 +184,7 @@ impl CraftOps for MockCraftOps {
             if let Some(obj) = self
                 .inventory
                 .iter()
-                .find(|o| &o.class_name == required_class && o.live)
+                .find(|o| &o.class_name == required_class && o.status == "live")
             {
                 available.push(FeasibilityInput {
                     class_name: obj.class_name.clone(),
@@ -211,7 +211,7 @@ fn default_inventory() -> Vec<InventoryObject> {
             id: "0xabc1111111111111".to_string(),
             class_name: "Log".to_string(),
             file_name: "Log.dobj".to_string(),
-            live: true,
+            status: "live".to_string(),
             fields: HashMap::from([
                 (
                     "blueprint".to_string(),
@@ -227,7 +227,7 @@ fn default_inventory() -> Vec<InventoryObject> {
             id: "0xabc2222222222222".to_string(),
             class_name: "Wood".to_string(),
             file_name: "Wood.dobj".to_string(),
-            live: true,
+            status: "live".to_string(),
             fields: HashMap::from([
                 (
                     "blueprint".to_string(),
@@ -243,7 +243,7 @@ fn default_inventory() -> Vec<InventoryObject> {
             id: "0xabc3333333333333".to_string(),
             class_name: "Stick".to_string(),
             file_name: "Stick.dobj".to_string(),
-            live: true,
+            status: "live".to_string(),
             fields: HashMap::from([
                 (
                     "blueprint".to_string(),
@@ -259,7 +259,7 @@ fn default_inventory() -> Vec<InventoryObject> {
             id: "0xabc4444444444444".to_string(),
             class_name: "WoodPick".to_string(),
             file_name: "WoodPick.dobj".to_string(),
-            live: true,
+            status: "live".to_string(),
             fields: HashMap::from([
                 (
                     "blueprint".to_string(),
@@ -279,7 +279,7 @@ fn default_inventory() -> Vec<InventoryObject> {
             id: "0xabc5555555555555".to_string(),
             class_name: "Stone".to_string(),
             file_name: "Stone.dobj".to_string(),
-            live: true,
+            status: "live".to_string(),
             fields: HashMap::from([
                 (
                     "blueprint".to_string(),
@@ -296,7 +296,7 @@ fn default_inventory() -> Vec<InventoryObject> {
             id: "0xdead000000000000".to_string(),
             class_name: "Log".to_string(),
             file_name: "Log_old.dobj".to_string(),
-            live: false,
+            status: "nullified".to_string(),
             fields: HashMap::from([(
                 "blueprint".to_string(),
                 serde_json::Value::String("Log".to_string()),
@@ -407,7 +407,7 @@ mod tests {
         let mock = MockCraftOps::new();
         let detail = mock.inspect_object("0xabc1111111111111").unwrap();
         assert_eq!(detail.class_name, "Log");
-        assert!(detail.live);
+        assert_eq!(detail.status, "live");
         assert!(detail.predicate_source.contains("FindLog"));
     }
 

--- a/mcp/src/types.rs
+++ b/mcp/src/types.rs
@@ -50,8 +50,8 @@ pub struct InventoryObject {
     pub class_name: String,
     /// The .dobj filename, e.g. "WoodPick.dobj"
     pub file_name: String,
-    /// Whether this object is live (not nullified)
-    pub live: bool,
+    /// Lifecycle status: "unknown", "pending", "live", or "nullified"
+    pub status: String,
     /// Application-layer fields as key-value pairs
     pub fields: HashMap<String, serde_json::Value>,
 }
@@ -87,8 +87,8 @@ pub struct ObjectDetail {
     pub id: String,
     /// Object class name
     pub class_name: String,
-    /// Whether this object is live (not nullified)
-    pub live: bool,
+    /// Lifecycle status: "unknown", "pending", "live", or "nullified"
+    pub status: String,
     /// Application-layer state fields
     pub state: HashMap<String, serde_json::Value>,
     /// Podlang predicate source for this object's class

--- a/mcp/src/types.rs
+++ b/mcp/src/types.rs
@@ -52,6 +52,8 @@ pub struct InventoryObject {
     pub file_name: String,
     /// Lifecycle status: "unknown", "pending", "live", or "nullified"
     pub status: String,
+    /// Transaction commitment hash (hex) if this object has been submitted
+    pub tx_hash: Option<String>,
     /// Application-layer fields as key-value pairs
     pub fields: HashMap<String, serde_json::Value>,
 }
@@ -89,6 +91,8 @@ pub struct ObjectDetail {
     pub class_name: String,
     /// Lifecycle status: "unknown", "pending", "live", or "nullified"
     pub status: String,
+    /// Transaction commitment hash (hex) if this object has been submitted
+    pub tx_hash: Option<String>,
     /// Application-layer state fields
     pub state: HashMap<String, serde_json::Value>,
     /// Podlang predicate source for this object's class


### PR DESCRIPTION
Update to match the object structure v0 doc: https://www.notion.so/Object-Structure-v0-33a5d7149de480aea435dc7830e69aa3

- Replace the binary `nullifier`/`live` fields on `.dobj` files with a proper `ObjectStatus` enum (unknown → pending → live → nullified) and an optional `txHash` field tracking on-chain inclusion
- Rewrite the execute flow to update object status incrementally through each phase (save as unknown, mark pending on relayer confirmation, mark live on synchronizer confirmation) instead of rolling back on post-acceptance failures
- Remove `rollback_results` — on pre-acceptance relayer failure, output files are preserved as `unknown` so users can retry submission without regenerating proofs
- Move local storage from `~/.objects` to `~/.dobj/objects` and consolidate settings under `~/.dobj/`
- Update `sync_inventory` reconciliation to use the full status model: three-pass reconcile now handles nullification, restoration of failed nullifications, and promotion to live
- Update GUI, MCP layer, and mock server to use status/txHash instead of nullifier/live
- Removed legacy field sourceAction (not used anywhere)
