### PR TITLE
fix subaction outputs

### DIFF
--- a/mcp/src/mock.rs
+++ b/mcp/src/mock.rs
@@ -349,13 +349,15 @@ fn default_actions() -> Vec<Action> {
             id: "MineStoneWithWoodPick".to_string(),
             description: "Mine stone using a wood pick (consumes durability)".to_string(),
             input_classes: vec!["WoodPick".to_string()],
-            output_classes: vec!["Stone".to_string(), "WoodPick".to_string()],
+            // Order matches engine emission: subaction's mutated WoodPick first,
+            // then the parent's freshly-output Stone.
+            output_classes: vec!["WoodPick".to_string(), "Stone".to_string()],
         },
         Action {
             id: "MineStoneWithStonePick".to_string(),
             description: "Mine stone using a stone pick (consumes durability)".to_string(),
             input_classes: vec!["StonePick".to_string()],
-            output_classes: vec!["Stone".to_string(), "StonePick".to_string()],
+            output_classes: vec!["StonePick".to_string(), "Stone".to_string()],
         },
     ]
 }

--- a/plugins/craft-basics/manifest.toml
+++ b/plugins/craft-basics/manifest.toml
@@ -2,7 +2,7 @@
 name = "craft-basics"
 version = "0.1.0"
 # Rewritten by `cargo run -p pexe -- build plugins/craft-basics`.
-module_hash = "732cc514be003de9e56d101ed4f45ff52d5e831fb6f0ad5280d6838860c87e3d"
+module_hash = "c259d6a3b012a5bb5017dc5069fc680c626f7a26f7448d19d20b0da6e3867410"
 
 [[classes]]
 name = "Log"

--- a/sdk/src/fmt_podlang.rs
+++ b/sdk/src/fmt_podlang.rs
@@ -104,9 +104,7 @@ fn fmt_action_pub_vars(action: &ActionContext) -> Vec<String> {
             // ActionMeta accumulates it. The class predicate (`IsClass`) calls
             // this predicate with one positional arg per output, so the parent
             // must publish the subaction's binding alongside its own outputs.
-            Inst::SubAction { action: _, obj } => {
-                vars.push(obj.borrow().var_name().to_string())
-            }
+            Inst::SubAction { action: _, obj } => vars.push(obj.borrow().var_name().to_string()),
             _ => {}
         }
     }

--- a/sdk/src/fmt_podlang.rs
+++ b/sdk/src/fmt_podlang.rs
@@ -93,13 +93,21 @@ fn fmt_action_vars(action: &ActionContext) -> Vec<String> {
 fn fmt_action_pub_vars(action: &ActionContext) -> Vec<String> {
     let mut vars = Vec::new();
     for inst in &action.insts {
-        if let Inst::Object {
-            io: ObjectIO::Mutate | ObjectIO::Output,
-            obj,
-            class: _,
-        } = inst
-        {
-            vars.push(obj.borrow().var_name().to_string())
+        match inst {
+            Inst::Object {
+                io: ObjectIO::Mutate | ObjectIO::Output,
+                obj,
+                class: _,
+            } => vars.push(obj.borrow().var_name().to_string()),
+            // A subaction's primary output is an output of the parent action
+            // too: it gets emitted into exe_ctx.outputs and the parent's
+            // ActionMeta accumulates it. The class predicate (`IsClass`) calls
+            // this predicate with one positional arg per output, so the parent
+            // must publish the subaction's binding alongside its own outputs.
+            Inst::SubAction { action: _, obj } => {
+                vars.push(obj.borrow().var_name().to_string())
+            }
+            _ => {}
         }
     }
     vars.extend_from_slice(&["tx".to_string(), "tx0".to_string()]);

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -459,10 +459,18 @@ impl ActionHandle {
         // Reveal the action in the internal pod that just outputs action statements.
         exe_ctx.bld.builder.reveal(&st_action).unwrap();
 
+        // Outputs from subactions have already been pushed onto
+        // exe_ctx.outputs by their own exe_action calls. The metadata indexes
+        // outputs of *this* action globally (subaction outputs first, then
+        // parent's own outputs in source order), so shift the local index by
+        // the number of outputs already accumulated to look up the right
+        // class_st_index.
+        let output_offset = exe_ctx.outputs.len();
         for (index, OutputData { class, obj: _ }) in output_objs.iter().enumerate() {
             let class = module.class_by_name(class);
             let mut sts = vec![Statement::None; class.actions.len()];
-            let class_st_index = module.output_index_class_st_index[&(action.to_string(), index)];
+            let class_st_index =
+                module.output_index_class_st_index[&(action.to_string(), output_offset + index)];
             sts[class_st_index] = st_action.clone();
             let pred = format!("Is{}", class.name);
             // We delay the creation of the class statement until we have created all actions
@@ -922,6 +930,15 @@ impl ActionMeta {
                         .ok_or_else(|| anyhow!("subaction {action} not defined"))?;
                     for input in &subaction.inputs {
                         meta.inputs.push(input.clone());
+                    }
+                    // The subaction's outputs are emitted into the same
+                    // exe_ctx.outputs at runtime (see exe_action), so they must
+                    // appear in the parent's metadata too — otherwise the
+                    // descriptor's output count won't match what the engine
+                    // returns. Subaction outputs come first in source order
+                    // because the subaction runs before the parent's own insts.
+                    for output in &subaction.outputs {
+                        meta.outputs.push(output.clone());
                     }
                 }
                 _ => {}

--- a/sdk/src/tests.rs
+++ b/sdk/src/tests.rs
@@ -160,7 +160,10 @@ fn test_sdk_1() {
 
     println!("exe MineStoneWithWoodPick");
     let executor = module.executor(true, grounding_witness(&state, &[wood_pick.tx.clone()]));
-    let [stone] = executor
+    // MineStoneWithWoodPick produces two outputs: the mutated WoodPick (from
+    // the UseWoodPick subaction) and the new Stone. Engine emission order is
+    // subaction-first.
+    let [_wood_pick, stone] = executor
         .action("MineStoneWithWoodPick", vec![wood_pick])
         .unwrap()
         .objs();


### PR DESCRIPTION
The engine accumulates outputs from subactions and the parent into the same `exe_ctx.outputs`, but `ActionMeta::from_action_ctx` only copied subaction inputs into the parent's metadata,. It never outputs, so the descriptor undercounted by one per subaction.

So `MineStoneWithWoodPick` failed in the GUI with `output mismatch: descriptor expects 1, engine returned 2`