### PR TITLE
Support dependent actions

### DIFF
--- a/sdk/README.md
+++ b/sdk/README.md
@@ -147,7 +147,7 @@ The emitted podlang embeds `target` as a hex `Raw(0x00…)` literal.
 - [ ] Execution time type checking without panics
 - [ ] operator+
 - [ ] operator*
-- [ ] dependent action
+- [x] dependent action
 - [x] pexe.zip support (packaged by the `pexe` crate's CLI)
 - [x] manifest support
 - [ ] error pretty print
@@ -211,6 +211,12 @@ UseWoodPick(wood_pick, tx, tx0, private: wood_pick0, wood_pick1, wood_pick2, dur
   tx::TxMutated(tx, tx0, wood_pick, wood_pick0)
 )
 
+MineStoneWithWoodPick(stone, tx, tx0, private: tx1, pick) = AND(
+  UseWoodPick(pick, tx1, tx0)
+  DictContains(stone, "blueprint", "Stone")
+  tx::TxInserted(tx, tx1, stone)
+)
+
 // Classes
 
 IsLog(state, private: tx, tx0) = OR(
@@ -229,5 +235,9 @@ IsStick(state, private: tx, tx0, _other_0) = OR(
 IsWoodPick(state, private: tx, tx0) = OR(
   CraftWoodPick(state, tx, tx0)
   UseWoodPick(state, tx, tx0)
+)
+
+IsStone(state, private: tx, tx0) = OR(
+  MineStoneWithWoodPick(state, tx, tx0)
 )
 ```

--- a/sdk/src/fmt_podlang.rs
+++ b/sdk/src/fmt_podlang.rs
@@ -99,7 +99,7 @@ fn fmt_action_pub_vars(action: &ActionContext) -> Vec<String> {
                 obj,
                 class: _,
             } => vars.push(obj.borrow().var_name().to_string()),
-            Inst::SubAction { action: _, obj } => vars.push(obj.borrow().var_name().to_string()),
+            // Inst::SubAction { action: _, obj } => vars.push(obj.borrow().var_name().to_string()),
             _ => {}
         }
     }

--- a/sdk/src/fmt_podlang.rs
+++ b/sdk/src/fmt_podlang.rs
@@ -93,13 +93,14 @@ fn fmt_action_vars(action: &ActionContext) -> Vec<String> {
 fn fmt_action_pub_vars(action: &ActionContext) -> Vec<String> {
     let mut vars = Vec::new();
     for inst in &action.insts {
-        if let Inst::Object {
-            io: ObjectIO::Mutate | ObjectIO::Output,
-            obj,
-            class: _,
-        } = inst
-        {
-            vars.push(obj.borrow().var_name().to_string());
+        match inst {
+            Inst::Object {
+                io: ObjectIO::Mutate | ObjectIO::Output,
+                obj,
+                class: _,
+            } => vars.push(obj.borrow().var_name().to_string()),
+            Inst::SubAction { action: _, obj } => vars.push(obj.borrow().var_name().to_string()),
+            _ => {}
         }
     }
     vars.extend_from_slice(&["tx".to_string(), "tx0".to_string()]);
@@ -109,11 +110,16 @@ fn fmt_action_pub_vars(action: &ActionContext) -> Vec<String> {
 fn fmt_action(action: &ActionContext, w: &mut dyn fmt::Write) -> fmt::Result {
     write!(w, "{}(", action.name)?;
     let pub_var_names = fmt_action_pub_vars(action);
-    for var in &pub_var_names {
-        write!(w, "{var}, ")?;
+    for (i, var) in pub_var_names.iter().enumerate() {
+        if i != 0 {
+            write!(w, ", ")?;
+        }
+        write!(w, "{var}")?;
     }
-    write!(w, "private: ")?;
     let var_names = fmt_action_vars(action);
+    if var_names.len() - pub_var_names.len() > 0 {
+        write!(w, ", private: ")?;
+    }
     for (i, var) in var_names
         .iter()
         .filter(|v| !pub_var_names.contains(v))
@@ -154,6 +160,16 @@ fn fmt_action(action: &ActionContext, w: &mut dyn fmt::Write) -> fmt::Result {
                 }
                 let obj = obj.borrow();
                 objs.push((io, obj.var_name().to_string()));
+            }
+            Inst::SubAction { action, obj } => {
+                let tx = &vars["tx"];
+                let tx_next = tx.next();
+                writeln!(
+                    w,
+                    "  {action}({obj}, {tx_next}, {tx})",
+                    obj = ArgFmt(&vars, obj)
+                )?;
+                vars.get_mut("tx").expect("tx exists").inc();
             }
             Inst::Set { obj, kvs } => {
                 let obj = &vars[obj.as_str()];

--- a/sdk/src/fmt_podlang.rs
+++ b/sdk/src/fmt_podlang.rs
@@ -93,14 +93,13 @@ fn fmt_action_vars(action: &ActionContext) -> Vec<String> {
 fn fmt_action_pub_vars(action: &ActionContext) -> Vec<String> {
     let mut vars = Vec::new();
     for inst in &action.insts {
-        match inst {
-            Inst::Object {
-                io: ObjectIO::Mutate | ObjectIO::Output,
-                obj,
-                class: _,
-            } => vars.push(obj.borrow().var_name().to_string()),
-            // Inst::SubAction { action: _, obj } => vars.push(obj.borrow().var_name().to_string()),
-            _ => {}
+        if let Inst::Object {
+            io: ObjectIO::Mutate | ObjectIO::Output,
+            obj,
+            class: _,
+        } = inst
+        {
+            vars.push(obj.borrow().var_name().to_string())
         }
     }
     vars.extend_from_slice(&["tx".to_string(), "tx0".to_string()]);

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -6,22 +6,22 @@ use std::rc::Rc;
 use std::slice;
 use std::sync::Arc;
 
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use hex::FromHex;
 use itertools::zip_eq;
 use lt_eq_u256_pod::LtEqU256Pod;
 use pod2::{
     backends::plonky2::{basetypes::DEFAULT_VD_SET, mainpod::Prover, mock::mainpod::MockProver},
     frontend::{MainPod, MultiPodBuilder, Operation, OperationArg},
-    lang::{load_module, Module},
+    lang::{Module, load_module},
     middleware::{
+        EMPTY_VALUE, F, Hash, Key, MainPodProver, NativePredicate, OperationAux, OperationType,
+        Params, Pod, Predicate, RawValue, Statement, VDSet, Value,
         containers::{Array, Dictionary, Set},
-        Hash, Key, MainPodProver, NativePredicate, OperationAux, OperationType, Params, Pod,
-        Predicate, RawValue, Statement, VDSet, Value, EMPTY_VALUE, F,
     },
 };
 use pod2utils::{dict, macros::BuildContext, rand_raw_value};
-use rhai::{CallFnOptions, Dynamic, Engine, EvalAltResult, EvalContext, Expression, Scope, AST};
+use rhai::{AST, CallFnOptions, Dynamic, Engine, EvalAltResult, EvalContext, Expression, Scope};
 use txlib::{GroundingWitness, Tx, TxBuilder};
 use vdfpod::VdfPod;
 

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -1,6 +1,7 @@
 use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
 use std::fmt;
+use std::mem;
 use std::rc::Rc;
 use std::slice;
 use std::sync::Arc;
@@ -394,6 +395,82 @@ impl ActionHandle {
             Ok(())
         }
     }
+    // Execute an action (assumes Execution phase), returns the Action statement
+    fn exe_action(&self, action: &str) -> RuntimeResult<Statement> {
+        let module = {
+            let ctx = self.0.borrow();
+            ctx.exe_ctx.as_ref().expect("Some").module.clone()
+        };
+        let options = CallFnOptions::new().with_tag(self.clone());
+        // Execute the action rhai code
+        let mut scope = Scope::new();
+        // We're passing a clone of `self` here which may have its ActionContext borrow-ed or
+        // borrow_mut-ed, so we need to make sure the ActionContext is not borrowed at this point.
+        let _result = module.engine.call_fn_with_options::<Dynamic>(
+            options,
+            &mut scope,
+            &module.ast,
+            &action,
+            (self.clone(),),
+        )?;
+        let mut ctx = self.0.borrow_mut();
+        let mut exe_ctx = ctx.exe_ctx.take().expect("Some"); // Take ExeContext from ActionContext
+
+        // Add the transaction predicates
+        let mut output_objs = Vec::new();
+        let insts = mem::take(&mut ctx.insts); // ctx.insts is cleared for the next action
+        for inst in &insts {
+            if let Inst::Object { io, obj, class } = inst {
+                let obj = obj.borrow().to_dict();
+                let st = match io {
+                    ObjectIO::Output => {
+                        output_objs.push(OutputData {
+                            class: class.clone(),
+                            obj: obj.clone(),
+                        });
+                        exe_ctx.tx_builder.insert(&mut exe_ctx.bld, obj)
+                    }
+                    ObjectIO::Input => {
+                        exe_ctx.inputs2.pop().expect("exists");
+                        exe_ctx.tx_builder.delete(&mut exe_ctx.bld, obj)
+                    }
+                    ObjectIO::Mutate => {
+                        let obj0 = exe_ctx.inputs2.pop().expect("exists").1;
+                        output_objs.push(OutputData {
+                            class: class.clone(),
+                            obj: obj.clone(),
+                        });
+                        exe_ctx.tx_builder.mutate(&mut exe_ctx.bld, obj, obj0)
+                    }
+                };
+                exe_ctx.sts.push(st);
+            }
+        }
+
+        // Action statement
+        let sts = mem::take(&mut exe_ctx.sts); // exe_ctx.sts is cleared for the next action
+        let st_action = exe_ctx
+            .bld
+            .apply_custom_pred(false, &action, HashMap::new(), sts)
+            .unwrap();
+
+        for (index, OutputData { class, obj: _ }) in output_objs.iter().enumerate() {
+            let class = module.class_by_name(class);
+            let mut sts = vec![Statement::None; class.actions.len()];
+            let class_st_index = module.output_index_class_st_index[&(action.to_string(), index)];
+            sts[class_st_index] = st_action.clone();
+            let pred = format!("Is{}", class.name);
+            // We delay the creation of the class statement until we have created all actions
+            // because the class statements go to different pods.
+            exe_ctx.output_objs_st_class_data.push((pred, sts));
+        }
+        exe_ctx
+            .outputs
+            .extend(output_objs.into_iter().map(|o| o.obj));
+
+        ctx.exe_ctx = Some(exe_ctx); // Put ExeContext back into ActionContext
+        Ok(st_action)
+    }
     //
     // Exposed methods helpers
     //
@@ -432,9 +509,18 @@ impl ActionHandle {
         // variables.  We could define the var syntax with destructuring of arrays with
         // `engine.register_custom_syntax_with_state_raw`
         let arg = Rc::new(RefCell::new(VarOrValue::var(Type::Dict)));
+        // We don't borrow the ActionContext here because exe_action requires exclusive access to
+        // it so that it can execute the Rhai code that calls hosts functions which borrow and
+        // borrow_mut the ActionContext.
+        let is_exe_phase = self.0.borrow().exe_ctx.is_some();
+        let st_action = if is_exe_phase {
+            self.exe_action(&action)?
+        } else {
+            Statement::None // placeholder
+        };
         let mut ctx = self.0.borrow_mut();
         if let Some(exe_ctx) = &mut ctx.exe_ctx {
-            // exe_ctx.sub_action(action);
+            exe_ctx.sts.push(st_action);
         }
         ctx.insts.push(Inst::SubAction {
             action,
@@ -824,7 +910,7 @@ impl ActionMeta {
                     meta.inputs.push((obj_name.clone(), class.clone()));
                     meta.outputs.push((obj_name, class.clone()));
                 }
-                Inst::SubAction { action, obj } => {
+                Inst::SubAction { action, obj: _ } => {
                     let subaction = actions
                         .iter()
                         .find(|a| &a.name == action)
@@ -833,10 +919,10 @@ impl ActionMeta {
                         meta.inputs.push(input.clone());
                     }
                     // For now subactions only support 1 output
-                    assert_eq!(1, subaction.outputs.len());
-                    let class = subaction.outputs[0].1.clone();
-                    let obj_name = obj.borrow().as_var().name.clone();
-                    meta.outputs.push((obj_name, class));
+                    // assert_eq!(1, subaction.outputs.len());
+                    // let class = subaction.outputs[0].1.clone();
+                    // let obj_name = obj.borrow().as_var().name.clone();
+                    // meta.outputs.push((obj_name, class));
                 }
                 _ => {}
             }
@@ -950,7 +1036,6 @@ impl Loader {
     fn module(self, engine: Rc<Engine>, ast: AST) -> SdkModule {
         let mut podlang_src = String::new();
         fmt_podlang::fmt(&self, &mut podlang_src).unwrap();
-        println!("DBG\n{podlang_src}");
 
         let params = Params::default();
         let module = Arc::new(
@@ -1085,8 +1170,15 @@ struct ExeContext {
     vd_set: VDSet,
     tx_builder: TxBuilder,
     bld: BuildContext,
+    module: Rc<SdkModule>,
+    // -- Consumed during execution --
     // Input (class statement, object) to be consumed by input/mutate
     inputs: Vec<(Statement, Dictionary)>,
+    inputs2: Vec<(Statement, Dictionary)>,
+    // -- Generated during execution --
+    outputs: Vec<Dictionary>,
+    // Data necessary to make each output object' class statement: (predicate name, statements)
+    output_objs_st_class_data: Vec<(String, Vec<Statement>)>,
     // Statements used to build the Action custom statement
     sts: Vec<Statement>,
 }
@@ -1104,9 +1196,6 @@ impl ExeContext {
         // TODO: If mock return a deterministic value that is different after every call, with a
         // nonce that persists
         Value::from(rand_raw_value())
-    }
-    fn action(&mut self) -> Result<()> {
-        todo!()
     }
 }
 
@@ -1183,77 +1272,83 @@ impl Executor {
             mock: self.mock,
             params: self.params.clone(),
             vd_set: self.vd_set.clone(),
-            inputs: input_class_sts_objs.clone(),
-            bld,
             tx_builder,
+            bld,
+            module: self.module.clone(),
+            inputs: input_class_sts_objs.clone(),
+            inputs2: input_class_sts_objs.clone(),
+            outputs: Vec::new(),
+            output_objs_st_class_data: Vec::new(),
             sts: Vec::new(),
         };
         let action_handle = ActionHandle::new(action.name.clone(), Some(exe_ctx));
-        let mut scope = Scope::new();
-        let options = CallFnOptions::new().with_tag(action_handle.clone());
-        // Execute the action rhai code
-        let _result = self.module.engine.call_fn_with_options::<Dynamic>(
-            options,
-            &mut scope,
-            &self.module.ast,
-            &action.name,
-            (action_handle.clone(),),
-        )?;
+        let st_action = action_handle.exe_action(&action.name)?;
+
+        // let options = CallFnOptions::new().with_tag(action_handle.clone());
+        // // Execute the action rhai code
+        // let mut scope = Scope::new();
+        // let _result = self.module.engine.call_fn_with_options::<Dynamic>(
+        //     options,
+        //     &mut scope,
+        //     &self.module.ast,
+        //     &action.name,
+        //     (action_handle.clone(),),
+        // )?;
         let mut ctx = action_handle.0.borrow_mut();
         let mut exe_ctx = ctx.exe_ctx.take().expect("Some");
 
-        // Add the transaction predicates
-        let mut output_objs = Vec::new();
-        for inst in &ctx.insts {
-            if let Inst::Object { io, obj, class } = inst {
-                let obj = obj.borrow().to_dict();
-                let st = match io {
-                    ObjectIO::Output => {
-                        output_objs.push(OutputData {
-                            class: class.clone(),
-                            obj: obj.clone(),
-                        });
-                        exe_ctx.tx_builder.insert(&mut exe_ctx.bld, obj)
-                    }
-                    ObjectIO::Input => {
-                        input_class_sts_objs.pop().expect("exists");
-                        exe_ctx.tx_builder.delete(&mut exe_ctx.bld, obj)
-                    }
-                    ObjectIO::Mutate => {
-                        let obj0 = input_class_sts_objs.pop().expect("exists").1;
-                        output_objs.push(OutputData {
-                            class: class.clone(),
-                            obj: obj.clone(),
-                        });
-                        exe_ctx.tx_builder.mutate(&mut exe_ctx.bld, obj, obj0)
-                    }
-                };
-                exe_ctx.sts.push(st);
-            }
-        }
+        // // Add the transaction predicates
+        // let mut output_objs = Vec::new();
+        // for inst in &ctx.insts {
+        //     if let Inst::Object { io, obj, class } = inst {
+        //         let obj = obj.borrow().to_dict();
+        //         let st = match io {
+        //             ObjectIO::Output => {
+        //                 output_objs.push(OutputData {
+        //                     class: class.clone(),
+        //                     obj: obj.clone(),
+        //                 });
+        //                 exe_ctx.tx_builder.insert(&mut exe_ctx.bld, obj)
+        //             }
+        //             ObjectIO::Input => {
+        //                 input_class_sts_objs.pop().expect("exists");
+        //                 exe_ctx.tx_builder.delete(&mut exe_ctx.bld, obj)
+        //             }
+        //             ObjectIO::Mutate => {
+        //                 let obj0 = input_class_sts_objs.pop().expect("exists").1;
+        //                 output_objs.push(OutputData {
+        //                     class: class.clone(),
+        //                     obj: obj.clone(),
+        //                 });
+        //                 exe_ctx.tx_builder.mutate(&mut exe_ctx.bld, obj, obj0)
+        //             }
+        //         };
+        //         exe_ctx.sts.push(st);
+        //     }
+        // }
 
-        // Action statement
-        let st_action = exe_ctx
-            .bld
-            .apply_custom_pred(false, &action.name, HashMap::new(), exe_ctx.sts)
-            .unwrap();
+        // // Action statement
+        // let st_action = exe_ctx
+        //     .bld
+        //     .apply_custom_pred(false, &action.name, HashMap::new(), exe_ctx.sts)
+        //     .unwrap();
         exe_ctx.bld.builder.reveal(&st_action).unwrap();
 
-        // Data necessary to make each output object' class statement
-        let mut output_objs_st_class_data = Vec::new();
+        // // Data necessary to make each output object' class statement
+        // let mut output_objs_st_class_data = Vec::new();
 
-        // Output (includes Output & Mutate) Class(obj) statements
-        for (index, OutputData { class, obj: _ }) in output_objs.iter().enumerate() {
-            let class = self.module.class_by_name(class);
-            let mut sts = vec![Statement::None; class.actions.len()];
-            let class_st_index =
-                self.module.output_index_class_st_index[&(action.name.clone(), index)];
-            sts[class_st_index] = st_action.clone();
-            let pred = format!("Is{}", class.name);
-            // We delay the creation of the class statement until we have created all actions
-            // because the class statements go to different pods.
-            output_objs_st_class_data.push((pred, sts));
-        }
+        // // Output (includes Output & Mutate) Class(obj) statements
+        // for (index, OutputData { class, obj: _ }) in output_objs.iter().enumerate() {
+        //     let class = self.module.class_by_name(class);
+        //     let mut sts = vec![Statement::None; class.actions.len()];
+        //     let class_st_index =
+        //         self.module.output_index_class_st_index[&(action.name.clone(), index)];
+        //     sts[class_st_index] = st_action.clone();
+        //     let pred = format!("Is{}", class.name);
+        //     // We delay the creation of the class statement until we have created all actions
+        //     // because the class statements go to different pods.
+        //     output_objs_st_class_data.push((pred, sts));
+        // }
 
         // output_objs.extend(output.into_iter().map(|out| out.obj));
 
@@ -1285,7 +1380,7 @@ impl Executor {
 
         // Make one pod for each object with just the corresponding class statement.
         let mut obj_pods = Vec::new();
-        for (pred, sts) in output_objs_st_class_data {
+        for (pred, sts) in exe_ctx.output_objs_st_class_data {
             bld.builder = self.new_builder();
             bld.builder.add_pod(pod.clone()).unwrap();
             let st_class = bld
@@ -1298,11 +1393,11 @@ impl Executor {
             obj_pods.push(obj_pod);
         }
 
-        let objs = output_objs.into_iter().map(|out| out.obj).collect();
+        // let objs = output_objs.into_iter().map(|out| out.obj).collect();
         Ok(SpendableObjects {
             tx_pod,
             obj_pods,
-            objs,
+            objs: exe_ctx.outputs,
             tx,
         })
     }

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -5,22 +5,22 @@ use std::rc::Rc;
 use std::slice;
 use std::sync::Arc;
 
-use anyhow::{Result, anyhow};
+use anyhow::{anyhow, Result};
 use hex::FromHex;
 use itertools::zip_eq;
 use lt_eq_u256_pod::LtEqU256Pod;
 use pod2::{
     backends::plonky2::{basetypes::DEFAULT_VD_SET, mainpod::Prover, mock::mainpod::MockProver},
     frontend::{MainPod, MultiPodBuilder, Operation, OperationArg},
-    lang::{Module, load_module},
+    lang::{load_module, Module},
     middleware::{
-        EMPTY_VALUE, F, Hash, Key, MainPodProver, NativePredicate, OperationAux, OperationType,
-        Params, Pod, Predicate, RawValue, Statement, VDSet, Value,
         containers::{Array, Dictionary, Set},
+        Hash, Key, MainPodProver, NativePredicate, OperationAux, OperationType, Params, Pod,
+        Predicate, RawValue, Statement, VDSet, Value, EMPTY_VALUE, F,
     },
 };
 use pod2utils::{dict, macros::BuildContext, rand_raw_value};
-use rhai::{AST, CallFnOptions, Dynamic, Engine, EvalAltResult, EvalContext, Expression, Scope};
+use rhai::{CallFnOptions, Dynamic, Engine, EvalAltResult, EvalContext, Expression, Scope, AST};
 use txlib::{GroundingWitness, Tx, TxBuilder};
 use vdfpod::VdfPod;
 
@@ -69,6 +69,10 @@ enum Inst {
         io: ObjectIO,
         obj: Ref,
         class: String,
+    },
+    SubAction {
+        action: String,
+        obj: Ref,
     },
     /// Update a key of the object
     Update {
@@ -422,6 +426,23 @@ impl ActionHandle {
     fn mutate(self, class: String) -> RuntimeResult<ArgHandle> {
         self.obj_io(ObjectIO::Mutate, class)
     }
+    fn subaction(self, action: String) -> RuntimeResult<ArgHandle> {
+        // For now assume that a subaction returns a single output object.
+        // If we want multiple outputs we need to extend the `var` syntax to declare multiple
+        // variables.  We could define the var syntax with destructuring of arrays with
+        // `engine.register_custom_syntax_with_state_raw`
+        let arg = Rc::new(RefCell::new(VarOrValue::var(Type::Dict)));
+        let mut ctx = self.0.borrow_mut();
+        if let Some(exe_ctx) = &mut ctx.exe_ctx {
+            // exe_ctx.sub_action(action);
+        }
+        ctx.insts.push(Inst::SubAction {
+            action,
+            obj: arg.clone(),
+        });
+        ctx.inc_t_var("tx").expect("tx exists");
+        Ok(ArgHandle::new(self.clone(), arg))
+    }
     fn random(self) -> RuntimeResult<ArgHandle> {
         let value = Rc::new(RefCell::new(VarOrValue::var(Type::Raw)));
         let mut ctx = self.0.borrow_mut();
@@ -770,13 +791,13 @@ pub struct ActionMeta {
     pub outputs: Vec<(String, String)>,
 }
 
-impl From<&ActionContext> for ActionMeta {
-    fn from(action: &ActionContext) -> Self {
+impl ActionMeta {
+    fn from_action_ctx(actions: &[ActionMeta], action_ctx: &ActionContext) -> Result<ActionMeta> {
         let mut meta = Self {
-            name: action.name.clone(),
+            name: action_ctx.name.clone(),
             ..Self::default()
         };
-        for inst in &action.insts {
+        for inst in &action_ctx.insts {
             match inst {
                 Inst::Object {
                     io: ObjectIO::Input,
@@ -803,10 +824,24 @@ impl From<&ActionContext> for ActionMeta {
                     meta.inputs.push((obj_name.clone(), class.clone()));
                     meta.outputs.push((obj_name, class.clone()));
                 }
+                Inst::SubAction { action, obj } => {
+                    let subaction = actions
+                        .iter()
+                        .find(|a| &a.name == action)
+                        .ok_or_else(|| anyhow!("subaction {action} not defined"))?;
+                    for input in &subaction.inputs {
+                        meta.inputs.push(input.clone());
+                    }
+                    // For now subactions only support 1 output
+                    assert_eq!(1, subaction.outputs.len());
+                    let class = subaction.outputs[0].1.clone();
+                    let obj_name = obj.borrow().as_var().name.clone();
+                    meta.outputs.push((obj_name, class));
+                }
                 _ => {}
             }
         }
-        meta
+        Ok(meta)
     }
 }
 
@@ -857,7 +892,7 @@ impl Loader {
         classes
     }
 
-    fn new(actions: Vec<ActionHandle>) -> Self {
+    fn new(actions: Vec<ActionHandle>) -> Result<Self> {
         let txlib_mod = Arc::new(txlib::predicates::module());
         let dependencies = vec![
             Dependency::Module {
@@ -879,18 +914,19 @@ impl Loader {
                 .unwrap(),
             },
         ];
-        let actions_meta: Vec<_> = actions
-            .iter()
-            .map(|a| ActionMeta::from(&*a.0.borrow()))
-            .collect();
+        let mut actions_meta = Vec::with_capacity(actions.len());
+        for action in &actions {
+            let action_meta = ActionMeta::from_action_ctx(&actions_meta, &*action.0.borrow())?;
+            actions_meta.push(action_meta);
+        }
         let classes = Self::actions_to_classes(&actions_meta);
-        Self {
+        Ok(Self {
             txlib_mod,
             dependencies,
             actions,
             actions_meta,
             classes,
-        }
+        })
     }
 
     fn action_by_name(&self, name: &str) -> &ActionMeta {
@@ -914,6 +950,7 @@ impl Loader {
     fn module(self, engine: Rc<Engine>, ast: AST) -> SdkModule {
         let mut podlang_src = String::new();
         fmt_podlang::fmt(&self, &mut podlang_src).unwrap();
+        println!("DBG\n{podlang_src}");
 
         let params = Params::default();
         let module = Arc::new(
@@ -1068,6 +1105,9 @@ impl ExeContext {
         // nonce that persists
         Value::from(rand_raw_value())
     }
+    fn action(&mut self) -> Result<()> {
+        todo!()
+    }
 }
 
 struct OutputData {
@@ -1143,8 +1183,6 @@ impl Executor {
             mock: self.mock,
             params: self.params.clone(),
             vd_set: self.vd_set.clone(),
-            // grounding_witness: self.grounding_witness,
-            // prover: self.prover,
             inputs: input_class_sts_objs.clone(),
             bld,
             tx_builder,
@@ -1335,6 +1373,7 @@ fn new_engine() -> Engine {
         .register_fn("output", ActionHandle::output)
         .register_fn("input", ActionHandle::input)
         .register_fn("mutate", ActionHandle::mutate)
+        .register_fn("subaction", ActionHandle::subaction)
         .register_fn("random", ActionHandle::random)
         .register_fn("st_gt", ActionHandle::st_gt)
         .register_fn("st_sum_of", ActionHandle::st_sum_of)
@@ -1404,7 +1443,7 @@ impl Sdk {
             action_handles.push(action_handle);
         }
 
-        let loader = Loader::new(action_handles);
+        let loader = Loader::new(action_handles)?;
         Ok(Rc::new(loader.module(self.engine.clone(), ast)))
     }
 

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -6,22 +6,22 @@ use std::rc::Rc;
 use std::slice;
 use std::sync::Arc;
 
-use anyhow::{Result, anyhow};
+use anyhow::{anyhow, Result};
 use hex::FromHex;
 use itertools::zip_eq;
 use lt_eq_u256_pod::LtEqU256Pod;
 use pod2::{
     backends::plonky2::{basetypes::DEFAULT_VD_SET, mainpod::Prover, mock::mainpod::MockProver},
     frontend::{MainPod, MultiPodBuilder, Operation, OperationArg},
-    lang::{Module, load_module},
+    lang::{load_module, Module},
     middleware::{
-        EMPTY_VALUE, F, Hash, Key, MainPodProver, NativePredicate, OperationAux, OperationType,
-        Params, Pod, Predicate, RawValue, Statement, VDSet, Value,
         containers::{Array, Dictionary, Set},
+        Hash, Key, MainPodProver, NativePredicate, OperationAux, OperationType, Params, Pod,
+        Predicate, RawValue, Statement, VDSet, Value, EMPTY_VALUE, F,
     },
 };
 use pod2utils::{dict, macros::BuildContext, rand_raw_value};
-use rhai::{AST, CallFnOptions, Dynamic, Engine, EvalAltResult, EvalContext, Expression, Scope};
+use rhai::{CallFnOptions, Dynamic, Engine, EvalAltResult, EvalContext, Expression, Scope, AST};
 use txlib::{GroundingWitness, Tx, TxBuilder};
 use vdfpod::VdfPod;
 
@@ -923,11 +923,6 @@ impl ActionMeta {
                     for input in &subaction.inputs {
                         meta.inputs.push(input.clone());
                     }
-                    // For now subactions only support 1 output
-                    // assert_eq!(1, subaction.outputs.len());
-                    // let class = subaction.outputs[0].1.clone();
-                    // let obj_name = obj.borrow().as_var().name.clone();
-                    // meta.outputs.push((obj_name, class));
                 }
                 _ => {}
             }
@@ -1331,7 +1326,6 @@ impl Executor {
             obj_pods.push(obj_pod);
         }
 
-        // let objs = output_objs.into_iter().map(|out| out.obj).collect();
         Ok(SpendableObjects {
             tx_pod,
             obj_pods,

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -453,6 +453,8 @@ impl ActionHandle {
             .bld
             .apply_custom_pred(false, &action, HashMap::new(), sts)
             .unwrap();
+        // Reveal the action in the internal pod that just outputs action statements.
+        exe_ctx.bld.builder.reveal(&st_action).unwrap();
 
         for (index, OutputData { class, obj: _ }) in output_objs.iter().enumerate() {
             let class = module.class_by_name(class);
@@ -1282,7 +1284,7 @@ impl Executor {
             sts: Vec::new(),
         };
         let action_handle = ActionHandle::new(action.name.clone(), Some(exe_ctx));
-        let st_action = action_handle.exe_action(&action.name)?;
+        action_handle.exe_action(&action.name)?;
 
         // let options = CallFnOptions::new().with_tag(action_handle.clone());
         // // Execute the action rhai code
@@ -1332,7 +1334,7 @@ impl Executor {
         //     .bld
         //     .apply_custom_pred(false, &action.name, HashMap::new(), exe_ctx.sts)
         //     .unwrap();
-        exe_ctx.bld.builder.reveal(&st_action).unwrap();
+        // exe_ctx.bld.builder.reveal(&st_action).unwrap();
 
         // // Data necessary to make each output object' class statement
         // let mut output_objs_st_class_data = Vec::new();

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -1,27 +1,27 @@
 use std::cell::RefCell;
-use std::collections::{HashMap, HashSet};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::fmt;
 use std::mem;
 use std::rc::Rc;
 use std::slice;
 use std::sync::Arc;
 
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use hex::FromHex;
 use itertools::zip_eq;
 use lt_eq_u256_pod::LtEqU256Pod;
 use pod2::{
     backends::plonky2::{basetypes::DEFAULT_VD_SET, mainpod::Prover, mock::mainpod::MockProver},
     frontend::{MainPod, MultiPodBuilder, Operation, OperationArg},
-    lang::{load_module, Module},
+    lang::{Module, load_module},
     middleware::{
+        EMPTY_VALUE, F, Hash, Key, MainPodProver, NativePredicate, OperationAux, OperationType,
+        Params, Pod, Predicate, RawValue, Statement, VDSet, Value,
         containers::{Array, Dictionary, Set},
-        Hash, Key, MainPodProver, NativePredicate, OperationAux, OperationType, Params, Pod,
-        Predicate, RawValue, Statement, VDSet, Value, EMPTY_VALUE, F,
     },
 };
 use pod2utils::{dict, macros::BuildContext, rand_raw_value};
-use rhai::{CallFnOptions, Dynamic, Engine, EvalAltResult, EvalContext, Expression, Scope, AST};
+use rhai::{AST, CallFnOptions, Dynamic, Engine, EvalAltResult, EvalContext, Expression, Scope};
 use txlib::{GroundingWitness, Tx, TxBuilder};
 use vdfpod::VdfPod;
 
@@ -367,12 +367,14 @@ impl ActionHandle {
                         .set_value(Value::from(Self::new_obj(exe_ctx)));
                 }
                 ObjectIO::Input => {
-                    let (st_class, obj) = exe_ctx.inputs.pop().expect("exists");
+                    let (st_class, obj) = exe_ctx.inputs[exe_ctx.input_index].clone();
+                    exe_ctx.input_index += 1;
                     exe_ctx.sts.push(st_class);
                     arg.borrow_mut().set_value(Value::from(obj));
                 }
                 ObjectIO::Mutate => {
-                    let (st_class, obj) = exe_ctx.inputs.pop().expect("exists");
+                    let (st_class, obj) = exe_ctx.inputs[exe_ctx.input_index].clone();
+                    exe_ctx.input_index += 1;
                     exe_ctx.sts.push(st_class);
                     arg.borrow_mut().set_value(Value::from(obj));
                 }
@@ -431,11 +433,11 @@ impl ActionHandle {
                         exe_ctx.tx_builder.insert(&mut exe_ctx.bld, obj)
                     }
                     ObjectIO::Input => {
-                        exe_ctx.inputs2.pop().expect("exists");
+                        exe_ctx.inputs.pop_front().expect("exists");
                         exe_ctx.tx_builder.delete(&mut exe_ctx.bld, obj)
                     }
                     ObjectIO::Mutate => {
-                        let obj0 = exe_ctx.inputs2.pop().expect("exists").1;
+                        let obj0 = exe_ctx.inputs.pop_front().expect("exists").1;
                         output_objs.push(OutputData {
                             class: class.clone(),
                             obj: obj.clone(),
@@ -446,12 +448,13 @@ impl ActionHandle {
                 exe_ctx.sts.push(st);
             }
         }
+        exe_ctx.input_index = 0; // Reset input index for consumption by object IO operations
 
         // Action statement
         let sts = mem::take(&mut exe_ctx.sts); // exe_ctx.sts is cleared for the next action
         let st_action = exe_ctx
             .bld
-            .apply_custom_pred(false, &action, HashMap::new(), sts)
+            .apply_custom_pred(false, action, HashMap::new(), sts)
             .unwrap();
         // Reveal the action in the internal pod that just outputs action statements.
         exe_ctx.bld.builder.reveal(&st_action).unwrap();
@@ -1004,7 +1007,7 @@ impl Loader {
         ];
         let mut actions_meta = Vec::with_capacity(actions.len());
         for action in &actions {
-            let action_meta = ActionMeta::from_action_ctx(&actions_meta, &*action.0.borrow())?;
+            let action_meta = ActionMeta::from_action_ctx(&actions_meta, &action.0.borrow())?;
             actions_meta.push(action_meta);
         }
         let classes = Self::actions_to_classes(&actions_meta);
@@ -1175,8 +1178,8 @@ struct ExeContext {
     module: Rc<SdkModule>,
     // -- Consumed during execution --
     // Input (class statement, object) to be consumed by input/mutate
-    inputs: Vec<(Statement, Dictionary)>,
-    inputs2: Vec<(Statement, Dictionary)>,
+    input_index: usize,
+    inputs: VecDeque<(Statement, Dictionary)>,
     // -- Generated during execution --
     outputs: Vec<Dictionary>,
     // Data necessary to make each output object' class statement: (predicate name, statements)
@@ -1265,8 +1268,6 @@ impl Executor {
                 .expect("MultiPodBuilder is unlimited");
             input_class_sts_objs.push((st_class, input.obj));
         }
-        // Reverse the input objects so that we can pop them in order
-        input_class_sts_objs.reverse();
 
         let tx_builder = self.new_tx_builder(&mut bld, &tx_inputs);
 
@@ -1277,8 +1278,8 @@ impl Executor {
             tx_builder,
             bld,
             module: self.module.clone(),
-            inputs: input_class_sts_objs.clone(),
-            inputs2: input_class_sts_objs.clone(),
+            input_index: 0,
+            inputs: VecDeque::from(input_class_sts_objs),
             outputs: Vec::new(),
             output_objs_st_class_data: Vec::new(),
             sts: Vec::new(),
@@ -1286,73 +1287,8 @@ impl Executor {
         let action_handle = ActionHandle::new(action.name.clone(), Some(exe_ctx));
         action_handle.exe_action(&action.name)?;
 
-        // let options = CallFnOptions::new().with_tag(action_handle.clone());
-        // // Execute the action rhai code
-        // let mut scope = Scope::new();
-        // let _result = self.module.engine.call_fn_with_options::<Dynamic>(
-        //     options,
-        //     &mut scope,
-        //     &self.module.ast,
-        //     &action.name,
-        //     (action_handle.clone(),),
-        // )?;
         let mut ctx = action_handle.0.borrow_mut();
         let mut exe_ctx = ctx.exe_ctx.take().expect("Some");
-
-        // // Add the transaction predicates
-        // let mut output_objs = Vec::new();
-        // for inst in &ctx.insts {
-        //     if let Inst::Object { io, obj, class } = inst {
-        //         let obj = obj.borrow().to_dict();
-        //         let st = match io {
-        //             ObjectIO::Output => {
-        //                 output_objs.push(OutputData {
-        //                     class: class.clone(),
-        //                     obj: obj.clone(),
-        //                 });
-        //                 exe_ctx.tx_builder.insert(&mut exe_ctx.bld, obj)
-        //             }
-        //             ObjectIO::Input => {
-        //                 input_class_sts_objs.pop().expect("exists");
-        //                 exe_ctx.tx_builder.delete(&mut exe_ctx.bld, obj)
-        //             }
-        //             ObjectIO::Mutate => {
-        //                 let obj0 = input_class_sts_objs.pop().expect("exists").1;
-        //                 output_objs.push(OutputData {
-        //                     class: class.clone(),
-        //                     obj: obj.clone(),
-        //                 });
-        //                 exe_ctx.tx_builder.mutate(&mut exe_ctx.bld, obj, obj0)
-        //             }
-        //         };
-        //         exe_ctx.sts.push(st);
-        //     }
-        // }
-
-        // // Action statement
-        // let st_action = exe_ctx
-        //     .bld
-        //     .apply_custom_pred(false, &action.name, HashMap::new(), exe_ctx.sts)
-        //     .unwrap();
-        // exe_ctx.bld.builder.reveal(&st_action).unwrap();
-
-        // // Data necessary to make each output object' class statement
-        // let mut output_objs_st_class_data = Vec::new();
-
-        // // Output (includes Output & Mutate) Class(obj) statements
-        // for (index, OutputData { class, obj: _ }) in output_objs.iter().enumerate() {
-        //     let class = self.module.class_by_name(class);
-        //     let mut sts = vec![Statement::None; class.actions.len()];
-        //     let class_st_index =
-        //         self.module.output_index_class_st_index[&(action.name.clone(), index)];
-        //     sts[class_st_index] = st_action.clone();
-        //     let pred = format!("Is{}", class.name);
-        //     // We delay the creation of the class statement until we have created all actions
-        //     // because the class statements go to different pods.
-        //     output_objs_st_class_data.push((pred, sts));
-        // }
-
-        // output_objs.extend(output.into_iter().map(|out| out.obj));
 
         // Prove a pod with the class statements and the last tx statement
         exe_ctx

--- a/sdk/src/tests.rs
+++ b/sdk/src/tests.rs
@@ -114,32 +114,32 @@ fn test_sdk_1() {
 
     let mut state = TestState::default();
 
-    println!("DBG FindLog");
+    println!("exe FindLog");
     let executor = module.executor(true, grounding_witness(&state, &[]));
     let [log_a] = executor.action("FindLog", vec![]).unwrap().objs();
     apply_tx(&mut state, &log_a.tx);
 
-    println!("DBG CraftWood");
+    println!("exe CraftWood");
     let executor = module.executor(true, grounding_witness(&state, &[log_a.tx.clone()]));
     let [wood_a] = executor.action("CraftWood", vec![log_a]).unwrap().objs();
     apply_tx(&mut state, &wood_a.tx);
 
-    println!("DBG CraftSticks");
+    println!("exe CraftSticks");
     let executor = module.executor(true, grounding_witness(&state, &[wood_a.tx.clone()]));
     let [stick_a, _stick_b] = executor.action("CraftSticks", vec![wood_a]).unwrap().objs();
     apply_tx(&mut state, &stick_a.tx);
 
-    println!("DBG FindLog");
+    println!("exe FindLog");
     let executor = module.executor(true, grounding_witness(&state, &[]));
     let [log_b] = executor.action("FindLog", vec![]).unwrap().objs();
     apply_tx(&mut state, &log_b.tx);
 
-    println!("DBG CraftWood");
+    println!("exe CraftWood");
     let executor = module.executor(true, grounding_witness(&state, &[log_b.tx.clone()]));
     let [wood_b] = executor.action("CraftWood", vec![log_b]).unwrap().objs();
     apply_tx(&mut state, &wood_b.tx);
 
-    println!("DBG CraftWoodPick");
+    println!("exe CraftWoodPick");
     let executor = module.executor(
         true,
         grounding_witness(&state, &[wood_b.tx.clone(), stick_a.tx.clone()]),
@@ -150,7 +150,7 @@ fn test_sdk_1() {
         .objs();
     apply_tx(&mut state, &wood_pick.tx);
 
-    println!("DBG UseWoodPick");
+    println!("exe UseWoodPick");
     let executor = module.executor(true, grounding_witness(&state, &[wood_pick.tx.clone()]));
     let [wood_pick] = executor
         .action("UseWoodPick", vec![wood_pick])
@@ -158,7 +158,7 @@ fn test_sdk_1() {
         .objs();
     apply_tx(&mut state, &wood_pick.tx);
 
-    println!("DBG MineStoneWithWoodPick");
+    println!("exe MineStoneWithWoodPick");
     let executor = module.executor(true, grounding_witness(&state, &[wood_pick.tx.clone()]));
     let [stone] = executor
         .action("MineStoneWithWoodPick", vec![wood_pick])

--- a/sdk/src/tests.rs
+++ b/sdk/src/tests.rs
@@ -114,26 +114,32 @@ fn test_sdk_1() {
 
     let mut state = TestState::default();
 
+    println!("DBG FindLog");
     let executor = module.executor(true, grounding_witness(&state, &[]));
     let [log_a] = executor.action("FindLog", vec![]).unwrap().objs();
     apply_tx(&mut state, &log_a.tx);
 
+    println!("DBG CraftWood");
     let executor = module.executor(true, grounding_witness(&state, &[log_a.tx.clone()]));
     let [wood_a] = executor.action("CraftWood", vec![log_a]).unwrap().objs();
     apply_tx(&mut state, &wood_a.tx);
 
+    println!("DBG CraftSticks");
     let executor = module.executor(true, grounding_witness(&state, &[wood_a.tx.clone()]));
     let [stick_a, _stick_b] = executor.action("CraftSticks", vec![wood_a]).unwrap().objs();
     apply_tx(&mut state, &stick_a.tx);
 
+    println!("DBG FindLog");
     let executor = module.executor(true, grounding_witness(&state, &[]));
     let [log_b] = executor.action("FindLog", vec![]).unwrap().objs();
     apply_tx(&mut state, &log_b.tx);
 
+    println!("DBG CraftWood");
     let executor = module.executor(true, grounding_witness(&state, &[log_b.tx.clone()]));
     let [wood_b] = executor.action("CraftWood", vec![log_b]).unwrap().objs();
     apply_tx(&mut state, &wood_b.tx);
 
+    println!("DBG CraftWoodPick");
     let executor = module.executor(
         true,
         grounding_witness(&state, &[wood_b.tx.clone(), stick_a.tx.clone()]),
@@ -144,6 +150,7 @@ fn test_sdk_1() {
         .objs();
     apply_tx(&mut state, &wood_pick.tx);
 
+    println!("DBG UseWoodPick");
     let executor = module.executor(true, grounding_witness(&state, &[wood_pick.tx.clone()]));
     let [wood_pick] = executor
         .action("UseWoodPick", vec![wood_pick])
@@ -151,6 +158,7 @@ fn test_sdk_1() {
         .objs();
     apply_tx(&mut state, &wood_pick.tx);
 
+    println!("DBG MineStoneWithWoodPick");
     let executor = module.executor(true, grounding_witness(&state, &[wood_pick.tx.clone()]));
     let [stone] = executor
         .action("MineStoneWithWoodPick", vec![wood_pick])

--- a/sdk/src/tests.rs
+++ b/sdk/src/tests.rs
@@ -88,6 +88,12 @@ fn test_sdk_1() {
             var wood_pick = action.mutate("WoodPick");
             use_pick(action, wood_pick, 10);
         }
+
+        fn MineStoneWithWoodPick(action) {
+            var pick = action.subaction("UseWoodPick");
+            var stone = action.output("Stone");
+            stone.set([["blueprint", "Stone"]]);
+        }
 "#;
 
     let sdk = Sdk::default();
@@ -98,6 +104,7 @@ fn test_sdk_1() {
         "CraftSticks",
         "CraftWoodPick",
         "UseWoodPick",
+        "MineStoneWithWoodPick",
     ];
     let module = sdk
         .load_module_from_src_actions(craft_src, actions)
@@ -143,6 +150,13 @@ fn test_sdk_1() {
         .unwrap()
         .objs();
     apply_tx(&mut state, &wood_pick.tx);
+
+    let executor = module.executor(true, grounding_witness(&state, &[wood_pick.tx.clone()]));
+    let [stone] = executor
+        .action("MineStoneWithWoodPick", vec![wood_pick])
+        .unwrap()
+        .objs();
+    apply_tx(&mut state, &stone.tx);
 }
 
 #[allow(clippy::cloned_ref_to_slice_refs)]


### PR DESCRIPTION
Add support of actions that depend on other actions.  In the code and SDK interface I call the action dependency "subaction" which is the same terminology used by the new txlib that Rob has designed.

The Rhai syntax for dependencies looks like this:

```rust
fn Foo(action) {
  var pick = action.subaction("UseWoodPick");
  // ... 
}
```

For now the code assumes a subaction only outputs a single object.

The implementation idea is that an action can execute another action.  This means that we're executing rhai, we jump to a host function, and then we must jump back to executing another rhai function.
To moved the code that executes a rhai function corresponding to an action to the `ActionHandler` and also made the Rhai engine and AST available in the ExeContext, so that we can easly execute rhai code again from a host function defined via an ActionHandler method.

The ActionHandler contains an shared mutable ActionContext.  We need to make sure that when executing a subaction the ActionContext is not borrowed, otherwise we would encounter runtime panics.  You can see this dance here
https://github.com/dobjlabs/zk-craft/blob/cde0f5e5e0f2ddb0eaaf16b500fe5e6aa62896f4/sdk/src/lib.rs#L520-L525
and here
https://github.com/dobjlabs/zk-craft/blob/cde0f5e5e0f2ddb0eaaf16b500fe5e6aa62896f4/sdk/src/lib.rs#L401-L417

---

From a conversation with Rob:

The implementation in the PR assumes subactions go first before anything else.
And there's no safeguard for that, so if you do subactions after a non-subaction operation it will fail in a non-obvious way.
For simplicity we could assume that we want subactions to always go first, and add safeguards for nice error reporting when that's not the case.
In the future, if we find that limiting we could implement support for subactions at any position.