### PR TITLE
Compute VDF and LtEqU256 verifier data hashes at runtime

### DIFF
--- a/craft_sdk/src/lib.rs
+++ b/craft_sdk/src/lib.rs
@@ -1100,7 +1100,6 @@ mod tests {
     use std::sync::Arc;
 
     use common::test_state::TestState;
-    use hex::FromHex;
     use lt_eq_u256_pod::LtEqU256Pod;
     use pod2::{
         frontend::{MainPod, Operation},
@@ -1382,17 +1381,11 @@ mod tests {
         let dependencies = vec![
             Dependency::Intro {
                 pred: "Vdf(count, input, output)",
-                hash: Hash::from_hex(
-                    "b77a964de74c8569e6c6172692bb50147df9334fd9b572abc8d4d9c688a40e06",
-                )
-                .unwrap(),
+                hash: *vdfpod::STANDARD_VDF_VD_HASH,
             },
             Dependency::Intro {
                 pred: "LtEqU256(lhs, rhs)",
-                hash: Hash::from_hex(
-                    "2e79114ee823f4783ab5b6eb93b49abba87fb69b4d14de4cf1d78648ade73529",
-                )
-                .unwrap(),
+                hash: *lt_eq_u256_pod::STANDARD_LT_EQ_U256_VD_HASH,
             },
         ];
 

--- a/driver/src/builtin.rs
+++ b/driver/src/builtin.rs
@@ -6,11 +6,10 @@ use craft_sdk::{
     Context, Helper, SpendableObject, SpendableObjects,
     api::{self, Arg, Step, StepKind},
 };
-use hex::FromHex;
 use lt_eq_u256_pod::LtEqU256Pod;
 use pod2::{
     frontend::{MainPod, Operation},
-    middleware::{F, Hash, Key, Pod, RawValue, Statement, Value},
+    middleware::{F, Key, Pod, RawValue, Statement, Value},
 };
 use txlib::GroundingWitness;
 use vdfpod::VdfPod;
@@ -407,17 +406,11 @@ pub(crate) fn dependencies() -> Vec<api::Dependency> {
     vec![
         api::Dependency::Intro {
             pred: "Vdf(count, input, output)",
-            hash: Hash::from_hex(
-                "b77a964de74c8569e6c6172692bb50147df9334fd9b572abc8d4d9c688a40e06",
-            )
-            .unwrap(),
+            hash: *vdfpod::STANDARD_VDF_VD_HASH,
         },
         api::Dependency::Intro {
             pred: "LtEqU256(lhs, rhs)",
-            hash: Hash::from_hex(
-                "2e79114ee823f4783ab5b6eb93b49abba87fb69b4d14de4cf1d78648ade73529",
-            )
-            .unwrap(),
+            hash: *lt_eq_u256_pod::STANDARD_LT_EQ_U256_VD_HASH,
         },
     ]
 }

--- a/intro_pods/lt_eq_u256_pod/src/lib.rs
+++ b/intro_pods/lt_eq_u256_pod/src/lib.rs
@@ -54,8 +54,10 @@ use pod2::{
         },
         deserialize_proof, mainpod,
         mainpod::calculate_statements_hash,
+        serialization::CircuitDataSerializer,
         serialize_proof,
     },
+    cache::{self, CacheEntry},
     measure_gates_begin, measure_gates_end, middleware,
     middleware::{
         C, D, EMPTY_HASH, F, Hash, IntroPredicateRef, Params, Pod, Proof, RawValue, ToFields,
@@ -70,16 +72,21 @@ const LT_EQ_U256_POD_TYPE: (usize, &str) = (2002, "LtEqU256");
 
 pub static STANDARD_LT_EQ_U256_VD_HASH: std::sync::LazyLock<Hash> =
     std::sync::LazyLock::new(|| {
-        let (_, data) = &*STANDARD_LT_EQ_U256_POD_DATA;
+        let (_, data) = &**STANDARD_LT_EQ_U256_POD_DATA;
         let hash_out =
             pod2::backends::plonky2::recursion::circuit::hash_verifier_data(&data.verifier_only);
         Hash(hash_out.elements.map(|e| e))
     });
 
-static STANDARD_LT_EQ_U256_POD_DATA: std::sync::LazyLock<(
-    LtEqU256PodTarget,
-    CircuitData<F, C, D>,
-)> = std::sync::LazyLock::new(|| build().expect("successful build"));
+static STANDARD_LT_EQ_U256_POD_DATA: std::sync::LazyLock<
+    CacheEntry<(LtEqU256PodTarget, CircuitDataSerializer)>,
+> = std::sync::LazyLock::new(|| {
+    cache::get("standard_lt_eq_u256_pod_circuit_data", &(), |_| {
+        let (target, circuit_data) = build().expect("successful build");
+        (target, CircuitDataSerializer(circuit_data))
+    })
+    .expect("cache ok")
+});
 fn build() -> Result<(LtEqU256PodTarget, CircuitData<F, C, D>)> {
     let params = Params::default();
 
@@ -159,7 +166,7 @@ impl LtEqU256Pod {
         }
 
         // Build the proof
-        let (lt_eq_u256_pod_target, circuit_data) = &*STANDARD_LT_EQ_U256_POD_DATA;
+        let (lt_eq_u256_pod_target, circuit_data) = &**STANDARD_LT_EQ_U256_POD_DATA;
         let statements = pub_self_statements(lhs, rhs)
             .into_iter()
             .map(mainpod::Statement::from)
@@ -227,7 +234,7 @@ impl Pod for LtEqU256Pod {
             ));
         }
 
-        let (_, circuit_data) = &*STANDARD_LT_EQ_U256_POD_DATA;
+        let (_, circuit_data) = &**STANDARD_LT_EQ_U256_POD_DATA;
 
         let public_inputs = statements_hash
             .to_fields()
@@ -288,11 +295,8 @@ impl Pod for LtEqU256Pod {
     }
 
     fn verifier_data(&self) -> VerifierOnlyCircuitData<C, D> {
-        STANDARD_LT_EQ_U256_POD_DATA
-            .1
-            .verifier_data()
-            .verifier_only
-            .clone()
+        let (_, circuit_data) = &**STANDARD_LT_EQ_U256_POD_DATA;
+        circuit_data.verifier_data().verifier_only.clone()
     }
 
     fn common_hash(&self) -> String {
@@ -345,7 +349,7 @@ fn pub_self_statements_target(
     )]
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 struct LtEqU256PodTarget {
     vd_root: HashOutTarget,
     lhs: ValueTarget,
@@ -584,8 +588,8 @@ mod tests {
 
     #[test]
     fn test_ltequ256_vd_hash() {
-        let expected_vd_hash =
-            hash_verifier_data(&STANDARD_LT_EQ_U256_POD_DATA.1.verifier_data().verifier_only);
+        let (_, circuit_data) = &**STANDARD_LT_EQ_U256_POD_DATA;
+        let expected_vd_hash = hash_verifier_data(&circuit_data.verifier_data().verifier_only);
         assert_eq!(
             expected_vd_hash,
             HashOut::from(*STANDARD_LT_EQ_U256_VD_HASH)

--- a/intro_pods/lt_eq_u256_pod/src/lib.rs
+++ b/intro_pods/lt_eq_u256_pod/src/lib.rs
@@ -28,7 +28,6 @@
 //! ```
 
 use anyhow::Result;
-use hex::FromHex;
 use itertools::Itertools;
 use plonky2::{
     field::types::{Field, PrimeField64},
@@ -71,7 +70,10 @@ const LT_EQ_U256_POD_TYPE: (usize, &str) = (2002, "LtEqU256");
 
 pub static STANDARD_LT_EQ_U256_VD_HASH: std::sync::LazyLock<Hash> =
     std::sync::LazyLock::new(|| {
-        Hash::from_hex("2e79114ee823f4783ab5b6eb93b49abba87fb69b4d14de4cf1d78648ade73529").unwrap()
+        let (_, data) = &*STANDARD_LT_EQ_U256_POD_DATA;
+        let hash_out =
+            pod2::backends::plonky2::recursion::circuit::hash_verifier_data(&data.verifier_only);
+        Hash(hash_out.elements.map(|e| e))
     });
 
 static STANDARD_LT_EQ_U256_POD_DATA: std::sync::LazyLock<(

--- a/intro_pods/vdfpod/src/lib.rs
+++ b/intro_pods/vdfpod/src/lib.rs
@@ -38,7 +38,6 @@
 //! of this file).
 
 use anyhow::{Result, anyhow};
-use hex::FromHex;
 use itertools::Itertools;
 use plonky2::{
     field::types::Field,
@@ -91,7 +90,10 @@ const NUM_PUBLIC_INPUTS: usize = 13; // 13: count + input + output + verified_da
 const VDF_POD_TYPE: (usize, &str) = (2001, "Vdf");
 
 pub static STANDARD_VDF_VD_HASH: std::sync::LazyLock<Hash> = std::sync::LazyLock::new(|| {
-    Hash::from_hex("b77a964de74c8569e6c6172692bb50147df9334fd9b572abc8d4d9c688a40e06").unwrap()
+    let (_, data) = &*STANDARD_VDF_POD_DATA;
+    let hash_out =
+        pod2::backends::plonky2::recursion::circuit::hash_verifier_data(&data.verifier_only);
+    Hash(hash_out.elements.map(|e| e))
 });
 
 static STANDARD_VDF_POD_DATA: std::sync::LazyLock<(VdfPodTarget, CircuitData<F, C, D>)> =

--- a/intro_pods/vdfpod/src/lib.rs
+++ b/intro_pods/vdfpod/src/lib.rs
@@ -72,8 +72,10 @@ use pod2::{
             circuit::{dummy as dummy_recursive, hash_verifier_data_gadget},
             new_params as new_recursive_params,
         },
+        serialization::CircuitDataSerializer,
         serialize_proof,
     },
+    cache::{self, CacheEntry},
     measure_gates_begin, measure_gates_end, middleware,
     middleware::{
         C, D, EMPTY_HASH, F, HASH_SIZE, Hash, IntroPredicateRef, Params, Pod, Proof, RawValue,
@@ -90,14 +92,21 @@ const NUM_PUBLIC_INPUTS: usize = 13; // 13: count + input + output + verified_da
 const VDF_POD_TYPE: (usize, &str) = (2001, "Vdf");
 
 pub static STANDARD_VDF_VD_HASH: std::sync::LazyLock<Hash> = std::sync::LazyLock::new(|| {
-    let (_, data) = &*STANDARD_VDF_POD_DATA;
+    let (_, data) = &**STANDARD_VDF_POD_DATA;
     let hash_out =
         pod2::backends::plonky2::recursion::circuit::hash_verifier_data(&data.verifier_only);
     Hash(hash_out.elements.map(|e| e))
 });
 
-static STANDARD_VDF_POD_DATA: std::sync::LazyLock<(VdfPodTarget, CircuitData<F, C, D>)> =
-    std::sync::LazyLock::new(|| build().expect("successful build"));
+static STANDARD_VDF_POD_DATA: std::sync::LazyLock<
+    CacheEntry<(VdfPodTarget, CircuitDataSerializer)>,
+> = std::sync::LazyLock::new(|| {
+    cache::get("standard_vdf_pod_circuit_data", &(), |_| {
+        let (target, circuit_data) = build().expect("successful build");
+        (target, CircuitDataSerializer(circuit_data))
+    })
+    .expect("cache ok")
+});
 fn build() -> Result<(VdfPodTarget, CircuitData<F, C, D>)> {
     let params = Params::default();
 
@@ -217,7 +226,7 @@ impl VdfPod {
         proof: ProofWithPublicInputs<F, C, D>,
     ) -> Result<VdfPod> {
         // verify the given proof in a VdfPodTarget circuit
-        let (vdf_pod_target, circuit_data) = &*STANDARD_VDF_POD_DATA;
+        let (vdf_pod_target, circuit_data) = &**STANDARD_VDF_POD_DATA;
         let statements = pub_self_statements(count, input, output)
             .into_iter()
             .map(mainpod::Statement::from)
@@ -339,7 +348,7 @@ impl Pod for VdfPod {
             ));
         }
 
-        let (_, circuit_data) = &*STANDARD_VDF_POD_DATA;
+        let (_, circuit_data) = &**STANDARD_VDF_POD_DATA;
 
         let public_inputs = statements_hash
             .to_fields()
@@ -402,11 +411,8 @@ impl Pod for VdfPod {
     }
 
     fn verifier_data(&self) -> VerifierOnlyCircuitData<C, D> {
-        STANDARD_VDF_POD_DATA
-            .1
-            .verifier_data()
-            .verifier_only
-            .clone()
+        let (_, circuit_data) = &**STANDARD_VDF_POD_DATA;
+        circuit_data.verifier_data().verifier_only.clone()
     }
 
     fn common_hash(&self) -> String {
@@ -465,7 +471,7 @@ fn pub_self_statements_target(
     )]
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 struct VdfPodTarget {
     vd_root: HashOutTarget,
     statements_hash: HashOutTarget,
@@ -753,7 +759,7 @@ mod tests {
             "generate VDF_RECURSIVE_CIRCUIT, STANDARD_VDF_POD_DATA, STANDARD_REC_MAIN_POD_CIRCUIT",
             {
                 let (_, _) = &*VDF_RECURSIVE_CIRCUIT;
-                let (_, _) = &*STANDARD_VDF_POD_DATA;
+                let (_, _) = &**STANDARD_VDF_POD_DATA;
                 let _ =
                     &*pod2::backends::plonky2::cache_get_standard_rec_main_pod_common_circuit_data(
                     );
@@ -819,7 +825,7 @@ mod tests {
             "generate VDF_RECURSIVE_CIRCUIT, STANDARD_VDF_POD_DATA, standard_rec_main_pod_common_circuit_data",
             {
                 let (_, _) = &*VDF_RECURSIVE_CIRCUIT;
-                let (_, _) = &*STANDARD_VDF_POD_DATA;
+                let (_, _) = &**STANDARD_VDF_POD_DATA;
                 let _ =
                     &*pod2::backends::plonky2::cache_get_standard_rec_main_pod_common_circuit_data(
                     );
@@ -881,8 +887,8 @@ mod tests {
 
     #[test]
     fn test_vdf_vd_hash() {
-        let expected_vd_hash =
-            hash_verifier_data(&STANDARD_VDF_POD_DATA.1.verifier_data().verifier_only);
+        let (_, circuit_data) = &**STANDARD_VDF_POD_DATA;
+        let expected_vd_hash = hash_verifier_data(&circuit_data.verifier_data().verifier_only);
         assert_eq!(expected_vd_hash, HashOut::from(*STANDARD_VDF_VD_HASH));
     }
 


### PR DESCRIPTION
Replaces hardcoded hex hash strings with hashes computed from the circuit's verifier data at init time, so they stay correct if the circuits change.

I was using a local pod2 build with different parameters and facing this issue