### PR TITLE
add stone and stone actions to craft basics pexe 

### DIFF
--- a/app-gui/src/features/actions/ActionGrid.tsx
+++ b/app-gui/src/features/actions/ActionGrid.tsx
@@ -25,7 +25,7 @@ export function ActionGrid({
   const compatibilityFiltered = useMemo(() => {
     if (!selectedObject) return actions;
     return actions.filter((action) =>
-      action.inputClasses.some(
+      action.totalInputClasses.some(
         (className) => className === selectedObject.className,
       ),
     );

--- a/app-gui/src/features/context/ContextPanel.tsx
+++ b/app-gui/src/features/context/ContextPanel.tsx
@@ -4,10 +4,7 @@ import type {
   ActionPayload as Action,
   InventoryObjectPayload as InventoryObject,
 } from "../../shared/api/wireTypes";
-import {
-  pickDobjFilePath,
-  readDobjFile,
-} from "../../shared/api/tauriClient";
+import { pickDobjFilePath, readDobjFile } from "../../shared/api/tauriClient";
 import { truncateDisplayHash } from "../../shared/format";
 import {
   displayPathInObjectsDir,
@@ -290,31 +287,31 @@ export function ContextPanel({
   const renderMethodCard = (config: {
     methodId: string;
     methodName: string;
-    inputClasses: string[];
-    inputClassHashes: string[];
+    totalInputClasses: string[];
+    totalInputClassHashes: string[];
     onRun: (boundArgs: BoundArg[]) => void;
   }) =>
     (() => {
-      const hasInputs = config.inputClasses.length > 0;
-      const boundArgs = config.inputClasses.map(
+      const hasInputs = config.totalInputClasses.length > 0;
+      const boundArgs = config.totalInputClasses.map(
         (_, index) => argBindings[argKey(config.methodId, index)] ?? null,
       );
       const filledCount = boundArgs.filter(
         (value) => value?.objectPath?.trim().length,
       ).length;
       const allArgsBound =
-        !hasInputs || filledCount === config.inputClasses.length;
+        !hasInputs || filledCount === config.totalInputClasses.length;
 
       return (
         <div className="method-card">
           {hasInputs && (
             <div className="method-card-body">
-              {config.inputClasses.map((expectedClassName, index) => {
+              {config.totalInputClasses.map((expectedClassName, index) => {
                 const key = argKey(config.methodId, index);
                 const bound = argBindings[key];
                 const isDropActive = hoverArgKey === key;
                 const err = argErrors[key];
-                const classHash = config.inputClassHashes[index] ?? "";
+                const classHash = config.totalInputClassHashes[index] ?? "";
 
                 return (
                   <div
@@ -512,9 +509,7 @@ export function ContextPanel({
       return <section className="context-panel">Object not found.</section>;
 
     const titleName = object.className;
-    const liveValueRaw = object.status === "live"
-      ? object.id
-      : object.status;
+    const liveValueRaw = object.status === "live" ? object.id : object.status;
     const liveValue = truncateDisplayHash(liveValueRaw);
 
     return (
@@ -601,8 +596,8 @@ export function ContextPanel({
       {renderMethodCard({
         methodId: action.id,
         methodName: action.id,
-        inputClasses: action.inputClasses,
-        inputClassHashes: action.inputClassHashes,
+        totalInputClasses: action.totalInputClasses,
+        totalInputClassHashes: action.totalInputClassHashes,
         onRun: (boundArgs) =>
           onRunProof({
             actionId: action.id,

--- a/app-gui/src/shared/api/wireTypes.ts
+++ b/app-gui/src/shared/api/wireTypes.ts
@@ -23,9 +23,9 @@ export interface ActionPayload {
   id: string;
   emoji: string;
   hash: string;
-  inputClassHashes: string[];
+  totalInputClassHashes: string[];
   description: string;
-  inputClasses: string[];
+  totalInputClasses: string[];
 }
 
 export interface LoadGuiInventoryResult {

--- a/plugins/craft-basics/manifest.toml
+++ b/plugins/craft-basics/manifest.toml
@@ -2,7 +2,7 @@
 name = "craft-basics"
 version = "0.1.0"
 # Rewritten by `cargo run -p pexe -- build plugins/craft-basics`.
-module_hash = "62525b9696c1402d3b37fbad775e7d3cc915aec4346f231b0fcb57d37ef451b9"
+module_hash = "732cc514be003de9e56d101ed4f45ff52d5e831fb6f0ad5280d6838860c87e3d"
 
 [[classes]]
 name = "Log"
@@ -20,9 +20,19 @@ emoji = "🥢"
 description = "A stick used as a handle in tool crafting."
 
 [[classes]]
+name = "Stone"
+emoji = "🪨"
+description = "Mined stone used to craft stronger tools."
+
+[[classes]]
 name = "WoodPick"
 emoji = "⛏️"
 description = "A wood pick that can mine stone while durability remains."
+
+[[classes]]
+name = "StonePick"
+emoji = "⛏️"
+description = "A stone pick that can mine stone while durability remains."
 
 [[actions]]
 name = "FindLog"
@@ -49,3 +59,24 @@ name = "UseWoodPick"
 emoji = "⛏️"
 description = "Internal durability/work update for wood pick usage."
 hidden = true
+
+[[actions]]
+name = "MineStoneWithWoodPick"
+emoji = "🪨"
+description = "Mine stone using a wood pick (consumes durability)."
+
+[[actions]]
+name = "CraftStonePick"
+emoji = "⛏️"
+description = "Combine stone and a stick to craft a stone pick."
+
+[[actions]]
+name = "UseStonePick"
+emoji = "⛏️"
+description = "Internal durability/work update for stone pick usage."
+hidden = true
+
+[[actions]]
+name = "MineStoneWithStonePick"
+emoji = "🪨"
+description = "Mine stone using a stone pick (consumes durability)."

--- a/plugins/craft-basics/plugin.rhai
+++ b/plugins/craft-basics/plugin.rhai
@@ -51,3 +51,30 @@ fn UseWoodPick(action) {
     var wood_pick = action.mutate("WoodPick");
     use_pick(action, wood_pick, 10);
 }
+
+fn MineStoneWithWoodPick(action) {
+    var pick = action.subaction("UseWoodPick");
+    var stone = action.output("Stone");
+    stone.set([["blueprint", "Stone"]]);
+}
+
+fn CraftStonePick(action) {
+    var stone = action.input("Stone");
+    var stick = action.input("Stick");
+    var pick = action.output("StonePick");
+    pick.set([
+        ["blueprint", "StonePick"],
+        ["durability", 200]
+    ]);
+}
+
+fn UseStonePick(action) {
+    var stone_pick = action.mutate("StonePick");
+    use_pick(action, stone_pick, 5);
+}
+
+fn MineStoneWithStonePick(action) {
+    var pick = action.subaction("UseStonePick");
+    var stone = action.output("Stone");
+    stone.set([["blueprint", "Stone"]]);
+}

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -7,9 +7,8 @@ use std::slice;
 use std::sync::Arc;
 
 use anyhow::{Result, anyhow};
-use hex::FromHex;
 use itertools::zip_eq;
-use lt_eq_u256_pod::LtEqU256Pod;
+use lt_eq_u256_pod::{LtEqU256Pod, STANDARD_LT_EQ_U256_VD_HASH};
 use pod2::{
     backends::plonky2::{basetypes::DEFAULT_VD_SET, mainpod::Prover, mock::mainpod::MockProver},
     frontend::{MainPod, MultiPodBuilder, Operation, OperationArg},
@@ -23,7 +22,7 @@ use pod2::{
 use pod2utils::{dict, macros::BuildContext, rand_raw_value};
 use rhai::{AST, CallFnOptions, Dynamic, Engine, EvalAltResult, EvalContext, Expression, Scope};
 use txlib::{GroundingWitness, Tx, TxBuilder};
-use vdfpod::VdfPod;
+use vdfpod::{STANDARD_VDF_VD_HASH, VdfPod};
 
 mod error;
 mod fmt_podlang;
@@ -998,17 +997,11 @@ impl Loader {
             },
             Dependency::Intro {
                 pred: "Vdf(count, input, output)".to_string(),
-                hash: Hash::from_hex(
-                    "b77a964de74c8569e6c6172692bb50147df9334fd9b572abc8d4d9c688a40e06",
-                )
-                .unwrap(),
+                hash: *STANDARD_VDF_VD_HASH,
             },
             Dependency::Intro {
                 pred: "LtEqU256(lhs, rhs)".to_string(),
-                hash: Hash::from_hex(
-                    "2e79114ee823f4783ab5b6eb93b49abba87fb69b4d14de4cf1d78648ade73529",
-                )
-                .unwrap(),
+                hash: *STANDARD_LT_EQ_U256_VD_HASH,
             },
         ];
         let mut actions_meta = Vec::with_capacity(actions.len());


### PR DESCRIPTION
We switched to pexe but didnt port over the stone and stonepick example we had before. We should keep it to be able to test end to end

Fixed some frontend types missed in https://github.com/dobjlabs/zk-craft/pull/91
