### PR TITLE
MCP: support parallel action execution

### DIFF
--- a/mcp/src/bin/proxy_stdio.rs
+++ b/mcp/src/bin/proxy_stdio.rs
@@ -3,77 +3,151 @@
 /// Claude Desktop launches this as a child process. It reads JSON-RPC from
 /// stdin, forwards to the Tauri app's streamable HTTP MCP endpoint, and
 /// writes responses to stdout.
+///
+/// Requests are dispatched concurrently so that long-running tool calls
+/// (e.g. proof generation) do not block other requests.
 use std::io::{BufRead, Write};
+use std::sync::Arc;
 
-fn main() -> anyhow::Result<()> {
+use tokio::sync::{Notify, RwLock, mpsc};
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
     craft_mcp::logging::init_stderr();
 
     let url = parse_url_from_args();
     tracing::info!("ZK-Craft MCP proxy connecting to {url}");
 
-    let client = reqwest::blocking::Client::builder()
+    let client = reqwest::Client::builder()
         .timeout(std::time::Duration::from_secs(600))
         .build()?;
-    let mut session_id: Option<String> = None;
 
-    let stdin = std::io::stdin().lock();
-    let mut stdout = std::io::stdout().lock();
+    let session_id: Arc<RwLock<Option<String>>> = Arc::new(RwLock::new(None));
+    let session_ready = Arc::new(Notify::new());
 
-    for line in stdin.lines() {
-        let line = line?;
-        let line = line.trim();
-        if line.is_empty() {
-            continue;
+    // Channel for serialised stdout writes (avoids interleaving).
+    let (stdout_tx, mut stdout_rx) = mpsc::unbounded_channel::<String>();
+
+    // Stdout writer task.
+    tokio::spawn(async move {
+        while let Some(line) = stdout_rx.recv().await {
+            let mut stdout = std::io::stdout().lock();
+            let _ = writeln!(stdout, "{line}");
+            let _ = stdout.flush();
         }
+    });
 
-        // Check if this is a request (has "id") or notification (no "id")
-        let parsed: serde_json::Value = serde_json::from_str(line)?;
-        let is_request = parsed.get("id").is_some();
-
-        // Build the HTTP request
-        let mut req = client
-            .post(&url)
-            .header("Content-Type", "application/json")
-            .header("Accept", "application/json, text/event-stream");
-
-        if let Some(sid) = &session_id {
-            req = req.header("Mcp-Session-Id", sid);
-        }
-
-        let resp = req.body(line.to_string()).send().map_err(|e| {
-            anyhow::anyhow!(
-                "Failed to connect to MCP server at {url}: {e}. Is the Tauri app running?"
-            )
-        })?;
-
-        // Capture session ID from response
-        if let Some(sid) = resp.headers().get("mcp-session-id") {
-            session_id = Some(sid.to_str().unwrap_or_default().to_string());
-        }
-
-        if !is_request {
-            // Notification — no response expected on stdio
-            continue;
-        }
-
-        // Parse SSE response to extract JSON-RPC messages
-        let body = resp.text()?;
-        for sse_line in body.lines() {
-            if let Some(data) = sse_line.strip_prefix("data: ") {
-                let data = data.trim();
-                if data.is_empty() {
-                    continue;
-                }
-                // Validate it's JSON before forwarding
-                if data.starts_with('{') {
-                    writeln!(stdout, "{data}")?;
-                    stdout.flush()?;
-                }
+    // Read stdin on a dedicated thread (blocking I/O).
+    let (stdin_tx, mut stdin_rx) = mpsc::unbounded_channel::<String>();
+    std::thread::spawn(move || {
+        let stdin = std::io::stdin().lock();
+        for line in stdin.lines() {
+            let Ok(line) = line else { break };
+            let line = line.trim().to_string();
+            if line.is_empty() {
+                continue;
             }
+            if stdin_tx.send(line).is_err() {
+                break;
+            }
+        }
+    });
+
+    // Dispatch loop.
+    let mut first = true;
+    while let Some(line) = stdin_rx.recv().await {
+        if first {
+            // The first request (typically `initialize`) must complete before
+            // concurrent requests can be dispatched, because we need the
+            // session ID from the response.
+            first = false;
+            handle_request(&client, &url, &line, &session_id, &stdout_tx).await;
+            session_ready.notify_waiters();
+        } else {
+            let client = client.clone();
+            let url = url.clone();
+            let session_id = session_id.clone();
+            let session_ready = session_ready.clone();
+            let stdout_tx = stdout_tx.clone();
+            tokio::spawn(async move {
+                // Wait until the session has been established.
+                if session_id.read().await.is_none() {
+                    session_ready.notified().await;
+                }
+                handle_request(&client, &url, &line, &session_id, &stdout_tx).await;
+            });
         }
     }
 
     Ok(())
+}
+
+async fn handle_request(
+    client: &reqwest::Client,
+    url: &str,
+    line: &str,
+    session_id: &Arc<RwLock<Option<String>>>,
+    stdout_tx: &mpsc::UnboundedSender<String>,
+) {
+    let parsed: serde_json::Value = match serde_json::from_str(line) {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::warn!("invalid JSON from stdin: {e}");
+            return;
+        }
+    };
+    let is_request = parsed.get("id").is_some();
+
+    let mut req = client
+        .post(url)
+        .header("Content-Type", "application/json")
+        .header("Accept", "application/json, text/event-stream");
+
+    if let Some(sid) = session_id.read().await.as_deref() {
+        req = req.header("Mcp-Session-Id", sid);
+    }
+
+    let resp = match req.body(line.to_string()).send().await {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::error!(
+                "Failed to connect to MCP server at {url}: {e}. Is the Tauri app running?"
+            );
+            return;
+        }
+    };
+
+    // Capture session ID from response.
+    if let Some(sid) = resp.headers().get("mcp-session-id") {
+        if let Ok(sid) = sid.to_str() {
+            *session_id.write().await = Some(sid.to_string());
+        }
+    }
+
+    if !is_request {
+        // Notification — no response expected on stdio.
+        return;
+    }
+
+    // Parse SSE response to extract JSON-RPC messages.
+    let body = match resp.text().await {
+        Ok(b) => b,
+        Err(e) => {
+            tracing::error!("failed to read response body: {e}");
+            return;
+        }
+    };
+    for sse_line in body.lines() {
+        if let Some(data) = sse_line.strip_prefix("data: ") {
+            let data = data.trim();
+            if data.is_empty() {
+                continue;
+            }
+            if data.starts_with('{') {
+                let _ = stdout_tx.send(data.to_string());
+            }
+        }
+    }
 }
 
 fn parse_url_from_args() -> String {

--- a/mcp/src/mock.rs
+++ b/mcp/src/mock.rs
@@ -1,5 +1,4 @@
 use std::collections::HashMap;
-use std::sync::Mutex;
 
 use anyhow::{anyhow, bail};
 
@@ -8,12 +7,11 @@ use crate::types::*;
 
 /// Mock implementation of CraftOps for testing.
 /// Returns realistic fixtures matching the zk-craft game.
+/// Multiple actions can run concurrently
 pub struct MockCraftOps {
     inventory: Vec<InventoryObject>,
     actions: Vec<Action>,
     state_root: String,
-    /// Simulates mutual exclusion: only one action at a time.
-    action_in_progress: Mutex<bool>,
 }
 
 impl MockCraftOps {
@@ -22,19 +20,12 @@ impl MockCraftOps {
             inventory: default_inventory(),
             actions: default_actions(),
             state_root: "0x9a8b7c6d5e4f3a2b1c0d9e8f7a6b5c4d3e2f1a0b".to_string(),
-            action_in_progress: Mutex::new(false),
         }
     }
 
     /// Create a mock with a custom inventory.
     pub fn with_inventory(mut self, inventory: Vec<InventoryObject>) -> Self {
         self.inventory = inventory;
-        self
-    }
-
-    /// Create a mock that simulates an action already in progress.
-    pub fn with_action_in_progress(self) -> Self {
-        *self.action_in_progress.lock().unwrap() = true;
         self
     }
 }
@@ -134,19 +125,10 @@ impl CraftOps for MockCraftOps {
     }
 
     fn run_action(&self, input: RunActionInput) -> anyhow::Result<RunActionResult> {
-        let mut in_progress = self.action_in_progress.lock().unwrap();
-        if *in_progress {
-            bail!("an action is already in progress");
-        }
-
         // Validate the action exists
         if !self.actions.iter().any(|a| a.id == input.action_id) {
             bail!("unknown action: {}", input.action_id);
         }
-
-        *in_progress = true;
-        // Simulate completion (in real impl this would block for proof generation)
-        *in_progress = false;
 
         Ok(RunActionResult {
             success: true,
@@ -476,19 +458,25 @@ mod tests {
     }
 
     #[test]
-    fn test_run_action_already_in_progress() {
-        let mock = MockCraftOps::new().with_action_in_progress();
-        let result = mock.run_action(RunActionInput {
-            action_id: "CraftWood".to_string(),
-            input_object_paths: vec!["Log.dobj".to_string()],
-        });
-        assert!(result.is_err());
-        assert!(
-            result
-                .unwrap_err()
-                .to_string()
-                .contains("already in progress")
-        );
+    fn test_run_action_concurrent() {
+        use std::sync::Arc;
+        let mock = Arc::new(MockCraftOps::new());
+        let handles: Vec<_> = (0..3)
+            .map(|_| {
+                let mock = mock.clone();
+                std::thread::spawn(move || {
+                    mock.run_action(RunActionInput {
+                        action_id: "FindLog".to_string(),
+                        input_object_paths: vec![],
+                    })
+                })
+            })
+            .collect();
+        for handle in handles {
+            let result = handle.join().unwrap();
+            assert!(result.is_ok());
+            assert!(result.unwrap().success);
+        }
     }
 
     #[test]

--- a/mcp/src/server.rs
+++ b/mcp/src/server.rs
@@ -126,7 +126,7 @@ impl<T: CraftOps> CraftMcpService<T> {
     }
 
     #[tool(
-        description = "Execute a crafting action. Blocks until proof generation completes. Returns error if another action is already in progress."
+        description = "Execute a crafting action. Blocks until proof generation completes. Multiple actions can run concurrently."
     )]
     async fn run_action(
         &self,
@@ -372,16 +372,24 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_run_action_in_progress_returns_error() {
-        let service = CraftMcpService::new(Arc::new(MockCraftOps::new().with_action_in_progress()));
-        let result = service
-            .run_action(Parameters(RunActionInput {
-                action_id: "FindLog".to_string(),
-                input_object_paths: vec![],
-            }))
-            .await;
-        let err = result.err().expect("should be an error");
-        assert!(err.contains("already in progress"));
+    async fn test_run_action_concurrent() {
+        let service = Arc::new(make_service());
+        let mut handles = Vec::new();
+        for _ in 0..3 {
+            let svc = service.clone();
+            handles.push(tokio::spawn(async move {
+                svc.run_action(Parameters(RunActionInput {
+                    action_id: "FindLog".to_string(),
+                    input_object_paths: vec![],
+                }))
+                .await
+            }));
+        }
+        for handle in handles {
+            let result = handle.await.unwrap();
+            assert!(result.is_ok());
+            assert!(result.unwrap().0.success);
+        }
     }
 
     #[test]


### PR DESCRIPTION
Rewrites the stdio-to-HTTP proxy from blocking sequential dispatch to async concurrent dispatch. Previously each JSON-RPC request blocked until the full response returned before the next was read, preventing parallel tool calls.

- `proxy_stdio.rs`: Replace `reqwest::blocking::Client` with `async reqwest::Client`, read stdin on a dedicated thread via `mpsc` channel, spawn a tokio task per request, serialize stdout writes through a channel. First request (`initialize`) is awaited to establish the session ID before concurrent dispatch begins.
- `server.rs`: Update `run_action` tool description to reflect that multiple actions can run concurrently.
- `mock.r`s: Remove `action_in_progress` mutex and `with_action_in_progress()` builder. Replace "already in progress" tests with concurrent execution tests (3 threads / 3 tokio tasks).

Tested with Google ADK MCP client to craft 10 logs at once, doesnt work with Claude Code/Desktop app due to a bug: https://github.com/anthropics/claude-code/issues/14353 (the suggested fix of adding annotation `read_only_hint = true` didnt work)