### PR TITLE
distinguish same-named classes/actions across plugins

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2789,6 +2789,7 @@ dependencies = [
  "serde_json",
  "synchronizer",
  "tempfile",
+ "toml 1.1.2+spec-1.1.0",
  "txlib",
  "vdfpod",
 ]

--- a/app-gui/src-tauri/src/bootstrap.rs
+++ b/app-gui/src-tauri/src/bootstrap.rs
@@ -29,9 +29,7 @@ pub struct Action {
     pub plugin_name: String,
     pub emoji: String,
     pub hash: String,
-    pub total_input_class_ids: Vec<String>,
-    pub total_input_class_names: Vec<String>,
-    pub total_input_class_hashes: Vec<String>,
+    pub total_inputs: Vec<::driver::ClassRef>,
     pub description: String,
 }
 
@@ -90,9 +88,7 @@ pub async fn load_gui_inventory(
                 plugin_name: action.plugin_name,
                 emoji: action.emoji,
                 hash: action.hash,
-                total_input_class_ids: action.total_input_class_ids,
-                total_input_class_names: action.total_input_class_names,
-                total_input_class_hashes: action.total_input_class_hashes,
+                total_inputs: action.total_inputs,
                 description: action.description,
             })
             .collect();

--- a/app-gui/src-tauri/src/bootstrap.rs
+++ b/app-gui/src-tauri/src/bootstrap.rs
@@ -9,7 +9,9 @@ use serde::Serialize;
 pub struct InventoryObject {
     pub id: String,
     pub file_name: String,
-    pub class_name: String,
+    pub class_id: String,
+    pub class_display_name: String,
+    pub plugin_name: String,
     pub class_hash: String,
     pub emoji: String,
     pub status: driver::ObjectStatus,
@@ -23,11 +25,14 @@ pub struct InventoryObject {
 #[serde(rename_all = "camelCase")]
 pub struct Action {
     pub id: String,
+    pub display_name: String,
+    pub plugin_name: String,
     pub emoji: String,
     pub hash: String,
+    pub total_input_class_ids: Vec<String>,
+    pub total_input_class_names: Vec<String>,
     pub total_input_class_hashes: Vec<String>,
     pub description: String,
-    pub total_input_classes: Vec<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -35,6 +40,9 @@ pub struct Action {
 pub struct LoadGuiInventoryResult {
     pub inventory: Vec<InventoryObject>,
     pub actions: Vec<Action>,
+    /// Bare class/action names that appear in more than one plugin. UI uses
+    /// this to decide when to append a plugin disambiguator to a label.
+    pub name_collisions: Vec<String>,
 }
 
 #[tauri::command]
@@ -46,7 +54,7 @@ pub async fn load_gui_inventory(
         let classes = driver
             .list_classes()?
             .into_iter()
-            .map(|class_info| (class_info.name.clone(), class_info))
+            .map(|class_info| (class_info.id.clone(), class_info))
             .collect::<HashMap<_, _>>();
         let inventory = driver
             .sync_inventory(None)
@@ -56,11 +64,13 @@ pub async fn load_gui_inventory(
             })
             .into_iter()
             .map(|object| {
-                let class_info = classes.get(&object.class_name);
+                let class_info = classes.get(&object.class_id);
                 InventoryObject {
                     id: object.id,
                     file_name: object.file_name,
-                    class_name: object.class_name.clone(),
+                    class_id: object.class_id.clone(),
+                    class_display_name: object.class_display_name,
+                    plugin_name: object.plugin_name,
                     class_hash: object.class_hash,
                     emoji: class_info
                         .map(|class_info| class_info.emoji.clone())
@@ -79,15 +89,24 @@ pub async fn load_gui_inventory(
             .into_iter()
             .map(|action| Action {
                 id: action.id,
+                display_name: action.display_name,
+                plugin_name: action.plugin_name,
                 emoji: action.emoji,
                 hash: action.hash,
+                total_input_class_ids: action.total_input_class_ids,
+                total_input_class_names: action.total_input_class_names,
                 total_input_class_hashes: action.total_input_class_hashes,
                 description: action.description,
-                total_input_classes: action.total_input_classes,
             })
             .collect();
 
-        Ok::<_, anyhow::Error>(LoadGuiInventoryResult { inventory, actions })
+        let name_collisions = driver.name_collisions();
+
+        Ok::<_, anyhow::Error>(LoadGuiInventoryResult {
+            inventory,
+            actions,
+            name_collisions,
+        })
     })
     .await
     .map_err(|err| anyhow::anyhow!("failed to load inventory task: {err}"))?

--- a/app-gui/src-tauri/src/bootstrap.rs
+++ b/app-gui/src-tauri/src/bootstrap.rs
@@ -1,8 +1,8 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use ::driver::{ClassRef, ObjectStatus, QualifiedName};
 use crate::error::CommandError;
+use ::driver::{ClassRef, ObjectStatus, QualifiedName};
 use serde::Serialize;
 
 #[derive(Debug, Serialize, Clone)]

--- a/app-gui/src-tauri/src/bootstrap.rs
+++ b/app-gui/src-tauri/src/bootstrap.rs
@@ -40,9 +40,6 @@ pub struct Action {
 pub struct LoadGuiInventoryResult {
     pub inventory: Vec<InventoryObject>,
     pub actions: Vec<Action>,
-    /// Bare class/action names that appear in more than one plugin. UI uses
-    /// this to decide when to append a plugin disambiguator to a label.
-    pub name_collisions: Vec<String>,
 }
 
 #[tauri::command]
@@ -100,13 +97,7 @@ pub async fn load_gui_inventory(
             })
             .collect();
 
-        let name_collisions = driver.name_collisions();
-
-        Ok::<_, anyhow::Error>(LoadGuiInventoryResult {
-            inventory,
-            actions,
-            name_collisions,
-        })
+        Ok::<_, anyhow::Error>(LoadGuiInventoryResult { inventory, actions })
     })
     .await
     .map_err(|err| anyhow::anyhow!("failed to load inventory task: {err}"))?

--- a/app-gui/src-tauri/src/bootstrap.rs
+++ b/app-gui/src-tauri/src/bootstrap.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use ::driver::{ClassRef, ObjectStatus, QualifiedName};
 use crate::error::CommandError;
 use serde::Serialize;
 
@@ -9,12 +10,10 @@ use serde::Serialize;
 pub struct InventoryObject {
     pub id: String,
     pub file_name: String,
-    pub class_id: String,
-    pub class_display_name: String,
-    pub plugin_name: String,
+    pub class: QualifiedName,
     pub class_hash: String,
     pub emoji: String,
-    pub status: driver::ObjectStatus,
+    pub status: ObjectStatus,
     pub tx_hash: Option<String>,
     pub grounded: bool,
     pub description: Option<String>,
@@ -24,12 +23,10 @@ pub struct InventoryObject {
 #[derive(Debug, Serialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Action {
-    pub id: String,
-    pub display_name: String,
-    pub plugin_name: String,
+    pub action: QualifiedName,
     pub emoji: String,
     pub hash: String,
-    pub total_inputs: Vec<::driver::ClassRef>,
+    pub total_inputs: Vec<ClassRef>,
     pub description: String,
 }
 
@@ -49,7 +46,7 @@ pub async fn load_gui_inventory(
         let classes = driver
             .list_classes()?
             .into_iter()
-            .map(|class_info| (class_info.id.clone(), class_info))
+            .map(|class_info| (class_info.class.clone(), class_info))
             .collect::<HashMap<_, _>>();
         let inventory = driver
             .sync_inventory(None)
@@ -59,13 +56,11 @@ pub async fn load_gui_inventory(
             })
             .into_iter()
             .map(|object| {
-                let class_info = classes.get(&object.class_id);
+                let class_info = classes.get(&object.class);
                 InventoryObject {
                     id: object.id,
                     file_name: object.file_name,
-                    class_id: object.class_id.clone(),
-                    class_display_name: object.class_display_name,
-                    plugin_name: object.plugin_name,
+                    class: object.class,
                     class_hash: object.class_hash,
                     emoji: class_info
                         .map(|class_info| class_info.emoji.clone())
@@ -83,9 +78,7 @@ pub async fn load_gui_inventory(
             .list_actions(None)?
             .into_iter()
             .map(|action| Action {
-                id: action.id,
-                display_name: action.display_name,
-                plugin_name: action.plugin_name,
+                action: action.action,
                 emoji: action.emoji,
                 hash: action.hash,
                 total_inputs: action.total_inputs,

--- a/app-gui/src-tauri/src/mcp.rs
+++ b/app-gui/src-tauri/src/mcp.rs
@@ -38,10 +38,16 @@ impl CraftOps for AppCraftOps {
                 display_name: action.display_name,
                 plugin_name: action.plugin_name,
                 description: action.description,
-                total_input_class_ids: action.total_input_class_ids,
-                total_input_class_names: action.total_input_class_names,
-                total_output_class_ids: action.total_output_class_ids,
-                total_output_class_names: action.total_output_class_names,
+                total_inputs: action
+                    .total_inputs
+                    .into_iter()
+                    .map(to_mcp_class_ref)
+                    .collect(),
+                total_outputs: action
+                    .total_outputs
+                    .into_iter()
+                    .map(to_mcp_class_ref)
+                    .collect(),
             })
             .collect())
     }
@@ -179,8 +185,11 @@ impl CraftOps for AppCraftOps {
                     file_name: candidate.file_name,
                 })
                 .collect(),
-            missing_input_class_ids: report.missing_input_class_ids,
-            missing_input_class_names: report.missing_input_class_names,
+            missing_inputs: report
+                .missing_inputs
+                .into_iter()
+                .map(to_mcp_class_ref)
+                .collect(),
         })
     }
 
@@ -209,5 +218,13 @@ fn to_mcp_inventory_object(object: ::driver::ObjectSummary) -> mcp::InventoryObj
         status: status_string(object.status),
         tx_hash: object.tx_hash,
         fields: object.fields,
+    }
+}
+
+fn to_mcp_class_ref(r: ::driver::ClassRef) -> mcp::ClassRef {
+    mcp::ClassRef {
+        id: r.id,
+        display_name: r.display_name,
+        hash: r.hash,
     }
 }

--- a/app-gui/src-tauri/src/mcp.rs
+++ b/app-gui/src-tauri/src/mcp.rs
@@ -1,6 +1,10 @@
 use std::path::Path;
 use std::sync::Arc;
 
+use ::driver::{
+    ClassRef, Driver, ExecuteActionInput, ObjectSelector, ObjectStatus, ObjectSummary,
+    QualifiedName,
+};
 use craft_mcp::ops::CraftOps;
 use craft_mcp::types as mcp;
 use tauri::Emitter;
@@ -9,11 +13,11 @@ use crate::progress::TauriProgressReporter;
 
 pub(crate) struct AppCraftOps {
     app: tauri::AppHandle,
-    driver: Arc<::driver::Driver>,
+    driver: Arc<Driver>,
 }
 
 impl AppCraftOps {
-    pub(crate) fn new(app: tauri::AppHandle, driver: Arc<::driver::Driver>) -> Self {
+    pub(crate) fn new(app: tauri::AppHandle, driver: Arc<Driver>) -> Self {
         Self { app, driver }
     }
 }
@@ -34,20 +38,10 @@ impl CraftOps for AppCraftOps {
             .list_actions(None)?
             .into_iter()
             .map(|action| mcp::Action {
-                id: action.id,
-                display_name: action.display_name,
-                plugin_name: action.plugin_name,
+                action: to_mcp_qname(action.action),
                 description: action.description,
-                total_inputs: action
-                    .total_inputs
-                    .into_iter()
-                    .map(to_mcp_class_ref)
-                    .collect(),
-                total_outputs: action
-                    .total_outputs
-                    .into_iter()
-                    .map(to_mcp_class_ref)
-                    .collect(),
+                total_inputs: action.total_inputs.into_iter().map(to_mcp_class_ref).collect(),
+                total_outputs: action.total_outputs.into_iter().map(to_mcp_class_ref).collect(),
             })
             .collect())
     }
@@ -58,12 +52,10 @@ impl CraftOps for AppCraftOps {
             .list_classes()?
             .into_iter()
             .map(|class_info| mcp::ClassSummary {
-                id: class_info.id,
-                display_name: class_info.display_name,
-                plugin_name: class_info.plugin_name,
+                class: to_mcp_qname(class_info.class),
                 live_count: class_info.live_count,
-                produced_by: class_info.produced_by,
-                consumed_by: class_info.consumed_by,
+                produced_by: class_info.produced_by.into_iter().map(to_mcp_qname).collect(),
+                consumed_by: class_info.consumed_by.into_iter().map(to_mcp_qname).collect(),
             })
             .collect())
     }
@@ -75,17 +67,15 @@ impl CraftOps for AppCraftOps {
     fn inspect_object(&self, object_id: &str) -> anyhow::Result<mcp::ObjectDetail> {
         let object = self
             .driver
-            .read_object(&::driver::ObjectSelector::ObjectId(object_id.to_string()))?;
+            .read_object(&ObjectSelector::ObjectId(object_id.to_string()))?;
         let predicate_source = self
             .driver
-            .get_class(&object.class_id)
+            .get_class(&object.class)
             .map(|c| c.predicate_source)
             .unwrap_or_default();
         Ok(mcp::ObjectDetail {
             id: object.id,
-            class_id: object.class_id,
-            class_display_name: object.class_display_name,
-            plugin_name: object.plugin_name,
+            class: to_mcp_qname(object.class),
             status: status_string(object.status),
             tx_hash: object.tx_hash,
             state: object.fields,
@@ -93,15 +83,13 @@ impl CraftOps for AppCraftOps {
         })
     }
 
-    fn inspect_class(&self, class_id: &str) -> anyhow::Result<mcp::ClassDetail> {
-        let class_info = self.driver.get_class(class_id)?;
+    fn inspect_class(&self, class: &mcp::QualifiedName) -> anyhow::Result<mcp::ClassDetail> {
+        let class_info = self.driver.get_class(&from_mcp_qname(class.clone()))?;
         Ok(mcp::ClassDetail {
-            class_id: class_info.id,
-            class_display_name: class_info.display_name,
-            plugin_name: class_info.plugin_name,
+            class: to_mcp_qname(class_info.class),
             predicate_source: class_info.predicate_source,
-            produced_by: class_info.produced_by,
-            consumed_by: class_info.consumed_by,
+            produced_by: class_info.produced_by.into_iter().map(to_mcp_qname).collect(),
+            consumed_by: class_info.consumed_by.into_iter().map(to_mcp_qname).collect(),
         })
     }
 
@@ -120,19 +108,20 @@ impl CraftOps for AppCraftOps {
                 } else {
                     path.to_string()
                 };
-                Ok(::driver::ObjectSelector::FileName(selector))
+                Ok(ObjectSelector::FileName(selector))
             })
             .collect::<anyhow::Result<Vec<_>>>()?;
 
+        let action_qname = from_mcp_qname(input.action.clone());
         let _ = self.app.emit(
             "mcp-action-started",
-            serde_json::json!({ "actionId": input.action_id }),
+            serde_json::json!({ "action": &input.action }),
         );
 
-        let reporter = TauriProgressReporter::new(self.app.clone(), input.action_id.clone());
+        let reporter = TauriProgressReporter::new(self.app.clone(), action_qname.id());
         let result = self.driver.execute_with_reporter(
-            ::driver::ExecuteActionInput {
-                action_id: input.action_id.clone(),
+            ExecuteActionInput {
+                action: action_qname.clone(),
                 input_objects,
             },
             &reporter,
@@ -144,12 +133,10 @@ impl CraftOps for AppCraftOps {
             .map(|file_name| {
                 let detail = self
                     .driver
-                    .read_object(&::driver::ObjectSelector::FileName(file_name.clone()))?;
+                    .read_object(&ObjectSelector::FileName(file_name.clone()))?;
                 Ok(mcp::InventoryObject {
                     id: detail.id,
-                    class_id: detail.class_id,
-                    class_display_name: detail.class_display_name,
-                    plugin_name: detail.plugin_name,
+                    class: to_mcp_qname(detail.class),
                     file_name: detail.file_name,
                     status: status_string(detail.status),
                     tx_hash: detail.tx_hash,
@@ -162,25 +149,26 @@ impl CraftOps for AppCraftOps {
             success: true,
             message: format!(
                 "Action {} completed. Old root: {}, New root: {}",
-                input.action_id, result.old_root, result.new_root
+                action_qname, result.old_root, result.new_root
             ),
             outputs,
             consumed: result.nullified_files,
         })
     }
 
-    fn check_feasibility(&self, action_id: &str) -> anyhow::Result<mcp::FeasibilityReport> {
-        let report = self.driver.check_action(action_id)?;
+    fn check_feasibility(
+        &self,
+        action: &mcp::QualifiedName,
+    ) -> anyhow::Result<mcp::FeasibilityReport> {
+        let report = self.driver.check_action(&from_mcp_qname(action.clone()))?;
         Ok(mcp::FeasibilityReport {
             feasible: report.feasible,
-            action_id: report.action_id,
+            action: to_mcp_qname(report.action),
             available_inputs: report
                 .available_inputs
                 .into_iter()
                 .map(|candidate| mcp::FeasibilityInput {
-                    class_id: candidate.class_id,
-                    class_display_name: candidate.class_display_name,
-                    plugin_name: candidate.plugin_name,
+                    class: to_mcp_qname(candidate.class),
                     object_id: candidate.object_id,
                     file_name: candidate.file_name,
                 })
@@ -198,22 +186,20 @@ impl CraftOps for AppCraftOps {
     }
 }
 
-fn status_string(status: ::driver::ObjectStatus) -> String {
+fn status_string(status: ObjectStatus) -> String {
     match status {
-        ::driver::ObjectStatus::Unknown => "unknown",
-        ::driver::ObjectStatus::Pending => "pending",
-        ::driver::ObjectStatus::Live => "live",
-        ::driver::ObjectStatus::Nullified => "nullified",
+        ObjectStatus::Unknown => "unknown",
+        ObjectStatus::Pending => "pending",
+        ObjectStatus::Live => "live",
+        ObjectStatus::Nullified => "nullified",
     }
     .to_string()
 }
 
-fn to_mcp_inventory_object(object: ::driver::ObjectSummary) -> mcp::InventoryObject {
+fn to_mcp_inventory_object(object: ObjectSummary) -> mcp::InventoryObject {
     mcp::InventoryObject {
         id: object.id,
-        class_id: object.class_id,
-        class_display_name: object.class_display_name,
-        plugin_name: object.plugin_name,
+        class: to_mcp_qname(object.class),
         file_name: object.file_name,
         status: status_string(object.status),
         tx_hash: object.tx_hash,
@@ -221,10 +207,20 @@ fn to_mcp_inventory_object(object: ::driver::ObjectSummary) -> mcp::InventoryObj
     }
 }
 
-fn to_mcp_class_ref(r: ::driver::ClassRef) -> mcp::ClassRef {
+fn to_mcp_class_ref(r: ClassRef) -> mcp::ClassRef {
     mcp::ClassRef {
-        id: r.id,
-        display_name: r.display_name,
+        class: to_mcp_qname(r.class),
         hash: r.hash,
     }
+}
+
+fn to_mcp_qname(q: QualifiedName) -> mcp::QualifiedName {
+    mcp::QualifiedName {
+        plugin_name: q.plugin_name,
+        name: q.name,
+    }
+}
+
+fn from_mcp_qname(q: mcp::QualifiedName) -> QualifiedName {
+    QualifiedName::new(q.plugin_name, q.name)
 }

--- a/app-gui/src-tauri/src/mcp.rs
+++ b/app-gui/src-tauri/src/mcp.rs
@@ -35,9 +35,13 @@ impl CraftOps for AppCraftOps {
             .into_iter()
             .map(|action| mcp::Action {
                 id: action.id,
+                display_name: action.display_name,
+                plugin_name: action.plugin_name,
                 description: action.description,
-                total_input_classes: action.total_input_classes,
-                total_output_classes: action.total_output_classes,
+                total_input_class_ids: action.total_input_class_ids,
+                total_input_class_names: action.total_input_class_names,
+                total_output_class_ids: action.total_output_class_ids,
+                total_output_class_names: action.total_output_class_names,
             })
             .collect())
     }
@@ -48,7 +52,9 @@ impl CraftOps for AppCraftOps {
             .list_classes()?
             .into_iter()
             .map(|class_info| mcp::ClassSummary {
-                name: class_info.name,
+                id: class_info.id,
+                display_name: class_info.display_name,
+                plugin_name: class_info.plugin_name,
                 live_count: class_info.live_count,
                 produced_by: class_info.produced_by,
                 consumed_by: class_info.consumed_by,
@@ -66,12 +72,14 @@ impl CraftOps for AppCraftOps {
             .read_object(&::driver::ObjectSelector::ObjectId(object_id.to_string()))?;
         let predicate_source = self
             .driver
-            .get_class(&object.class_name)
+            .get_class(&object.class_id)
             .map(|c| c.predicate_source)
             .unwrap_or_default();
         Ok(mcp::ObjectDetail {
             id: object.id,
-            class_name: object.class_name,
+            class_id: object.class_id,
+            class_display_name: object.class_display_name,
+            plugin_name: object.plugin_name,
             status: status_string(object.status),
             tx_hash: object.tx_hash,
             state: object.fields,
@@ -79,10 +87,12 @@ impl CraftOps for AppCraftOps {
         })
     }
 
-    fn inspect_class(&self, class_name: &str) -> anyhow::Result<mcp::ClassDetail> {
-        let class_info = self.driver.get_class(class_name)?;
+    fn inspect_class(&self, class_id: &str) -> anyhow::Result<mcp::ClassDetail> {
+        let class_info = self.driver.get_class(class_id)?;
         Ok(mcp::ClassDetail {
-            class_name: class_info.name,
+            class_id: class_info.id,
+            class_display_name: class_info.display_name,
+            plugin_name: class_info.plugin_name,
             predicate_source: class_info.predicate_source,
             produced_by: class_info.produced_by,
             consumed_by: class_info.consumed_by,
@@ -131,7 +141,9 @@ impl CraftOps for AppCraftOps {
                     .read_object(&::driver::ObjectSelector::FileName(file_name.clone()))?;
                 Ok(mcp::InventoryObject {
                     id: detail.id,
-                    class_name: detail.class_name,
+                    class_id: detail.class_id,
+                    class_display_name: detail.class_display_name,
+                    plugin_name: detail.plugin_name,
                     file_name: detail.file_name,
                     status: status_string(detail.status),
                     tx_hash: detail.tx_hash,
@@ -160,12 +172,15 @@ impl CraftOps for AppCraftOps {
                 .available_inputs
                 .into_iter()
                 .map(|candidate| mcp::FeasibilityInput {
-                    class_name: candidate.class_name,
+                    class_id: candidate.class_id,
+                    class_display_name: candidate.class_display_name,
+                    plugin_name: candidate.plugin_name,
                     object_id: candidate.object_id,
                     file_name: candidate.file_name,
                 })
                 .collect(),
-            missing_inputs: report.missing_inputs,
+            missing_input_class_ids: report.missing_input_class_ids,
+            missing_input_class_names: report.missing_input_class_names,
         })
     }
 
@@ -187,7 +202,9 @@ fn status_string(status: ::driver::ObjectStatus) -> String {
 fn to_mcp_inventory_object(object: ::driver::ObjectSummary) -> mcp::InventoryObject {
     mcp::InventoryObject {
         id: object.id,
-        class_name: object.class_name,
+        class_id: object.class_id,
+        class_display_name: object.class_display_name,
+        plugin_name: object.plugin_name,
         file_name: object.file_name,
         status: status_string(object.status),
         tx_hash: object.tx_hash,

--- a/app-gui/src-tauri/src/mcp.rs
+++ b/app-gui/src-tauri/src/mcp.rs
@@ -40,8 +40,16 @@ impl CraftOps for AppCraftOps {
             .map(|action| mcp::Action {
                 action: to_mcp_qname(action.action),
                 description: action.description,
-                total_inputs: action.total_inputs.into_iter().map(to_mcp_class_ref).collect(),
-                total_outputs: action.total_outputs.into_iter().map(to_mcp_class_ref).collect(),
+                total_inputs: action
+                    .total_inputs
+                    .into_iter()
+                    .map(to_mcp_class_ref)
+                    .collect(),
+                total_outputs: action
+                    .total_outputs
+                    .into_iter()
+                    .map(to_mcp_class_ref)
+                    .collect(),
             })
             .collect())
     }
@@ -54,8 +62,16 @@ impl CraftOps for AppCraftOps {
             .map(|class_info| mcp::ClassSummary {
                 class: to_mcp_qname(class_info.class),
                 live_count: class_info.live_count,
-                produced_by: class_info.produced_by.into_iter().map(to_mcp_qname).collect(),
-                consumed_by: class_info.consumed_by.into_iter().map(to_mcp_qname).collect(),
+                produced_by: class_info
+                    .produced_by
+                    .into_iter()
+                    .map(to_mcp_qname)
+                    .collect(),
+                consumed_by: class_info
+                    .consumed_by
+                    .into_iter()
+                    .map(to_mcp_qname)
+                    .collect(),
             })
             .collect())
     }
@@ -88,8 +104,16 @@ impl CraftOps for AppCraftOps {
         Ok(mcp::ClassDetail {
             class: to_mcp_qname(class_info.class),
             predicate_source: class_info.predicate_source,
-            produced_by: class_info.produced_by.into_iter().map(to_mcp_qname).collect(),
-            consumed_by: class_info.consumed_by.into_iter().map(to_mcp_qname).collect(),
+            produced_by: class_info
+                .produced_by
+                .into_iter()
+                .map(to_mcp_qname)
+                .collect(),
+            consumed_by: class_info
+                .consumed_by
+                .into_iter()
+                .map(to_mcp_qname)
+                .collect(),
         })
     }
 

--- a/app-gui/src-tauri/src/run_action.rs
+++ b/app-gui/src-tauri/src/run_action.rs
@@ -1,6 +1,7 @@
 use std::path::Path;
 use std::sync::Arc;
 
+use ::driver::QualifiedName;
 use anyhow::{anyhow, Result};
 use serde::{Deserialize, Serialize};
 
@@ -10,7 +11,7 @@ use crate::progress::TauriProgressReporter;
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RunActionInput {
-    pub action_id: String,
+    pub action: QualifiedName,
     pub input_object_paths: Vec<String>,
 }
 
@@ -50,10 +51,10 @@ pub async fn run_action(
             })
             .collect::<Result<Vec<_>>>()?;
 
-        let reporter = TauriProgressReporter::new(app, input.action_id.clone());
+        let reporter = TauriProgressReporter::new(app, input.action.id());
         let result = driver.execute_with_reporter(
             ::driver::ExecuteActionInput {
-                action_id: input.action_id,
+                action: input.action,
                 input_objects,
             },
             &reporter,

--- a/app-gui/src/App.tsx
+++ b/app-gui/src/App.tsx
@@ -32,7 +32,7 @@ function App() {
   const inventory = useStore((state) => state.inventory);
   const actions = useStore((state) => state.actions);
   const activeObjectId = useStore((state) => state.activeObjectId);
-  const activeActionId = useStore((state) => state.activeActionId);
+  const activeAction = useStore((state) => state.activeAction);
   const contextSelection = useStore((state) => state.contextSelection);
   const showNullifiedItems = useStore((state) => state.showNullifiedItems);
   const hydrateData = useStore((state) => state.hydrateData);
@@ -118,7 +118,7 @@ function App() {
     let unlisten: (() => void) | null = null;
     listenMcpActionStarted((event) => {
       if (!cancelled) {
-        initProofPanel({ actionId: event.actionId, args: ["(via MCP)"] });
+        initProofPanel({ action: event.action, args: ["(via MCP)"] });
       }
     })
       .then((dispose) => {
@@ -309,7 +309,7 @@ function App() {
           <div className="right-column">
             <ActionGrid
               actions={actions}
-              activeActionId={activeActionId}
+              activeAction={activeAction}
               selectedObject={selectedObject}
               onSelectAction={selectAction}
               onClearSelection={clearSelection}

--- a/app-gui/src/features/actions/ActionGrid.tsx
+++ b/app-gui/src/features/actions/ActionGrid.tsx
@@ -4,8 +4,6 @@ import type {
   InventoryObjectPayload as InventoryObject,
 } from "../../shared/api/wireTypes";
 import { truncateDisplayHash } from "../../shared/format";
-import { classDisplayLabel } from "../../shared/objectUtils";
-import { useStore } from "../../shared/state/store";
 
 interface ActionGridProps {
   actions: Action[];
@@ -23,7 +21,6 @@ export function ActionGrid({
   onClearSelection,
 }: ActionGridProps) {
   const [search, setSearch] = useState("");
-  const nameCollisions = useStore((state) => state.nameCollisions);
 
   const compatibilityFiltered = useMemo(() => {
     if (!selectedObject) return actions;
@@ -47,13 +44,7 @@ export function ActionGrid({
     });
   }, [compatibilityFiltered, search, selectedObject]);
 
-  const selectedObjectLabel = selectedObject
-    ? classDisplayLabel(
-        selectedObject.classDisplayName,
-        selectedObject.pluginName,
-        nameCollisions,
-      )
-    : "";
+  const selectedObjectLabel = selectedObject?.classDisplayName ?? "";
   const filterLabel = selectedObject
     ? visibleActions.length > 0
       ? `accepts # ${selectedObjectLabel}`
@@ -97,11 +88,7 @@ export function ActionGrid({
       </div>
       <div className="action-list">
         {visibleActions.map((action) => {
-          const label = classDisplayLabel(
-            action.displayName,
-            action.pluginName,
-            nameCollisions,
-          );
+          const label = action.displayName;
           return (
             <button
               key={action.id}

--- a/app-gui/src/features/actions/ActionGrid.tsx
+++ b/app-gui/src/features/actions/ActionGrid.tsx
@@ -26,9 +26,7 @@ export function ActionGrid({
   const compatibilityFiltered = useMemo(() => {
     if (!selectedObject) return actions;
     return actions.filter((action) =>
-      action.totalInputClassIds.some(
-        (classId) => classId === selectedObject.classId,
-      ),
+      action.totalInputs.some((ref) => ref.id === selectedObject.classId),
     );
   }, [actions, selectedObject]);
 

--- a/app-gui/src/features/actions/ActionGrid.tsx
+++ b/app-gui/src/features/actions/ActionGrid.tsx
@@ -4,6 +4,7 @@ import type {
   InventoryObjectPayload as InventoryObject,
 } from "../../shared/api/wireTypes";
 import { truncateDisplayHash } from "../../shared/format";
+import { pluginScopedLabel } from "../../shared/objectUtils";
 
 interface ActionGridProps {
   actions: Action[];
@@ -44,7 +45,9 @@ export function ActionGrid({
     });
   }, [compatibilityFiltered, search, selectedObject]);
 
-  const selectedObjectLabel = selectedObject?.classDisplayName ?? "";
+  const selectedObjectLabel = selectedObject
+    ? pluginScopedLabel(selectedObject.classDisplayName, selectedObject.pluginName)
+    : "";
   const filterLabel = selectedObject
     ? visibleActions.length > 0
       ? `accepts # ${selectedObjectLabel}`
@@ -88,7 +91,7 @@ export function ActionGrid({
       </div>
       <div className="action-list">
         {visibleActions.map((action) => {
-          const label = action.displayName;
+          const label = pluginScopedLabel(action.displayName, action.pluginName);
           return (
             <button
               key={action.id}

--- a/app-gui/src/features/actions/ActionGrid.tsx
+++ b/app-gui/src/features/actions/ActionGrid.tsx
@@ -2,21 +2,22 @@ import { useMemo, useState } from "react";
 import type {
   ActionPayload as Action,
   InventoryObjectPayload as InventoryObject,
+  QualifiedNamePayload,
 } from "../../shared/api/wireTypes";
 import { truncateDisplayHash } from "../../shared/format";
-import { pluginScopedLabel } from "../../shared/objectUtils";
+import { pluginScopedLabel, qualifiedEq, qualifiedId } from "../../shared/objectUtils";
 
 interface ActionGridProps {
   actions: Action[];
-  activeActionId: string | null;
+  activeAction: QualifiedNamePayload | null;
   selectedObject: InventoryObject | null;
-  onSelectAction: (actionId: string) => void;
+  onSelectAction: (action: QualifiedNamePayload) => void;
   onClearSelection: () => void;
 }
 
 export function ActionGrid({
   actions,
-  activeActionId,
+  activeAction,
   selectedObject,
   onSelectAction,
   onClearSelection,
@@ -26,7 +27,7 @@ export function ActionGrid({
   const compatibilityFiltered = useMemo(() => {
     if (!selectedObject) return actions;
     return actions.filter((action) =>
-      action.totalInputs.some((ref) => ref.id === selectedObject.classId),
+      action.totalInputs.some((ref) => qualifiedEq(ref.class, selectedObject.class)),
     );
   }, [actions, selectedObject]);
 
@@ -36,15 +37,15 @@ export function ActionGrid({
     if (!q) return compatibilityFiltered;
     return compatibilityFiltered.filter((action) => {
       return (
-        action.id.toLowerCase().includes(q) ||
-        action.displayName.toLowerCase().includes(q) ||
+        action.action.name.toLowerCase().includes(q) ||
+        action.action.pluginName.toLowerCase().includes(q) ||
         action.description.toLowerCase().includes(q)
       );
     });
   }, [compatibilityFiltered, search, selectedObject]);
 
   const selectedObjectLabel = selectedObject
-    ? pluginScopedLabel(selectedObject.classDisplayName, selectedObject.pluginName)
+    ? pluginScopedLabel(selectedObject.class)
     : "";
   const filterLabel = selectedObject
     ? visibleActions.length > 0
@@ -89,13 +90,16 @@ export function ActionGrid({
       </div>
       <div className="action-list">
         {visibleActions.map((action) => {
-          const label = pluginScopedLabel(action.displayName, action.pluginName);
+          const id = qualifiedId(action.action);
+          const label = pluginScopedLabel(action.action);
+          const isActive =
+            activeAction !== null && qualifiedEq(activeAction, action.action);
           return (
             <button
-              key={action.id}
+              key={id}
               type="button"
-              className={`action-row ${activeActionId === action.id ? "active" : ""}`}
-              onClick={() => onSelectAction(action.id)}
+              className={`action-row ${isActive ? "active" : ""}`}
+              onClick={() => onSelectAction(action.action)}
             >
               <span className="action-row-emoji">{action.emoji}</span>
               <span className="action-row-name">{label}</span>

--- a/app-gui/src/features/actions/ActionGrid.tsx
+++ b/app-gui/src/features/actions/ActionGrid.tsx
@@ -4,6 +4,8 @@ import type {
   InventoryObjectPayload as InventoryObject,
 } from "../../shared/api/wireTypes";
 import { truncateDisplayHash } from "../../shared/format";
+import { classDisplayLabel } from "../../shared/objectUtils";
+import { useStore } from "../../shared/state/store";
 
 interface ActionGridProps {
   actions: Action[];
@@ -21,12 +23,13 @@ export function ActionGrid({
   onClearSelection,
 }: ActionGridProps) {
   const [search, setSearch] = useState("");
+  const nameCollisions = useStore((state) => state.nameCollisions);
 
   const compatibilityFiltered = useMemo(() => {
     if (!selectedObject) return actions;
     return actions.filter((action) =>
-      action.totalInputClasses.some(
-        (className) => className === selectedObject.className,
+      action.totalInputClassIds.some(
+        (classId) => classId === selectedObject.classId,
       ),
     );
   }, [actions, selectedObject]);
@@ -38,14 +41,22 @@ export function ActionGrid({
     return compatibilityFiltered.filter((action) => {
       return (
         action.id.toLowerCase().includes(q) ||
+        action.displayName.toLowerCase().includes(q) ||
         action.description.toLowerCase().includes(q)
       );
     });
   }, [compatibilityFiltered, search, selectedObject]);
 
+  const selectedObjectLabel = selectedObject
+    ? classDisplayLabel(
+        selectedObject.classDisplayName,
+        selectedObject.pluginName,
+        nameCollisions,
+      )
+    : "";
   const filterLabel = selectedObject
     ? visibleActions.length > 0
-      ? `accepts # ${selectedObject.className}`
+      ? `accepts # ${selectedObjectLabel}`
       : "no matching actions"
     : "";
   const tabLabel = selectedObject
@@ -85,20 +96,27 @@ export function ActionGrid({
         )}
       </div>
       <div className="action-list">
-        {visibleActions.map((action) => (
-          <button
-            key={action.id}
-            type="button"
-            className={`action-row ${activeActionId === action.id ? "active" : ""}`}
-            onClick={() => onSelectAction(action.id)}
-          >
-            <span className="action-row-emoji">{action.emoji}</span>
-            <span className="action-row-name">{action.id}</span>
-            <span className="action-row-hash" title={action.hash || "No hash"}>
-              {truncateDisplayHash(action.hash)}
-            </span>
-          </button>
-        ))}
+        {visibleActions.map((action) => {
+          const label = classDisplayLabel(
+            action.displayName,
+            action.pluginName,
+            nameCollisions,
+          );
+          return (
+            <button
+              key={action.id}
+              type="button"
+              className={`action-row ${activeActionId === action.id ? "active" : ""}`}
+              onClick={() => onSelectAction(action.id)}
+            >
+              <span className="action-row-emoji">{action.emoji}</span>
+              <span className="action-row-name">{label}</span>
+              <span className="action-row-hash" title={action.hash || "No hash"}>
+                {truncateDisplayHash(action.hash)}
+              </span>
+            </button>
+          );
+        })}
         {visibleActions.length === 0 && (
           <div className="action-empty">No actions match.</div>
         )}

--- a/app-gui/src/features/context/ContextPanel.tsx
+++ b/app-gui/src/features/context/ContextPanel.tsx
@@ -7,12 +7,12 @@ import type {
 import { pickDobjFilePath, readDobjFile } from "../../shared/api/tauriClient";
 import { truncateDisplayHash } from "../../shared/format";
 import {
+  classDisplayLabel,
   displayPathInObjectsDir,
-  displayObjectFileName,
-  isLiveObject,
   isNullifiedObject,
   joinObjectsDirPath,
 } from "../../shared/objectUtils";
+import { useStore } from "../../shared/state/store";
 import { isRecord, normalizePod2Value } from "../../shared/pod2utils";
 import type { ContextSelection } from "../../shared/state/store";
 
@@ -52,6 +52,7 @@ export function ContextPanel({
   const [hoverArgKey, setHoverArgKey] = useState<string | null>(null);
   const [argErrors, setArgErrors] = useState<Record<string, string>>({});
   const previousProofStatusRef = useRef(proofStatus);
+  const nameCollisions = useStore((state) => state.nameCollisions);
   const selectionKey =
     selection.kind === "object"
       ? `object:${selection.objectId}`
@@ -82,33 +83,36 @@ export function ContextPanel({
   ): {
     objectPath?: string;
     name?: string;
-    className?: string;
+    classId?: string;
+    classDisplayName?: string;
   } => {
     try {
       return JSON.parse(raw) as {
         objectPath?: string;
         name?: string;
-        className?: string;
+        classId?: string;
+        classDisplayName?: string;
       };
     } catch {
       return { name: raw };
     }
   };
 
-  const normalizeName = (value: string) => value.trim().toLowerCase();
-
+  /** Compatibility is by qualified class id; bare names alone are ambiguous
+   * across plugins. */
   const isArgCompatible = (
-    expectedClassName: string,
-    droppedClassName?: string,
+    expectedClassId: string,
+    droppedClassId?: string,
   ) => {
-    if (!droppedClassName) return false;
-    return normalizeName(droppedClassName) === normalizeName(expectedClassName);
+    if (!droppedClassId) return false;
+    return droppedClassId === expectedClassId;
   };
 
   const handleDropArg = (
     event: DragEvent<HTMLDivElement>,
     methodId: string,
-    expectedClassName: string,
+    expectedClassId: string,
+    expectedClassDisplay: string,
     index: number,
   ) => {
     if (proofRunning) return;
@@ -126,11 +130,11 @@ export function ContextPanel({
     const droppedName = parsed.name ?? raw;
     const droppedPath = parsed.objectPath?.trim() ?? "";
 
-    if (!isArgCompatible(expectedClassName, parsed.className)) {
-      const got = parsed.className ?? droppedName;
+    if (!isArgCompatible(expectedClassId, parsed.classId)) {
+      const got = parsed.classDisplayName ?? parsed.classId ?? droppedName;
       setArgErrors((prev) => ({
         ...prev,
-        [key]: `Expected ${expectedClassName} but got ${got}`,
+        [key]: `Expected ${expectedClassDisplay} but got ${got}`,
       }));
       return;
     }
@@ -177,7 +181,8 @@ export function ContextPanel({
 
   const handleBrowseArgFile = async (
     methodId: string,
-    expectedClassName: string,
+    expectedClassId: string,
+    expectedClassDisplay: string,
     index: number,
   ) => {
     const key = argKey(methodId, index);
@@ -212,7 +217,7 @@ export function ContextPanel({
     }
 
     let parsed: {
-      className: string;
+      classId: string;
       status: string;
     };
     try {
@@ -225,11 +230,11 @@ export function ContextPanel({
       return;
     }
 
-    const className = parsed.className.trim();
+    const classId = parsed.classId.trim();
     const objectIsLive = parsed.status === "live";
-    const fileLabel = displayObjectFileName(className);
+    const fileLabel = selectedName;
 
-    if (!className) {
+    if (!classId) {
       setArgErrors((prev) => ({
         ...prev,
         [key]: `Missing required fields in .dobj: ${selectedName}`,
@@ -237,10 +242,10 @@ export function ContextPanel({
       return;
     }
 
-    if (!isArgCompatible(expectedClassName, className)) {
+    if (!isArgCompatible(expectedClassId, classId)) {
       setArgErrors((prev) => ({
         ...prev,
-        [key]: `Expected ${expectedClassName} but got ${className}`,
+        [key]: `Expected ${expectedClassDisplay} but got ${classId}`,
       }));
       return;
     }
@@ -287,40 +292,49 @@ export function ContextPanel({
   const renderMethodCard = (config: {
     methodId: string;
     methodName: string;
-    totalInputClasses: string[];
+    totalInputClassIds: string[];
+    totalInputClassNames: string[];
     totalInputClassHashes: string[];
+    pluginName: string;
     onRun: (boundArgs: BoundArg[]) => void;
   }) =>
     (() => {
-      const hasInputs = config.totalInputClasses.length > 0;
-      const boundArgs = config.totalInputClasses.map(
+      const hasInputs = config.totalInputClassIds.length > 0;
+      const boundArgs = config.totalInputClassIds.map(
         (_, index) => argBindings[argKey(config.methodId, index)] ?? null,
       );
       const filledCount = boundArgs.filter(
         (value) => value?.objectPath?.trim().length,
       ).length;
       const allArgsBound =
-        !hasInputs || filledCount === config.totalInputClasses.length;
+        !hasInputs || filledCount === config.totalInputClassIds.length;
 
       return (
         <div className="method-card">
           {hasInputs && (
             <div className="method-card-body">
-              {config.totalInputClasses.map((expectedClassName, index) => {
+              {config.totalInputClassIds.map((expectedClassId, index) => {
                 const key = argKey(config.methodId, index);
                 const bound = argBindings[key];
                 const isDropActive = hoverArgKey === key;
                 const err = argErrors[key];
                 const classHash = config.totalInputClassHashes[index] ?? "";
+                const expectedClassName =
+                  config.totalInputClassNames[index] ?? expectedClassId;
+                const expectedClassLabel = classDisplayLabel(
+                  expectedClassName,
+                  config.pluginName,
+                  nameCollisions,
+                );
 
                 return (
                   <div
-                    key={`${expectedClassName}:${index}`}
+                    key={`${expectedClassId}:${index}`}
                     className="method-arg"
                   >
                     <div className="method-arg-row">
                       <span className="method-arg-label">
-                        {renderClassChip(`# ${expectedClassName}`, classHash)}
+                        {renderClassChip(`# ${expectedClassLabel}`, classHash)}
                       </span>
                       <div
                         className={`method-arg-drop ${bound ? "filled" : ""} ${isDropActive ? "drop-active" : ""} ${err ? "error" : ""}`}
@@ -343,7 +357,8 @@ export function ContextPanel({
                           handleDropArg(
                             event,
                             config.methodId,
-                            expectedClassName,
+                            expectedClassId,
+                            expectedClassLabel,
                             index,
                           )
                         }
@@ -369,7 +384,8 @@ export function ContextPanel({
                           }
                           void handleBrowseArgFile(
                             config.methodId,
-                            expectedClassName,
+                            expectedClassId,
+                            expectedClassLabel,
                             index,
                           );
                         }}
@@ -406,8 +422,7 @@ export function ContextPanel({
     })();
 
   const displayThingPath = (object: InventoryObject) => {
-    const displayName = displayObjectFileName(object.className);
-    const absolutePath = joinObjectsDirPath(objectsDirPath, displayName, {
+    const absolutePath = joinObjectsDirPath(objectsDirPath, object.fileName, {
       nullified: isNullifiedObject(object),
     });
     return displayPathInObjectsDir(absolutePath, objectsDirPath);
@@ -508,7 +523,11 @@ export function ContextPanel({
     if (!object)
       return <section className="context-panel">Object not found.</section>;
 
-    const titleName = object.className;
+    const titleName = classDisplayLabel(
+      object.classDisplayName,
+      object.pluginName,
+      nameCollisions,
+    );
     const liveValueRaw = object.status === "live" ? object.id : object.status;
     const liveValue = truncateDisplayHash(liveValueRaw);
 
@@ -540,7 +559,7 @@ export function ContextPanel({
           )}
           {renderMetaRow(
             "Type",
-            renderClassChip(`# ${object.className}`, object.classHash),
+            renderClassChip(`# ${titleName}`, object.classHash),
           )}
           {renderMetaRow(
             "Path",
@@ -565,12 +584,17 @@ export function ContextPanel({
     return <section className="context-panel">Action not found.</section>;
   const actionHashRaw = action.hash.trim();
   const actionHashDisplay = truncateDisplayHash(actionHashRaw);
+  const actionLabel = classDisplayLabel(
+    action.displayName,
+    action.pluginName,
+    nameCollisions,
+  );
 
   return (
     <section className="context-panel">
       <div className="context-title-row">
         <div className="context-title">
-          {action.emoji} {action.id}
+          {action.emoji} {actionLabel}
         </div>
         <button
           type="button"
@@ -595,9 +619,11 @@ export function ContextPanel({
 
       {renderMethodCard({
         methodId: action.id,
-        methodName: action.id,
-        totalInputClasses: action.totalInputClasses,
+        methodName: actionLabel,
+        totalInputClassIds: action.totalInputClassIds,
+        totalInputClassNames: action.totalInputClassNames,
         totalInputClassHashes: action.totalInputClassHashes,
+        pluginName: action.pluginName,
         onRun: (boundArgs) =>
           onRunProof({
             actionId: action.id,

--- a/app-gui/src/features/context/ContextPanel.tsx
+++ b/app-gui/src/features/context/ContextPanel.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState, type ReactNode } from "react";
 import type { DragEvent } from "react";
 import type {
   ActionPayload as Action,
+  ClassRefPayload,
   InventoryObjectPayload as InventoryObject,
 } from "../../shared/api/wireTypes";
 import { pickDobjFilePath, readDobjFile } from "../../shared/api/tauriClient";
@@ -291,36 +292,33 @@ export function ContextPanel({
     methodId: string;
     methodName: string;
     pluginName: string;
-    totalInputClassIds: string[];
-    totalInputClassNames: string[];
-    totalInputClassHashes: string[];
+    totalInputs: ClassRefPayload[];
     onRun: (boundArgs: BoundArg[]) => void;
   }) =>
     (() => {
-      const hasInputs = config.totalInputClassIds.length > 0;
-      const boundArgs = config.totalInputClassIds.map(
+      const hasInputs = config.totalInputs.length > 0;
+      const boundArgs = config.totalInputs.map(
         (_, index) => argBindings[argKey(config.methodId, index)] ?? null,
       );
       const filledCount = boundArgs.filter(
         (value) => value?.objectPath?.trim().length,
       ).length;
       const allArgsBound =
-        !hasInputs || filledCount === config.totalInputClassIds.length;
+        !hasInputs || filledCount === config.totalInputs.length;
 
       return (
         <div className="method-card">
           {hasInputs && (
             <div className="method-card-body">
-              {config.totalInputClassIds.map((expectedClassId, index) => {
+              {config.totalInputs.map((required, index) => {
                 const key = argKey(config.methodId, index);
                 const bound = argBindings[key];
                 const isDropActive = hoverArgKey === key;
                 const err = argErrors[key];
-                const classHash = config.totalInputClassHashes[index] ?? "";
-                const expectedClassName =
-                  config.totalInputClassNames[index] ?? expectedClassId;
+                const expectedClassId = required.id;
+                const classHash = required.hash;
                 const expectedClassLabel = pluginScopedLabel(
-                  expectedClassName,
+                  required.displayName,
                   config.pluginName,
                 );
 
@@ -610,9 +608,7 @@ export function ContextPanel({
         methodId: action.id,
         methodName: actionLabel,
         pluginName: action.pluginName,
-        totalInputClassIds: action.totalInputClassIds,
-        totalInputClassNames: action.totalInputClassNames,
-        totalInputClassHashes: action.totalInputClassHashes,
+        totalInputs: action.totalInputs,
         onRun: (boundArgs) =>
           onRunProof({
             actionId: action.id,

--- a/app-gui/src/features/context/ContextPanel.tsx
+++ b/app-gui/src/features/context/ContextPanel.tsx
@@ -10,6 +10,7 @@ import {
   displayPathInObjectsDir,
   isNullifiedObject,
   joinObjectsDirPath,
+  pluginScopedLabel,
 } from "../../shared/objectUtils";
 import { isRecord, normalizePod2Value } from "../../shared/pod2utils";
 import type { ContextSelection } from "../../shared/state/store";
@@ -289,6 +290,7 @@ export function ContextPanel({
   const renderMethodCard = (config: {
     methodId: string;
     methodName: string;
+    pluginName: string;
     totalInputClassIds: string[];
     totalInputClassNames: string[];
     totalInputClassHashes: string[];
@@ -315,8 +317,12 @@ export function ContextPanel({
                 const isDropActive = hoverArgKey === key;
                 const err = argErrors[key];
                 const classHash = config.totalInputClassHashes[index] ?? "";
-                const expectedClassLabel =
+                const expectedClassName =
                   config.totalInputClassNames[index] ?? expectedClassId;
+                const expectedClassLabel = pluginScopedLabel(
+                  expectedClassName,
+                  config.pluginName,
+                );
 
                 return (
                   <div
@@ -514,7 +520,7 @@ export function ContextPanel({
     if (!object)
       return <section className="context-panel">Object not found.</section>;
 
-    const titleName = object.classDisplayName;
+    const titleName = pluginScopedLabel(object.classDisplayName, object.pluginName);
     const liveValueRaw = object.status === "live" ? object.id : object.status;
     const liveValue = truncateDisplayHash(liveValueRaw);
 
@@ -571,7 +577,7 @@ export function ContextPanel({
     return <section className="context-panel">Action not found.</section>;
   const actionHashRaw = action.hash.trim();
   const actionHashDisplay = truncateDisplayHash(actionHashRaw);
-  const actionLabel = action.displayName;
+  const actionLabel = pluginScopedLabel(action.displayName, action.pluginName);
 
   return (
     <section className="context-panel">
@@ -603,6 +609,7 @@ export function ContextPanel({
       {renderMethodCard({
         methodId: action.id,
         methodName: actionLabel,
+        pluginName: action.pluginName,
         totalInputClassIds: action.totalInputClassIds,
         totalInputClassNames: action.totalInputClassNames,
         totalInputClassHashes: action.totalInputClassHashes,

--- a/app-gui/src/features/context/ContextPanel.tsx
+++ b/app-gui/src/features/context/ContextPanel.tsx
@@ -7,12 +7,10 @@ import type {
 import { pickDobjFilePath, readDobjFile } from "../../shared/api/tauriClient";
 import { truncateDisplayHash } from "../../shared/format";
 import {
-  classDisplayLabel,
   displayPathInObjectsDir,
   isNullifiedObject,
   joinObjectsDirPath,
 } from "../../shared/objectUtils";
-import { useStore } from "../../shared/state/store";
 import { isRecord, normalizePod2Value } from "../../shared/pod2utils";
 import type { ContextSelection } from "../../shared/state/store";
 
@@ -52,7 +50,6 @@ export function ContextPanel({
   const [hoverArgKey, setHoverArgKey] = useState<string | null>(null);
   const [argErrors, setArgErrors] = useState<Record<string, string>>({});
   const previousProofStatusRef = useRef(proofStatus);
-  const nameCollisions = useStore((state) => state.nameCollisions);
   const selectionKey =
     selection.kind === "object"
       ? `object:${selection.objectId}`
@@ -295,7 +292,6 @@ export function ContextPanel({
     totalInputClassIds: string[];
     totalInputClassNames: string[];
     totalInputClassHashes: string[];
-    pluginName: string;
     onRun: (boundArgs: BoundArg[]) => void;
   }) =>
     (() => {
@@ -319,13 +315,8 @@ export function ContextPanel({
                 const isDropActive = hoverArgKey === key;
                 const err = argErrors[key];
                 const classHash = config.totalInputClassHashes[index] ?? "";
-                const expectedClassName =
+                const expectedClassLabel =
                   config.totalInputClassNames[index] ?? expectedClassId;
-                const expectedClassLabel = classDisplayLabel(
-                  expectedClassName,
-                  config.pluginName,
-                  nameCollisions,
-                );
 
                 return (
                   <div
@@ -523,11 +514,7 @@ export function ContextPanel({
     if (!object)
       return <section className="context-panel">Object not found.</section>;
 
-    const titleName = classDisplayLabel(
-      object.classDisplayName,
-      object.pluginName,
-      nameCollisions,
-    );
+    const titleName = object.classDisplayName;
     const liveValueRaw = object.status === "live" ? object.id : object.status;
     const liveValue = truncateDisplayHash(liveValueRaw);
 
@@ -584,11 +571,7 @@ export function ContextPanel({
     return <section className="context-panel">Action not found.</section>;
   const actionHashRaw = action.hash.trim();
   const actionHashDisplay = truncateDisplayHash(actionHashRaw);
-  const actionLabel = classDisplayLabel(
-    action.displayName,
-    action.pluginName,
-    nameCollisions,
-  );
+  const actionLabel = action.displayName;
 
   return (
     <section className="context-panel">
@@ -623,7 +606,6 @@ export function ContextPanel({
         totalInputClassIds: action.totalInputClassIds,
         totalInputClassNames: action.totalInputClassNames,
         totalInputClassHashes: action.totalInputClassHashes,
-        pluginName: action.pluginName,
         onRun: (boundArgs) =>
           onRunProof({
             actionId: action.id,

--- a/app-gui/src/features/context/ContextPanel.tsx
+++ b/app-gui/src/features/context/ContextPanel.tsx
@@ -4,6 +4,7 @@ import type {
   ActionPayload as Action,
   ClassRefPayload,
   InventoryObjectPayload as InventoryObject,
+  QualifiedNamePayload,
 } from "../../shared/api/wireTypes";
 import { pickDobjFilePath, readDobjFile } from "../../shared/api/tauriClient";
 import { truncateDisplayHash } from "../../shared/format";
@@ -12,6 +13,8 @@ import {
   isNullifiedObject,
   joinObjectsDirPath,
   pluginScopedLabel,
+  qualifiedEq,
+  qualifiedId,
 } from "../../shared/objectUtils";
 import { isRecord, normalizePod2Value } from "../../shared/pod2utils";
 import type { ContextSelection } from "../../shared/state/store";
@@ -23,7 +26,7 @@ interface ContextPanelProps {
   actions: Action[];
   onClearSelection: () => void;
   onRunProof: (input: {
-    actionId: string;
+    action: QualifiedNamePayload;
     inputBindings: Array<{
       objectPath: string;
       label: string;
@@ -56,7 +59,7 @@ export function ContextPanel({
     selection.kind === "object"
       ? `object:${selection.objectId}`
       : selection.kind === "action"
-        ? `action:${selection.actionId}`
+        ? `action:${qualifiedId(selection.action)}`
         : "none";
 
   useEffect(() => {
@@ -82,36 +85,24 @@ export function ContextPanel({
   ): {
     objectPath?: string;
     name?: string;
-    classId?: string;
-    classDisplayName?: string;
+    class?: QualifiedNamePayload;
   } => {
     try {
       return JSON.parse(raw) as {
         objectPath?: string;
         name?: string;
-        classId?: string;
-        classDisplayName?: string;
+        class?: QualifiedNamePayload;
       };
     } catch {
       return { name: raw };
     }
   };
 
-  /** Compatibility is by qualified class id; bare names alone are ambiguous
-   * across plugins. */
-  const isArgCompatible = (
-    expectedClassId: string,
-    droppedClassId?: string,
-  ) => {
-    if (!droppedClassId) return false;
-    return droppedClassId === expectedClassId;
-  };
-
   const handleDropArg = (
     event: DragEvent<HTMLDivElement>,
     methodId: string,
-    expectedClassId: string,
-    expectedClassDisplay: string,
+    expected: QualifiedNamePayload,
+    expectedLabel: string,
     index: number,
   ) => {
     if (proofRunning) return;
@@ -129,11 +120,13 @@ export function ContextPanel({
     const droppedName = parsed.name ?? raw;
     const droppedPath = parsed.objectPath?.trim() ?? "";
 
-    if (!isArgCompatible(expectedClassId, parsed.classId)) {
-      const got = parsed.classDisplayName ?? parsed.classId ?? droppedName;
+    if (!parsed.class || !qualifiedEq(parsed.class, expected)) {
+      const got = parsed.class
+        ? pluginScopedLabel(parsed.class)
+        : droppedName;
       setArgErrors((prev) => ({
         ...prev,
-        [key]: `Expected ${expectedClassDisplay} but got ${got}`,
+        [key]: `Expected ${expectedLabel} but got ${got}`,
       }));
       return;
     }
@@ -180,8 +173,8 @@ export function ContextPanel({
 
   const handleBrowseArgFile = async (
     methodId: string,
-    expectedClassId: string,
-    expectedClassDisplay: string,
+    expected: QualifiedNamePayload,
+    expectedLabel: string,
     index: number,
   ) => {
     const key = argKey(methodId, index);
@@ -216,7 +209,7 @@ export function ContextPanel({
     }
 
     let parsed: {
-      classId: string;
+      class: QualifiedNamePayload;
       status: string;
     };
     try {
@@ -229,11 +222,10 @@ export function ContextPanel({
       return;
     }
 
-    const classId = parsed.classId.trim();
     const objectIsLive = parsed.status === "live";
     const fileLabel = selectedName;
 
-    if (!classId) {
+    if (!parsed.class) {
       setArgErrors((prev) => ({
         ...prev,
         [key]: `Missing required fields in .dobj: ${selectedName}`,
@@ -241,10 +233,10 @@ export function ContextPanel({
       return;
     }
 
-    if (!isArgCompatible(expectedClassId, classId)) {
+    if (!qualifiedEq(parsed.class, expected)) {
       setArgErrors((prev) => ({
         ...prev,
-        [key]: `Expected ${expectedClassDisplay} but got ${classId}`,
+        [key]: `Expected ${expectedLabel} but got ${pluginScopedLabel(parsed.class)}`,
       }));
       return;
     }
@@ -291,7 +283,6 @@ export function ContextPanel({
   const renderMethodCard = (config: {
     methodId: string;
     methodName: string;
-    pluginName: string;
     totalInputs: ClassRefPayload[];
     onRun: (boundArgs: BoundArg[]) => void;
   }) =>
@@ -315,21 +306,16 @@ export function ContextPanel({
                 const bound = argBindings[key];
                 const isDropActive = hoverArgKey === key;
                 const err = argErrors[key];
-                const expectedClassId = required.id;
-                const classHash = required.hash;
-                const expectedClassLabel = pluginScopedLabel(
-                  required.displayName,
-                  config.pluginName,
-                );
+                const expectedClassLabel = pluginScopedLabel(required.class);
 
                 return (
                   <div
-                    key={`${expectedClassId}:${index}`}
+                    key={`${qualifiedId(required.class)}:${index}`}
                     className="method-arg"
                   >
                     <div className="method-arg-row">
                       <span className="method-arg-label">
-                        {renderClassChip(`# ${expectedClassLabel}`, classHash)}
+                        {renderClassChip(`# ${expectedClassLabel}`, required.hash)}
                       </span>
                       <div
                         className={`method-arg-drop ${bound ? "filled" : ""} ${isDropActive ? "drop-active" : ""} ${err ? "error" : ""}`}
@@ -352,7 +338,7 @@ export function ContextPanel({
                           handleDropArg(
                             event,
                             config.methodId,
-                            expectedClassId,
+                            required.class,
                             expectedClassLabel,
                             index,
                           )
@@ -379,7 +365,7 @@ export function ContextPanel({
                           }
                           void handleBrowseArgFile(
                             config.methodId,
-                            expectedClassId,
+                            required.class,
                             expectedClassLabel,
                             index,
                           );
@@ -518,7 +504,7 @@ export function ContextPanel({
     if (!object)
       return <section className="context-panel">Object not found.</section>;
 
-    const titleName = pluginScopedLabel(object.classDisplayName, object.pluginName);
+    const titleName = pluginScopedLabel(object.class);
     const liveValueRaw = object.status === "live" ? object.id : object.status;
     const liveValue = truncateDisplayHash(liveValueRaw);
 
@@ -568,14 +554,14 @@ export function ContextPanel({
     );
   }
 
-  const action = actions.find(
-    (candidate) => candidate.id === selection.actionId,
+  const action = actions.find((candidate) =>
+    qualifiedEq(candidate.action, selection.action),
   );
   if (!action)
     return <section className="context-panel">Action not found.</section>;
   const actionHashRaw = action.hash.trim();
   const actionHashDisplay = truncateDisplayHash(actionHashRaw);
-  const actionLabel = pluginScopedLabel(action.displayName, action.pluginName);
+  const actionLabel = pluginScopedLabel(action.action);
 
   return (
     <section className="context-panel">
@@ -605,13 +591,12 @@ export function ContextPanel({
       <div className="context-desc">{action.description}</div>
 
       {renderMethodCard({
-        methodId: action.id,
+        methodId: qualifiedId(action.action),
         methodName: actionLabel,
-        pluginName: action.pluginName,
         totalInputs: action.totalInputs,
         onRun: (boundArgs) =>
           onRunProof({
-            actionId: action.id,
+            action: action.action,
             inputBindings: boundArgs.map((arg) => ({
               objectPath: arg.objectPath,
               label: arg.label,

--- a/app-gui/src/features/inventory/InventoryPanel.tsx
+++ b/app-gui/src/features/inventory/InventoryPanel.tsx
@@ -42,13 +42,12 @@ export function InventoryPanel({
       return;
     }
     const objectPath = joinObjectsDirPath(objectsDirPath, object.fileName);
-    const displayLabel = pluginScopedLabel(object.classDisplayName, object.pluginName);
+    const displayLabel = pluginScopedLabel(object.class);
 
     const payload = JSON.stringify({
       objectPath,
       name: displayLabel,
-      classId: object.classId,
-      classDisplayName: object.classDisplayName,
+      class: object.class,
     });
     event.dataTransfer.setData("application/x-zkcraft-object", payload);
     event.dataTransfer.setData("text/plain", displayLabel);
@@ -70,7 +69,7 @@ export function InventoryPanel({
   const nullifiedObjects = inventory.filter((object) => isNullifiedObject(object));
 
   const renderInventoryObject = (object: InventoryObject) => {
-    const displayName = pluginScopedLabel(object.classDisplayName, object.pluginName);
+    const displayName = pluginScopedLabel(object.class);
     const hashLineRaw = object.status === "live"
       ? object.id
       : object.status;

--- a/app-gui/src/features/inventory/InventoryPanel.tsx
+++ b/app-gui/src/features/inventory/InventoryPanel.tsx
@@ -3,13 +3,11 @@ import type { DragEvent } from "react";
 import type { InventoryObjectPayload as InventoryObject } from "../../shared/api/wireTypes";
 import { truncateDisplayHash } from "../../shared/format";
 import {
-  classDisplayLabel,
   displayPathInObjectsDir,
   isLiveObject,
   isNullifiedObject,
   joinObjectsDirPath,
 } from "../../shared/objectUtils";
-import { useStore } from "../../shared/state/store";
 
 interface InventoryPanelProps {
   inventory: InventoryObject[];
@@ -31,7 +29,6 @@ export function InventoryPanel({
   onOpenObjectsDir,
 }: InventoryPanelProps) {
   const isDraggingRef = useRef(false);
-  const nameCollisions = useStore((state) => state.nameCollisions);
 
   const isUsable = (object: InventoryObject) => isLiveObject(object);
 
@@ -44,11 +41,7 @@ export function InventoryPanel({
       return;
     }
     const objectPath = joinObjectsDirPath(objectsDirPath, object.fileName);
-    const displayLabel = classDisplayLabel(
-      object.classDisplayName,
-      object.pluginName,
-      nameCollisions,
-    );
+    const displayLabel = object.classDisplayName;
 
     const payload = JSON.stringify({
       objectPath,
@@ -76,11 +69,7 @@ export function InventoryPanel({
   const nullifiedObjects = inventory.filter((object) => isNullifiedObject(object));
 
   const renderInventoryObject = (object: InventoryObject) => {
-    const displayName = classDisplayLabel(
-      object.classDisplayName,
-      object.pluginName,
-      nameCollisions,
-    );
+    const displayName = object.classDisplayName;
     const hashLineRaw = object.status === "live"
       ? object.id
       : object.status;

--- a/app-gui/src/features/inventory/InventoryPanel.tsx
+++ b/app-gui/src/features/inventory/InventoryPanel.tsx
@@ -3,12 +3,13 @@ import type { DragEvent } from "react";
 import type { InventoryObjectPayload as InventoryObject } from "../../shared/api/wireTypes";
 import { truncateDisplayHash } from "../../shared/format";
 import {
+  classDisplayLabel,
   displayPathInObjectsDir,
-  displayObjectFileName,
   isLiveObject,
   isNullifiedObject,
   joinObjectsDirPath,
 } from "../../shared/objectUtils";
+import { useStore } from "../../shared/state/store";
 
 interface InventoryPanelProps {
   inventory: InventoryObject[];
@@ -30,6 +31,7 @@ export function InventoryPanel({
   onOpenObjectsDir,
 }: InventoryPanelProps) {
   const isDraggingRef = useRef(false);
+  const nameCollisions = useStore((state) => state.nameCollisions);
 
   const isUsable = (object: InventoryObject) => isLiveObject(object);
 
@@ -42,16 +44,21 @@ export function InventoryPanel({
       return;
     }
     const objectPath = joinObjectsDirPath(objectsDirPath, object.fileName);
-    const displayName = displayObjectFileName(object.className);
+    const displayLabel = classDisplayLabel(
+      object.classDisplayName,
+      object.pluginName,
+      nameCollisions,
+    );
 
     const payload = JSON.stringify({
       objectPath,
-      name: displayName,
-      className: object.className,
+      name: displayLabel,
+      classId: object.classId,
+      classDisplayName: object.classDisplayName,
     });
     event.dataTransfer.setData("application/x-zkcraft-object", payload);
-    event.dataTransfer.setData("text/plain", displayName);
-    event.dataTransfer.setData("text", displayName);
+    event.dataTransfer.setData("text/plain", displayLabel);
+    event.dataTransfer.setData("text", displayLabel);
     event.dataTransfer.effectAllowed = "copy";
     isDraggingRef.current = true;
   };
@@ -69,7 +76,11 @@ export function InventoryPanel({
   const nullifiedObjects = inventory.filter((object) => isNullifiedObject(object));
 
   const renderInventoryObject = (object: InventoryObject) => {
-    const displayName = displayObjectFileName(object.className);
+    const displayName = classDisplayLabel(
+      object.classDisplayName,
+      object.pluginName,
+      nameCollisions,
+    );
     const hashLineRaw = object.status === "live"
       ? object.id
       : object.status;

--- a/app-gui/src/features/inventory/InventoryPanel.tsx
+++ b/app-gui/src/features/inventory/InventoryPanel.tsx
@@ -7,6 +7,7 @@ import {
   isLiveObject,
   isNullifiedObject,
   joinObjectsDirPath,
+  pluginScopedLabel,
 } from "../../shared/objectUtils";
 
 interface InventoryPanelProps {
@@ -41,7 +42,7 @@ export function InventoryPanel({
       return;
     }
     const objectPath = joinObjectsDirPath(objectsDirPath, object.fileName);
-    const displayLabel = object.classDisplayName;
+    const displayLabel = pluginScopedLabel(object.classDisplayName, object.pluginName);
 
     const payload = JSON.stringify({
       objectPath,
@@ -69,7 +70,7 @@ export function InventoryPanel({
   const nullifiedObjects = inventory.filter((object) => isNullifiedObject(object));
 
   const renderInventoryObject = (object: InventoryObject) => {
-    const displayName = object.classDisplayName;
+    const displayName = pluginScopedLabel(object.classDisplayName, object.pluginName);
     const hashLineRaw = object.status === "live"
       ? object.id
       : object.status;

--- a/app-gui/src/features/proof-runner/ProofRunnerPanel.tsx
+++ b/app-gui/src/features/proof-runner/ProofRunnerPanel.tsx
@@ -1,5 +1,6 @@
 import { useLayoutEffect, useRef, useState } from "react";
 import { truncateDisplayHash } from "../../shared/format";
+import { qualifiedEq } from "../../shared/objectUtils";
 import { useStore } from "../../shared/state/store";
 
 export function ProofRunnerPanel() {
@@ -31,7 +32,7 @@ export function ProofRunnerPanel() {
     if (!runActive) {
       setShowCpuDuringRun(false);
     }
-  }, [runActive, proof.runActionId]);
+  }, [runActive, proof.runAction]);
 
   const globalRootRaw = proof.stats.globalStateRoot?.trim() ?? "";
   const globalRootDisplay = globalRootRaw
@@ -49,18 +50,18 @@ export function ProofRunnerPanel() {
   };
 
   const canReturnToAction =
-    !!proof.runActionId &&
+    proof.runAction !== null &&
     (proof.status === "generating" ||
       proof.status === "committing" ||
       proof.status === "summary");
   const alreadyViewingRunningAction =
-    proof.runActionId !== null &&
+    proof.runAction !== null &&
     contextSelection.kind === "action" &&
-    contextSelection.actionId === proof.runActionId;
+    qualifiedEq(contextSelection.action, proof.runAction);
 
   const returnToRunningAction = () => {
-    if (!proof.runActionId) return;
-    selectAction(proof.runActionId);
+    if (!proof.runAction) return;
+    selectAction(proof.runAction);
   };
 
   const toggleProofPanelView = () => {

--- a/app-gui/src/shared/api/tauriClient.ts
+++ b/app-gui/src/shared/api/tauriClient.ts
@@ -5,6 +5,7 @@ import type {
   CpuSample,
   LoadGuiInventoryResult,
   ObjectRecordPayload,
+  QualifiedNamePayload,
   RunActionInput,
   RunActionProgress,
   RunActionResult,
@@ -17,6 +18,7 @@ export type {
   InventoryObjectPayload,
   LoadGuiInventoryResult,
   ObjectRecordPayload,
+  QualifiedNamePayload,
   RunActionInput,
   RunActionProgress,
   RunActionResult,
@@ -75,11 +77,14 @@ export function getGlobalStateRoot(): Promise<string> {
 }
 
 export function listenMcpActionStarted(
-  handler: (event: { actionId: string }) => void,
+  handler: (event: { action: QualifiedNamePayload }) => void,
 ): Promise<UnlistenFn> {
-  return listen<{ actionId: string }>("mcp-action-started", (event) => {
-    handler(event.payload);
-  });
+  return listen<{ action: QualifiedNamePayload }>(
+    "mcp-action-started",
+    (event) => {
+      handler(event.payload);
+    },
+  );
 }
 
 export function getAppSettings(): Promise<AppSettingsPayload> {

--- a/app-gui/src/shared/api/wireTypes.ts
+++ b/app-gui/src/shared/api/wireTypes.ts
@@ -3,17 +3,21 @@ export type ProofProgressStatus = "running" | "done";
 
 export type ObjectStatus = "unknown" | "pending" | "live" | "nullified";
 
-// Action IDs and class names are not enumerated at compile time — they come
+// Action and class names are not enumerated at compile time — they come
 // from whichever plugin archives the user has installed in ~/.dobj/actions/.
+
+/** A name scoped to a plugin. Both classes and actions are identified this
+ * way; the printable form `<pluginName>::<name>` matches podlang's
+ * namespaced-predicate syntax. */
+export interface QualifiedNamePayload {
+  pluginName: string;
+  name: string;
+}
 
 export interface InventoryObjectPayload {
   id: string;
   fileName: string;
-  /** Qualified class id (`<plugin>::<class>`). */
-  classId: string;
-  /** Bare class name from the plugin manifest. */
-  classDisplayName: string;
-  pluginName: string;
+  class: QualifiedNamePayload;
   classHash: string;
   emoji: string;
   status: ObjectStatus;
@@ -24,20 +28,13 @@ export interface InventoryObjectPayload {
 }
 
 export interface ClassRefPayload {
-  /** Qualified class id (`<plugin>::<class>`). */
-  id: string;
-  /** Bare class name from the producing plugin's manifest. */
-  displayName: string;
+  class: QualifiedNamePayload;
   /** Hex-encoded `Is{class}` predicate hash. */
   hash: string;
 }
 
 export interface ActionPayload {
-  /** Qualified action id (`<plugin>::<action>`). */
-  id: string;
-  /** Bare action name from the plugin manifest. */
-  displayName: string;
-  pluginName: string;
+  action: QualifiedNamePayload;
   emoji: string;
   hash: string;
   totalInputs: ClassRefPayload[];
@@ -50,7 +47,7 @@ export interface LoadGuiInventoryResult {
 }
 
 export interface RunActionInput {
-  actionId: string;
+  action: QualifiedNamePayload;
   inputObjectPaths: string[];
 }
 
@@ -64,8 +61,7 @@ export interface RunActionResult {
 
 export interface ObjectRecordPayload {
   id: string;
-  /** Qualified class id (`<plugin>::<class>`). */
-  classId: string;
+  class: QualifiedNamePayload;
   status: ObjectStatus;
   txHash: string | null;
   pod: unknown;

--- a/app-gui/src/shared/api/wireTypes.ts
+++ b/app-gui/src/shared/api/wireTypes.ts
@@ -9,7 +9,11 @@ export type ObjectStatus = "unknown" | "pending" | "live" | "nullified";
 export interface InventoryObjectPayload {
   id: string;
   fileName: string;
-  className: string;
+  /** Qualified class id (`<plugin>:<class>`). */
+  classId: string;
+  /** Bare class name from the plugin manifest. */
+  classDisplayName: string;
+  pluginName: string;
   classHash: string;
   emoji: string;
   status: ObjectStatus;
@@ -20,17 +24,24 @@ export interface InventoryObjectPayload {
 }
 
 export interface ActionPayload {
+  /** Qualified action id (`<plugin>:<action>`). */
   id: string;
+  /** Bare action name from the plugin manifest. */
+  displayName: string;
+  pluginName: string;
   emoji: string;
   hash: string;
+  totalInputClassIds: string[];
+  totalInputClassNames: string[];
   totalInputClassHashes: string[];
   description: string;
-  totalInputClasses: string[];
 }
 
 export interface LoadGuiInventoryResult {
   inventory: InventoryObjectPayload[];
   actions: ActionPayload[];
+  /** Bare class/action names that appear in more than one loaded plugin. */
+  nameCollisions: string[];
 }
 
 export interface RunActionInput {
@@ -48,7 +59,8 @@ export interface RunActionResult {
 
 export interface ObjectRecordPayload {
   id: string;
-  className: string;
+  /** Qualified class id (`<plugin>:<class>`). */
+  classId: string;
   status: ObjectStatus;
   txHash: string | null;
   pod: unknown;

--- a/app-gui/src/shared/api/wireTypes.ts
+++ b/app-gui/src/shared/api/wireTypes.ts
@@ -23,6 +23,15 @@ export interface InventoryObjectPayload {
   obj: unknown;
 }
 
+export interface ClassRefPayload {
+  /** Qualified class id (`<plugin>:<class>`). */
+  id: string;
+  /** Bare class name from the producing plugin's manifest. */
+  displayName: string;
+  /** Hex-encoded `Is{class}` predicate hash. */
+  hash: string;
+}
+
 export interface ActionPayload {
   /** Qualified action id (`<plugin>:<action>`). */
   id: string;
@@ -31,9 +40,7 @@ export interface ActionPayload {
   pluginName: string;
   emoji: string;
   hash: string;
-  totalInputClassIds: string[];
-  totalInputClassNames: string[];
-  totalInputClassHashes: string[];
+  totalInputs: ClassRefPayload[];
   description: string;
 }
 

--- a/app-gui/src/shared/api/wireTypes.ts
+++ b/app-gui/src/shared/api/wireTypes.ts
@@ -40,8 +40,6 @@ export interface ActionPayload {
 export interface LoadGuiInventoryResult {
   inventory: InventoryObjectPayload[];
   actions: ActionPayload[];
-  /** Bare class/action names that appear in more than one loaded plugin. */
-  nameCollisions: string[];
 }
 
 export interface RunActionInput {

--- a/app-gui/src/shared/api/wireTypes.ts
+++ b/app-gui/src/shared/api/wireTypes.ts
@@ -9,7 +9,7 @@ export type ObjectStatus = "unknown" | "pending" | "live" | "nullified";
 export interface InventoryObjectPayload {
   id: string;
   fileName: string;
-  /** Qualified class id (`<plugin>:<class>`). */
+  /** Qualified class id (`<plugin>::<class>`). */
   classId: string;
   /** Bare class name from the plugin manifest. */
   classDisplayName: string;
@@ -24,7 +24,7 @@ export interface InventoryObjectPayload {
 }
 
 export interface ClassRefPayload {
-  /** Qualified class id (`<plugin>:<class>`). */
+  /** Qualified class id (`<plugin>::<class>`). */
   id: string;
   /** Bare class name from the producing plugin's manifest. */
   displayName: string;
@@ -33,7 +33,7 @@ export interface ClassRefPayload {
 }
 
 export interface ActionPayload {
-  /** Qualified action id (`<plugin>:<action>`). */
+  /** Qualified action id (`<plugin>::<action>`). */
   id: string;
   /** Bare action name from the plugin manifest. */
   displayName: string;
@@ -64,7 +64,7 @@ export interface RunActionResult {
 
 export interface ObjectRecordPayload {
   id: string;
-  /** Qualified class id (`<plugin>:<class>`). */
+  /** Qualified class id (`<plugin>::<class>`). */
   classId: string;
   status: ObjectStatus;
   txHash: string | null;

--- a/app-gui/src/shared/objectUtils.ts
+++ b/app-gui/src/shared/objectUtils.ts
@@ -14,33 +14,6 @@ export function displayObjectFileName(className: string): string {
   return `${className}.dobj`;
 }
 
-/**
- * Render a class label that includes a plugin disambiguator only when the
- * bare class name collides with another loaded plugin. Keeps the common
- * single-plugin case clean.
- */
-export function classDisplayLabel(
-  displayName: string,
-  pluginName: string,
-  nameCollisions: string[],
-): string {
-  if (!pluginName || !nameCollisions.includes(displayName)) {
-    return displayName;
-  }
-  return `${displayName} (${pluginName})`;
-}
-
-/**
- * Render an action label with the same collision rule.
- */
-export function actionDisplayLabel(
-  displayName: string,
-  pluginName: string,
-  nameCollisions: string[],
-): string {
-  return classDisplayLabel(displayName, pluginName, nameCollisions);
-}
-
 function normalizeObjectsDir(objectsDirPath: string): string {
   return objectsDirPath.replace(/[\\/]+$/, "");
 }

--- a/app-gui/src/shared/objectUtils.ts
+++ b/app-gui/src/shared/objectUtils.ts
@@ -10,8 +10,16 @@ export function isNullifiedObject(object: ObjectLike): boolean {
   return object.status === "nullified";
 }
 
-export function displayObjectFileName(className: string): string {
-  return `${className}.dobj`;
+/**
+ * Format a class or action label that includes the originating plugin name,
+ * so two plugins that expose the same bare name (e.g. `Wood` or `MakeFoo`)
+ * stay visually distinguishable in lists, headers, and slot chips.
+ */
+export function pluginScopedLabel(
+  displayName: string,
+  pluginName: string,
+): string {
+  return pluginName ? `${displayName} (${pluginName})` : displayName;
 }
 
 function normalizeObjectsDir(objectsDirPath: string): string {

--- a/app-gui/src/shared/objectUtils.ts
+++ b/app-gui/src/shared/objectUtils.ts
@@ -1,3 +1,5 @@
+import type { QualifiedNamePayload } from "./api/wireTypes";
+
 interface ObjectLike {
   status: string;
 }
@@ -11,15 +13,34 @@ export function isNullifiedObject(object: ObjectLike): boolean {
 }
 
 /**
- * Format a class or action label that includes the originating plugin name,
- * so two plugins that expose the same bare name (e.g. `Wood` or `MakeFoo`)
- * stay visually distinguishable in lists, headers, and slot chips.
+ * Canonical printable form `<plugin>::<name>` matching podlang's
+ * namespaced-predicate syntax. Use this for tooltips, drag payloads, or
+ * anywhere a single-string identifier is needed.
  */
-export function pluginScopedLabel(
-  displayName: string,
-  pluginName: string,
-): string {
-  return pluginName ? `${displayName} (${pluginName})` : displayName;
+export function qualifiedId(q: QualifiedNamePayload): string {
+  return `${q.pluginName}::${q.name}`;
+}
+
+/**
+ * `true` when two qualified names refer to the same plugin-scoped class or
+ * action. The wire type is structural, so equality is field-by-field.
+ */
+export function qualifiedEq(
+  a: QualifiedNamePayload,
+  b: QualifiedNamePayload,
+): boolean {
+  return a.pluginName === b.pluginName && a.name === b.name;
+}
+
+/**
+ * Label that always includes the originating plugin name so two plugins
+ * that expose the same bare name (e.g. `Wood` or `MakeFoo`) stay visually
+ * distinguishable in lists, headers, and slot chips. Returns just the bare
+ * name when the qualified name has no plugin (shouldn't happen in normal
+ * data flows but falls back gracefully).
+ */
+export function pluginScopedLabel(q: QualifiedNamePayload): string {
+  return q.pluginName ? `${q.name} (${q.pluginName})` : q.name;
 }
 
 function normalizeObjectsDir(objectsDirPath: string): string {

--- a/app-gui/src/shared/objectUtils.ts
+++ b/app-gui/src/shared/objectUtils.ts
@@ -14,6 +14,33 @@ export function displayObjectFileName(className: string): string {
   return `${className}.dobj`;
 }
 
+/**
+ * Render a class label that includes a plugin disambiguator only when the
+ * bare class name collides with another loaded plugin. Keeps the common
+ * single-plugin case clean.
+ */
+export function classDisplayLabel(
+  displayName: string,
+  pluginName: string,
+  nameCollisions: string[],
+): string {
+  if (!pluginName || !nameCollisions.includes(displayName)) {
+    return displayName;
+  }
+  return `${displayName} (${pluginName})`;
+}
+
+/**
+ * Render an action label with the same collision rule.
+ */
+export function actionDisplayLabel(
+  displayName: string,
+  pluginName: string,
+  nameCollisions: string[],
+): string {
+  return classDisplayLabel(displayName, pluginName, nameCollisions);
+}
+
 function normalizeObjectsDir(objectsDirPath: string): string {
   return objectsDirPath.replace(/[\\/]+$/, "");
 }

--- a/app-gui/src/shared/state/store.ts
+++ b/app-gui/src/shared/state/store.ts
@@ -4,9 +4,11 @@ import {
   runAction,
   type ActionPayload as Action,
   type InventoryObjectPayload as InventoryObject,
+  type QualifiedNamePayload,
   type RunActionProgress,
 } from "../api/tauriClient";
 import { normalizeErrorMessage } from "../error";
+import { qualifiedEq, qualifiedId } from "../objectUtils";
 
 type ProofStatus = "idle" | "generating" | "committing" | "summary" | "error";
 type StepStatus = "pending" | "running" | "done";
@@ -30,7 +32,8 @@ interface ProofSummary {
 }
 
 interface ProofState {
-  runActionId: string | null;
+  /** Identity (qualified) of the action currently being proved, when one is. */
+  runAction: QualifiedNamePayload | null;
   status: ProofStatus;
   args: string[];
   messages: string[];
@@ -45,27 +48,30 @@ interface ProofState {
 export type ContextSelection =
   | { kind: "none" }
   | { kind: "object"; objectId: string }
-  | { kind: "action"; actionId: string };
+  | { kind: "action"; action: QualifiedNamePayload };
 
 export interface AppState {
   contextSelection: ContextSelection;
   activeObjectId: string | null;
-  activeActionId: string | null;
+  activeAction: QualifiedNamePayload | null;
   showNullifiedItems: boolean;
   inventory: InventoryObject[];
   actions: Action[];
   proof: ProofState;
   hydrateData: () => Promise<void>;
   selectObject: (objectId: string) => void;
-  selectAction: (actionId: string) => void;
+  selectAction: (action: QualifiedNamePayload) => void;
   clearSelection: () => void;
   toggleNullified: () => void;
   recordCpuSample: (usagePct: number, totalCpuSecs: number) => void;
   setGlobalStateRoot: (hash: string | null) => void;
   applyRunActionProgress: (event: RunActionProgress) => void;
-  initProofPanel: (input: { actionId: string; args: string[] }) => void;
+  initProofPanel: (input: {
+    action: QualifiedNamePayload;
+    args: string[];
+  }) => void;
   runProof: (input: {
-    actionId: string;
+    action: QualifiedNamePayload;
     inputBindings: Array<{
       objectPath: string;
       label: string;
@@ -75,11 +81,11 @@ export interface AppState {
 
 const initialAppState: Pick<
   AppState,
-  "contextSelection" | "activeObjectId" | "activeActionId" | "showNullifiedItems"
+  "contextSelection" | "activeObjectId" | "activeAction" | "showNullifiedItems"
 > = {
   contextSelection: { kind: "none" },
   activeObjectId: null,
-  activeActionId: null,
+  activeAction: null,
   showNullifiedItems: false,
 };
 
@@ -88,7 +94,7 @@ export const useStore = create<AppState>((set, get) => ({
   inventory: [],
   actions: [],
   proof: {
-    runActionId: null,
+    runAction: null,
     status: "idle",
     args: [],
     messages: [],
@@ -115,7 +121,7 @@ export const useStore = create<AppState>((set, get) => ({
     set((prev) => {
       if (
         prev.activeObjectId === objectId &&
-        prev.activeActionId === null &&
+        prev.activeAction === null &&
         prev.contextSelection.kind === "object" &&
         prev.contextSelection.objectId === objectId
       ) {
@@ -128,36 +134,37 @@ export const useStore = create<AppState>((set, get) => ({
       return {
         ...prev,
         activeObjectId: objectId,
-        activeActionId: null,
+        activeAction: null,
         contextSelection: { kind: "object", objectId },
       };
     }),
-  selectAction: (actionId) =>
+  selectAction: (action) =>
     set((prev) => {
       if (
-        prev.activeActionId === actionId &&
+        prev.activeAction !== null &&
+        qualifiedEq(prev.activeAction, action) &&
         prev.activeObjectId === null &&
         prev.contextSelection.kind === "action" &&
-        prev.contextSelection.actionId === actionId
+        qualifiedEq(prev.contextSelection.action, action)
       ) {
         return {
           ...prev,
-          activeActionId: null,
+          activeAction: null,
           contextSelection: { kind: "none" },
         };
       }
       return {
         ...prev,
         activeObjectId: null,
-        activeActionId: actionId,
-        contextSelection: { kind: "action", actionId },
+        activeAction: action,
+        contextSelection: { kind: "action", action },
       };
     }),
   clearSelection: () =>
     set((prev) => ({
       ...prev,
       activeObjectId: null,
-      activeActionId: null,
+      activeAction: null,
       contextSelection: { kind: "none" },
     })),
   toggleNullified: () =>
@@ -200,7 +207,10 @@ export const useStore = create<AppState>((set, get) => ({
     }),
   applyRunActionProgress: (event) =>
     set((prev) => {
-      if (prev.proof.runActionId !== event.runId) return prev;
+      const runAction = prev.proof.runAction;
+      if (runAction === null || qualifiedId(runAction) !== event.runId) {
+        return prev;
+      }
 
       const nextSteps = prev.proof.steps.map((step) => ({ ...step }));
       const updateStep = (stepId: string, patch: Partial<ProofStep>) => {
@@ -242,7 +252,7 @@ export const useStore = create<AppState>((set, get) => ({
         },
       };
     }),
-  initProofPanel: ({ actionId, args }) =>
+  initProofPanel: ({ action, args }) =>
     set((prev) => {
       if (
         prev.proof.status === "generating" ||
@@ -253,7 +263,7 @@ export const useStore = create<AppState>((set, get) => ({
       return {
         ...prev,
         proof: {
-          runActionId: actionId,
+          runAction: action,
           status: "generating",
           args,
           messages: ["Running action..."],
@@ -279,23 +289,28 @@ export const useStore = create<AppState>((set, get) => ({
         },
       };
     }),
-  runProof: async ({ actionId, inputBindings }) => {
+  runProof: async ({ action, inputBindings }) => {
     const postDoneHoldMs = 2800;
     const verifyTargets =
       inputBindings.length > 0
         ? inputBindings.map((binding) => binding.label)
         : ["(no inputs)"];
 
-    get().initProofPanel({ actionId, args: verifyTargets });
+    get().initProofPanel({ action, args: verifyTargets });
 
     try {
       const result = await runAction({
-        actionId,
+        action,
         inputObjectPaths: inputBindings.map((binding) => binding.objectPath),
       });
 
       set((prev) => {
-        if (prev.proof.runActionId !== actionId) return prev;
+        if (
+          prev.proof.runAction === null ||
+          !qualifiedEq(prev.proof.runAction, action)
+        ) {
+          return prev;
+        }
         return {
           ...prev,
           proof: {
@@ -319,7 +334,7 @@ export const useStore = create<AppState>((set, get) => ({
         ...prev,
         proof: {
           ...prev.proof,
-          runActionId: null,
+          runAction: null,
           status: "idle",
           args: [],
           messages: [],
@@ -336,7 +351,7 @@ export const useStore = create<AppState>((set, get) => ({
       set((prev) => ({
         ...prev,
         proof: {
-          runActionId: null,
+          runAction: null,
           status: "error",
           args: verifyTargets,
           messages: [],

--- a/app-gui/src/shared/state/store.ts
+++ b/app-gui/src/shared/state/store.ts
@@ -54,8 +54,6 @@ export interface AppState {
   showNullifiedItems: boolean;
   inventory: InventoryObject[];
   actions: Action[];
-  /** Bare class/action names that appear in more than one loaded plugin. */
-  nameCollisions: string[];
   proof: ProofState;
   hydrateData: () => Promise<void>;
   selectObject: (objectId: string) => void;
@@ -89,7 +87,6 @@ export const useStore = create<AppState>((set, get) => ({
   ...initialAppState,
   inventory: [],
   actions: [],
-  nameCollisions: [],
   proof: {
     runActionId: null,
     status: "idle",
@@ -112,7 +109,6 @@ export const useStore = create<AppState>((set, get) => ({
       ...prev,
       inventory: data.inventory,
       actions: data.actions,
-      nameCollisions: data.nameCollisions,
     }));
   },
   selectObject: (objectId) =>

--- a/app-gui/src/shared/state/store.ts
+++ b/app-gui/src/shared/state/store.ts
@@ -54,6 +54,8 @@ export interface AppState {
   showNullifiedItems: boolean;
   inventory: InventoryObject[];
   actions: Action[];
+  /** Bare class/action names that appear in more than one loaded plugin. */
+  nameCollisions: string[];
   proof: ProofState;
   hydrateData: () => Promise<void>;
   selectObject: (objectId: string) => void;
@@ -87,6 +89,7 @@ export const useStore = create<AppState>((set, get) => ({
   ...initialAppState,
   inventory: [],
   actions: [],
+  nameCollisions: [],
   proof: {
     runActionId: null,
     status: "idle",
@@ -109,6 +112,7 @@ export const useStore = create<AppState>((set, get) => ({
       ...prev,
       inventory: data.inventory,
       actions: data.actions,
+      nameCollisions: data.nameCollisions,
     }));
   },
   selectObject: (objectId) =>

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -32,7 +32,7 @@ pub mod groth {
 use std::io;
 
 use anyhow::{Result, anyhow};
-use hex::ToHex;
+use hex::{FromHex, ToHex};
 use pod2::middleware::Hash;
 use tracing_subscriber::{EnvFilter, fmt::time::OffsetTime, prelude::*};
 
@@ -83,6 +83,11 @@ impl ProofType {
 
 pub fn encode_hash_hex(hash: &Hash) -> String {
     format!("0x{}", hash.encode_hex::<String>())
+}
+
+pub fn decode_hash_hex(s: &str) -> Result<Hash> {
+    let trimmed = s.strip_prefix("0x").unwrap_or(s);
+    Hash::from_hex(trimmed).map_err(|err| anyhow!("invalid hash hex {s:?}: {err}"))
 }
 
 pub fn log_init() {

--- a/common/src/proof.rs
+++ b/common/src/proof.rs
@@ -44,27 +44,20 @@ struct MockProofJson {
 }
 
 #[cfg(any(test, feature = "test-utils"))]
-pub fn parse_hex_hash(s: &str) -> Result<Hash> {
-    use anyhow::Context;
-
-    let hex = s.strip_prefix("0x").unwrap_or(s);
-    <Hash as hex::FromHex>::from_hex(hex).context("Invalid Hash hex")
-}
-
-#[cfg(any(test, feature = "test-utils"))]
 impl BlobParser for MockBlobParser {
     fn parse_blob(&self, blob_bytes: &[u8]) -> Result<Option<Payload>> {
+        use crate::decode_hash_hex;
         let json: MockProofJson = match serde_json::from_slice(blob_bytes) {
             Ok(j) => j,
             Err(_) => return Ok(None),
         };
-        let tx_final = parse_hex_hash(&json.tx_final)?;
+        let tx_final = decode_hash_hex(&json.tx_final)?;
         let nullifiers = json
             .nullifiers
             .iter()
-            .map(|s| parse_hex_hash(s))
+            .map(|s| decode_hash_hex(s))
             .collect::<Result<Vec<_>>>()?;
-        let state_root_hash = parse_hex_hash(&json.state_root_hash)?;
+        let state_root_hash = decode_hash_hex(&json.state_root_hash)?;
         Ok(Some(Payload {
             proof: PayloadProof::Groth16(vec![]),
             tx_final,

--- a/driver/Cargo.toml
+++ b/driver/Cargo.toml
@@ -29,3 +29,4 @@ dirs = "6.0.0"
 [dev-dependencies]
 common = { path = "../common", features = ["test-utils"] }
 tempfile = "3"
+toml = { workspace = true }

--- a/driver/src/catalog.rs
+++ b/driver/src/catalog.rs
@@ -7,7 +7,7 @@ use crate::types::ActionSummary;
 
 /// A class entry surfaced by an [`ActionCatalog`].
 ///
-/// The `id` is the qualified `<plugin>:<class>` form used everywhere as the
+/// The `id` is the qualified `<plugin>::<class>` form used everywhere as the
 /// canonical handle. `display_name` is the bare class name; `plugin_name` is
 /// available for collision-aware UI labels. `hash` is the on-chain
 /// `Is{class}` predicate hash — it disambiguates classes that share a

--- a/driver/src/catalog.rs
+++ b/driver/src/catalog.rs
@@ -31,12 +31,6 @@ pub trait ActionCatalog: Send + Sync {
     fn list_classes(&self) -> Vec<CatalogClass>;
     fn get_class(&self, class_id: &str) -> Option<CatalogClass>;
     fn get_class_by_hash(&self, class_hash: &Hash) -> Option<CatalogClass>;
-    /// Bare names that appear in more than one loaded plugin. Callers that
-    /// render a class label can use this to decide when to disambiguate
-    /// (e.g. by appending the plugin name).
-    fn name_collisions(&self) -> Vec<String> {
-        Vec::new()
-    }
     fn execute_action(
         &self,
         action_id: String,

--- a/driver/src/catalog.rs
+++ b/driver/src/catalog.rs
@@ -3,37 +3,33 @@ use pod2::middleware::Hash;
 use sdk::{SpendableObject, SpendableObjects};
 use txlib::GroundingWitness;
 
+use crate::qualified_name::QualifiedName;
 use crate::types::ActionSummary;
 
-/// A class entry surfaced by an [`ActionCatalog`].
-///
-/// The `id` is the qualified `<plugin>::<class>` form used everywhere as the
-/// canonical handle. `display_name` is the bare class name; `plugin_name` is
-/// available for collision-aware UI labels. `hash` is the on-chain
-/// `Is{class}` predicate hash — it disambiguates classes that share a
-/// display name but live in different plugins.
+/// A class entry surfaced by an [`ActionCatalog`]. `class` is the canonical
+/// plugin-scoped handle; `hash` is the on-chain `Is{class}` predicate hash
+/// that distinguishes classes which share a bare name but live in
+/// different plugins.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CatalogClass {
-    pub id: String,
-    pub display_name: String,
-    pub plugin_name: String,
+    pub class: QualifiedName,
     pub emoji: String,
     pub hash: String,
     pub description: String,
-    pub produced_by: Vec<String>,
-    pub consumed_by: Vec<String>,
+    pub produced_by: Vec<QualifiedName>,
+    pub consumed_by: Vec<QualifiedName>,
     pub predicate_source: String,
 }
 
 pub trait ActionCatalog: Send + Sync {
     fn list_actions(&self) -> Vec<ActionSummary>;
-    fn get_action(&self, action_id: &str) -> Option<ActionSummary>;
+    fn get_action(&self, action: &QualifiedName) -> Option<ActionSummary>;
     fn list_classes(&self) -> Vec<CatalogClass>;
-    fn get_class(&self, class_id: &str) -> Option<CatalogClass>;
+    fn get_class(&self, class: &QualifiedName) -> Option<CatalogClass>;
     fn get_class_by_hash(&self, class_hash: &Hash) -> Option<CatalogClass>;
     fn execute_action(
         &self,
-        action_id: String,
+        action: QualifiedName,
         grounding_witness: GroundingWitness,
         inputs: Vec<SpendableObject>,
     ) -> Result<SpendableObjects>;

--- a/driver/src/catalog.rs
+++ b/driver/src/catalog.rs
@@ -1,12 +1,22 @@
 use anyhow::Result;
+use pod2::middleware::Hash;
 use sdk::{SpendableObject, SpendableObjects};
 use txlib::GroundingWitness;
 
 use crate::types::ActionSummary;
 
+/// A class entry surfaced by an [`ActionCatalog`].
+///
+/// The `id` is the qualified `<plugin>:<class>` form used everywhere as the
+/// canonical handle. `display_name` is the bare class name; `plugin_name` is
+/// available for collision-aware UI labels. `hash` is the on-chain
+/// `Is{class}` predicate hash — it disambiguates classes that share a
+/// display name but live in different plugins.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CatalogClass {
-    pub name: String,
+    pub id: String,
+    pub display_name: String,
+    pub plugin_name: String,
     pub emoji: String,
     pub hash: String,
     pub description: String,
@@ -19,7 +29,14 @@ pub trait ActionCatalog: Send + Sync {
     fn list_actions(&self) -> Vec<ActionSummary>;
     fn get_action(&self, action_id: &str) -> Option<ActionSummary>;
     fn list_classes(&self) -> Vec<CatalogClass>;
-    fn get_class(&self, class_name: &str) -> Option<CatalogClass>;
+    fn get_class(&self, class_id: &str) -> Option<CatalogClass>;
+    fn get_class_by_hash(&self, class_hash: &Hash) -> Option<CatalogClass>;
+    /// Bare names that appear in more than one loaded plugin. Callers that
+    /// render a class label can use this to decide when to disambiguate
+    /// (e.g. by appending the plugin name).
+    fn name_collisions(&self) -> Vec<String> {
+        Vec::new()
+    }
     fn execute_action(
         &self,
         action_id: String,

--- a/driver/src/clients/synchronizer_client.rs
+++ b/driver/src/clients/synchronizer_client.rs
@@ -4,7 +4,6 @@ use std::{
 };
 
 use anyhow::{Result, anyhow};
-use hex::FromHex;
 use pod2::middleware::Hash;
 use serde::de::DeserializeOwned;
 use synchronizer::api_types::{
@@ -13,7 +12,7 @@ use synchronizer::api_types::{
 };
 use txlib::{GroundingWitness, StateRoot};
 
-use common::encode_hash_hex;
+use common::{decode_hash_hex, encode_hash_hex};
 
 pub const SYNCHRONIZER_POLL_TIMEOUT_SECS: u64 = 120;
 pub const SYNCHRONIZER_POLL_INTERVAL_MS: u64 = 1200;
@@ -183,8 +182,7 @@ impl SynchronizerClient for HttpSynchronizerClient {
 }
 
 fn parse_hash_hex(value: &str) -> Result<Hash> {
-    let trimmed = value.trim().strip_prefix("0x").unwrap_or(value.trim());
-    Hash::from_hex(trimmed).map_err(|err| anyhow!("invalid hash {value}: {err}"))
+    decode_hash_hex(value.trim())
 }
 
 fn send_json_request<T: DeserializeOwned>(
@@ -300,7 +298,7 @@ mod tests {
     use super::*;
 
     fn test_hash(byte: u8) -> Hash {
-        Hash::from_hex(hex::encode([byte; 32])).expect("valid test hash")
+        decode_hash_hex(&hex::encode([byte; 32])).expect("valid test hash")
     }
 
     #[test]

--- a/driver/src/driver.rs
+++ b/driver/src/driver.rs
@@ -25,6 +25,7 @@ use crate::object_store::{
     write_object_file,
 };
 use crate::pexe_catalog::PexeCatalog;
+use crate::qualified_name::QualifiedName;
 use crate::settings::{default_settings, read_settings, write_settings};
 use crate::types::{
     ActionQuery, ActionSummary, CheckActionCandidate, CheckActionReport, ClassSummary, DriverPaths,
@@ -204,13 +205,15 @@ impl Driver {
             .into_iter()
             .filter(|action| {
                 query.is_none_or(|query| {
-                    query.id.as_ref().is_none_or(|id| &action.id == id)
-                        && query.input_class_id.as_ref().is_none_or(|class_id| {
-                            action.total_inputs.iter().any(|r| &r.id == class_id)
-                        })
-                        && query.output_class_id.as_ref().is_none_or(|class_id| {
-                            action.total_outputs.iter().any(|r| &r.id == class_id)
-                        })
+                    query.action.as_ref().is_none_or(|q| &action.action == q)
+                        && query
+                            .input_class
+                            .as_ref()
+                            .is_none_or(|c| action.total_inputs.iter().any(|r| r.class == *c))
+                        && query
+                            .output_class
+                            .as_ref()
+                            .is_none_or(|c| action.total_outputs.iter().any(|r| r.class == *c))
                 })
             })
             .collect())
@@ -229,23 +232,23 @@ impl Driver {
             .map(|class_info| ClassSummary {
                 live_count: live_objects
                     .iter()
-                    .filter(|entry| entry.record.class_id == class_info.id)
+                    .filter(|entry| entry.record.class == class_info.class)
                     .count(),
                 ..self.class_summary(class_info)
             })
             .collect())
     }
 
-    pub fn get_class(&self, class_id: &str) -> Result<ClassSummary> {
+    pub fn get_class(&self, class: &QualifiedName) -> Result<ClassSummary> {
         let class_info = self
             .deps
             .catalog
-            .get_class(class_id)
-            .ok_or_else(|| anyhow!("unknown class: {class_id}"))?;
+            .get_class(class)
+            .ok_or_else(|| anyhow!("unknown class: {class}"))?;
         let live_count = load_object_files(&self.paths)?
             .into_iter()
             .filter(|entry| {
-                entry.record.status == ObjectStatus::Live && entry.record.class_id == class_id
+                entry.record.status == ObjectStatus::Live && entry.record.class == *class
             })
             .count();
         Ok(ClassSummary {
@@ -254,12 +257,12 @@ impl Driver {
         })
     }
 
-    pub fn check_action(&self, action_id: &str) -> Result<CheckActionReport> {
-        let action = self
+    pub fn check_action(&self, action: &QualifiedName) -> Result<CheckActionReport> {
+        let action_summary = self
             .deps
             .catalog
-            .get_action(action_id)
-            .ok_or_else(|| anyhow!("unknown action: {action_id}"))?;
+            .get_action(action)
+            .ok_or_else(|| anyhow!("unknown action: {action}"))?;
         let entries = load_object_files(&self.paths)?;
         let live_objects = entries
             .iter()
@@ -271,15 +274,15 @@ impl Driver {
         let mut used_ids = HashSet::new();
 
         // Apply the same cryptographic check that `resolve_inputs` runs at
-        // execute time: a candidate must match by qualified class id AND its
+        // execute time: a candidate must match by qualified class AND its
         // on-chain `obj["type"]` predicate hash must equal the action's
         // required class hash. Without the hash check, a tampered or
         // stale-migration .dobj would be reported as feasible here and then
         // rejected at execute, wasting proof-generation time.
-        for required in &action.total_inputs {
+        for required in &action_summary.total_inputs {
             let expected_hash = decode_hash_hex(required.hash.as_str()).ok();
             let candidate = live_objects.iter().find(|entry| {
-                entry.record.class_id == required.id
+                entry.record.class == required.class
                     && !used_ids.contains(&entry.record.id)
                     && matches!(
                         (expected_hash, obj_type_hash(&entry.record.obj)),
@@ -288,13 +291,8 @@ impl Driver {
             });
             if let Some(entry) = candidate {
                 used_ids.insert(entry.record.id.clone());
-                // Cross-plugin class refs are rejected at catalog load, so
-                // the action's plugin owns its input classes. No catalog
-                // round-trip needed.
                 available.push(CheckActionCandidate {
-                    class_id: required.id.clone(),
-                    class_display_name: required.display_name.clone(),
-                    plugin_name: action.plugin_name.clone(),
+                    class: required.class.clone(),
                     object_id: entry.record.id.clone(),
                     file_name: entry.file_name.clone(),
                 });
@@ -305,7 +303,7 @@ impl Driver {
 
         Ok(CheckActionReport {
             feasible: missing_inputs.is_empty(),
-            action_id: action_id.to_string(),
+            action: action.clone(),
             available_inputs: available,
             missing_inputs,
         })
@@ -333,8 +331,8 @@ impl Driver {
         let action = self
             .deps
             .catalog
-            .get_action(&input.action_id)
-            .ok_or_else(|| anyhow!("unknown action: {}", input.action_id))?;
+            .get_action(&input.action)
+            .ok_or_else(|| anyhow!("unknown action: {}", input.action))?;
 
         validate_execute_request(&input, &action)?;
 
@@ -359,7 +357,7 @@ impl Driver {
             .map(|input| input.record.spendable())
             .collect::<Vec<_>>();
         let spendable_outputs = self.deps.catalog.execute_action(
-            input.action_id.clone(),
+            input.action.clone(),
             grounding_witness,
             execution_inputs,
         )?;
@@ -376,13 +374,7 @@ impl Driver {
         let expected_tx_final = spendable_outputs.tx.dict().commitment();
 
         reporter.on_step(ExecutionPhase::Commit, "Creating files", &commit_ctx);
-        let saved = save_results(
-            &self.paths,
-            &action,
-            &input.action_id,
-            &resolved_inputs,
-            &spendable_outputs,
-        )?;
+        let saved = save_results(&self.paths, &action, &resolved_inputs, &spendable_outputs)?;
 
         // Submit to relayer. Output files are kept as Unknown on failure so
         // the user can retry submission later without regenerating proofs.
@@ -394,7 +386,7 @@ impl Driver {
         let submit_response = match self.deps.relayer.submit_proof(
             &settings.relayer_api_url,
             &payload_bytes,
-            Some(format!("driver:{}", input.action_id)),
+            Some(format!("driver:{}", input.action)),
         ) {
             Ok(resp) if resp.status == relayer::api_types::JobStatus::Failed => {
                 return Err(anyhow!("relayer rejected job {} immediately", resp.job_id));
@@ -500,17 +492,16 @@ impl Driver {
     }
 
     fn object_summary(&self, entry: &ObjectFileEntry, grounded: Option<bool>) -> ObjectSummary {
-        let class_info = self.deps.catalog.get_class(&entry.record.class_id);
-        let (class_hash, display_name, plugin_name) = match class_info {
-            Some(c) => (c.hash, c.display_name, c.plugin_name),
-            None => (String::new(), entry.record.class_id.clone(), String::new()),
-        };
+        let class_hash = self
+            .deps
+            .catalog
+            .get_class(&entry.record.class)
+            .map(|c| c.hash)
+            .unwrap_or_default();
         ObjectSummary {
             id: entry.record.id.clone(),
             file_name: entry.file_name.clone(),
-            class_id: entry.record.class_id.clone(),
-            class_display_name: display_name,
-            plugin_name,
+            class: entry.record.class.clone(),
             class_hash,
             status: entry.record.status,
             tx_hash: entry.record.tx_hash.clone(),
@@ -521,9 +512,7 @@ impl Driver {
 
     fn class_summary(&self, class_info: CatalogClass) -> ClassSummary {
         ClassSummary {
-            id: class_info.id,
-            display_name: class_info.display_name,
-            plugin_name: class_info.plugin_name,
+            class: class_info.class,
             emoji: class_info.emoji,
             hash: class_info.hash,
             description: class_info.description,

--- a/driver/src/driver.rs
+++ b/driver/src/driver.rs
@@ -15,8 +15,8 @@ use crate::clients::{
     SynchronizerClient,
 };
 use crate::execute::{
-    build_relayer_payload, reconcile_objects, resolve_inputs, save_results, update_output_files,
-    validate_execute_request,
+    build_relayer_payload, obj_type_hash, parse_class_hash_hex, reconcile_objects, resolve_inputs,
+    save_results, update_output_files, validate_execute_request,
 };
 use crate::object_record::ObjectStatus;
 use crate::object_record::parse_object_record_file;
@@ -273,28 +273,39 @@ impl Driver {
         let mut missing_class_names = Vec::new();
         let mut used_ids = HashSet::new();
 
+        // Apply the same cryptographic check that `resolve_inputs` runs at
+        // execute time: a candidate must match by qualified class id AND its
+        // on-chain `obj["type"]` predicate hash must equal the action's
+        // required class hash. Without the hash check, a tampered or
+        // stale-migration .dobj would be reported as feasible here and then
+        // rejected at execute, wasting proof-generation time.
         for (slot, required_class_id) in action.total_input_class_ids.iter().enumerate() {
-            if let Some(entry) = live_objects.iter().find(|entry| {
-                &entry.record.class_id == required_class_id && !used_ids.contains(&entry.record.id)
-            }) {
+            let required_class_name = action.total_input_class_names[slot].as_str();
+            let expected_hash =
+                parse_class_hash_hex(action.total_input_class_hashes[slot].as_str());
+            let candidate = live_objects.iter().find(|entry| {
+                &entry.record.class_id == required_class_id
+                    && !used_ids.contains(&entry.record.id)
+                    && matches!(
+                        (expected_hash, obj_type_hash(&entry.record.obj)),
+                        (Some(expected), Some(actual)) if expected == actual
+                    )
+            });
+            if let Some(entry) = candidate {
                 used_ids.insert(entry.record.id.clone());
-                let candidate_class = self.deps.catalog.get_class(&entry.record.class_id);
+                // Cross-plugin class refs are rejected at catalog load, so
+                // the action's plugin owns its input classes. No catalog
+                // round-trip needed.
                 available.push(CheckActionCandidate {
-                    class_id: entry.record.class_id.clone(),
-                    class_display_name: candidate_class
-                        .as_ref()
-                        .map(|c| c.display_name.clone())
-                        .unwrap_or_else(|| entry.record.class_id.clone()),
-                    plugin_name: candidate_class
-                        .as_ref()
-                        .map(|c| c.plugin_name.clone())
-                        .unwrap_or_default(),
+                    class_id: required_class_id.clone(),
+                    class_display_name: required_class_name.to_string(),
+                    plugin_name: action.plugin_name.clone(),
                     object_id: entry.record.id.clone(),
                     file_name: entry.file_name.clone(),
                 });
             } else {
                 missing_class_ids.push(required_class_id.clone());
-                missing_class_names.push(action.total_input_class_names[slot].clone());
+                missing_class_names.push(required_class_name.to_string());
             }
         }
 

--- a/driver/src/driver.rs
+++ b/driver/src/driver.rs
@@ -204,12 +204,13 @@ impl Driver {
             .into_iter()
             .filter(|action| {
                 query.is_none_or(|query| {
-                    query.name.as_ref().is_none_or(|name| &action.id == name)
-                        && query.input_class.as_ref().is_none_or(|class_name| {
-                            action.total_input_classes.contains(class_name)
-                        })
-                        && query.output_class.as_ref().is_none_or(|class_name| {
-                            action.total_output_classes.contains(class_name)
+                    query.id.as_ref().is_none_or(|id| &action.id == id)
+                        && query
+                            .input_class_id
+                            .as_ref()
+                            .is_none_or(|class_id| action.total_input_class_ids.contains(class_id))
+                        && query.output_class_id.as_ref().is_none_or(|class_id| {
+                            action.total_output_class_ids.contains(class_id)
                         })
                 })
             })
@@ -229,23 +230,23 @@ impl Driver {
             .map(|class_info| ClassSummary {
                 live_count: live_objects
                     .iter()
-                    .filter(|entry| entry.record.class_name == class_info.name)
+                    .filter(|entry| entry.record.class_id == class_info.id)
                     .count(),
                 ..self.class_summary(class_info)
             })
             .collect())
     }
 
-    pub fn get_class(&self, class_name: &str) -> Result<ClassSummary> {
+    pub fn get_class(&self, class_id: &str) -> Result<ClassSummary> {
         let class_info = self
             .deps
             .catalog
-            .get_class(class_name)
-            .ok_or_else(|| anyhow!("unknown class: {class_name}"))?;
+            .get_class(class_id)
+            .ok_or_else(|| anyhow!("unknown class: {class_id}"))?;
         let live_count = load_object_files(&self.paths)?
             .into_iter()
             .filter(|entry| {
-                entry.record.status == ObjectStatus::Live && entry.record.class_name == class_name
+                entry.record.status == ObjectStatus::Live && entry.record.class_id == class_id
             })
             .count();
         Ok(ClassSummary {
@@ -267,29 +268,41 @@ impl Driver {
             .collect::<Vec<_>>();
 
         let mut available = Vec::new();
-        let mut missing = Vec::new();
+        let mut missing_class_ids = Vec::new();
+        let mut missing_class_names = Vec::new();
         let mut used_ids = HashSet::new();
 
-        for required_class in &action.total_input_classes {
+        for (slot, required_class_id) in action.total_input_class_ids.iter().enumerate() {
             if let Some(entry) = live_objects.iter().find(|entry| {
-                &entry.record.class_name == required_class && !used_ids.contains(&entry.record.id)
+                &entry.record.class_id == required_class_id && !used_ids.contains(&entry.record.id)
             }) {
                 used_ids.insert(entry.record.id.clone());
+                let candidate_class = self.deps.catalog.get_class(&entry.record.class_id);
                 available.push(CheckActionCandidate {
-                    class_name: entry.record.class_name.clone(),
+                    class_id: entry.record.class_id.clone(),
+                    class_display_name: candidate_class
+                        .as_ref()
+                        .map(|c| c.display_name.clone())
+                        .unwrap_or_else(|| entry.record.class_id.clone()),
+                    plugin_name: candidate_class
+                        .as_ref()
+                        .map(|c| c.plugin_name.clone())
+                        .unwrap_or_default(),
                     object_id: entry.record.id.clone(),
                     file_name: entry.file_name.clone(),
                 });
             } else {
-                missing.push(required_class.clone());
+                missing_class_ids.push(required_class_id.clone());
+                missing_class_names.push(action.total_input_class_names[slot].clone());
             }
         }
 
         Ok(CheckActionReport {
-            feasible: missing.is_empty(),
+            feasible: missing_class_ids.is_empty(),
             action_id: action_id.to_string(),
             available_inputs: available,
-            missing_inputs: missing,
+            missing_input_class_ids: missing_class_ids,
+            missing_input_class_names: missing_class_names,
         })
     }
 
@@ -481,17 +494,28 @@ impl Driver {
         self.deps.catalog.generated_podlang()
     }
 
+    /// Bare class/action names that appear in more than one loaded plugin.
+    /// UI callers can use this to decide when a label needs disambiguation.
+    pub fn name_collisions(&self) -> Vec<String> {
+        self.deps.catalog.name_collisions()
+    }
+
     fn object_summary(&self, entry: &ObjectFileEntry, grounded: Option<bool>) -> ObjectSummary {
-        let class_hash = self
-            .deps
-            .catalog
-            .get_class(&entry.record.class_name)
-            .map(|class_info| class_info.hash)
-            .unwrap_or_default();
+        let class_info = self.deps.catalog.get_class(&entry.record.class_id);
+        let (class_hash, display_name, plugin_name) = match class_info {
+            Some(c) => (c.hash, c.display_name, c.plugin_name),
+            None => (
+                String::new(),
+                entry.record.class_id.clone(),
+                String::new(),
+            ),
+        };
         ObjectSummary {
             id: entry.record.id.clone(),
             file_name: entry.file_name.clone(),
-            class_name: entry.record.class_name.clone(),
+            class_id: entry.record.class_id.clone(),
+            class_display_name: display_name,
+            plugin_name,
             class_hash,
             status: entry.record.status,
             tx_hash: entry.record.tx_hash.clone(),
@@ -502,7 +526,9 @@ impl Driver {
 
     fn class_summary(&self, class_info: CatalogClass) -> ClassSummary {
         ClassSummary {
-            name: class_info.name,
+            id: class_info.id,
+            display_name: class_info.display_name,
+            plugin_name: class_info.plugin_name,
             emoji: class_info.emoji,
             hash: class_info.hash,
             description: class_info.description,

--- a/driver/src/driver.rs
+++ b/driver/src/driver.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use std::sync::Arc;
 
 use anyhow::{Result, anyhow};
-use common::encode_hash_hex;
+use common::{decode_hash_hex, encode_hash_hex};
 use pod2::middleware::Hash;
 use sdk::SpendableObjects;
 use txlib::object_nullifier_hash;
@@ -15,8 +15,8 @@ use crate::clients::{
     SynchronizerClient,
 };
 use crate::execute::{
-    build_relayer_payload, obj_type_hash, parse_class_hash_hex, reconcile_objects, resolve_inputs,
-    save_results, update_output_files, validate_execute_request,
+    build_relayer_payload, obj_type_hash, reconcile_objects, resolve_inputs, save_results,
+    update_output_files, validate_execute_request,
 };
 use crate::object_record::ObjectStatus;
 use crate::object_record::parse_object_record_file;
@@ -277,7 +277,7 @@ impl Driver {
         // stale-migration .dobj would be reported as feasible here and then
         // rejected at execute, wasting proof-generation time.
         for required in &action.total_inputs {
-            let expected_hash = parse_class_hash_hex(required.hash.as_str());
+            let expected_hash = decode_hash_hex(required.hash.as_str()).ok();
             let candidate = live_objects.iter().find(|entry| {
                 entry.record.class_id == required.id
                     && !used_ids.contains(&entry.record.id)

--- a/driver/src/driver.rs
+++ b/driver/src/driver.rs
@@ -209,9 +209,10 @@ impl Driver {
                             .input_class_id
                             .as_ref()
                             .is_none_or(|class_id| action.total_input_class_ids.contains(class_id))
-                        && query.output_class_id.as_ref().is_none_or(|class_id| {
-                            action.total_output_class_ids.contains(class_id)
-                        })
+                        && query
+                            .output_class_id
+                            .as_ref()
+                            .is_none_or(|class_id| action.total_output_class_ids.contains(class_id))
                 })
             })
             .collect())
@@ -504,11 +505,7 @@ impl Driver {
         let class_info = self.deps.catalog.get_class(&entry.record.class_id);
         let (class_hash, display_name, plugin_name) = match class_info {
             Some(c) => (c.hash, c.display_name, c.plugin_name),
-            None => (
-                String::new(),
-                entry.record.class_id.clone(),
-                String::new(),
-            ),
+            None => (String::new(), entry.record.class_id.clone(), String::new()),
         };
         ObjectSummary {
             id: entry.record.id.clone(),

--- a/driver/src/driver.rs
+++ b/driver/src/driver.rs
@@ -495,12 +495,6 @@ impl Driver {
         self.deps.catalog.generated_podlang()
     }
 
-    /// Bare class/action names that appear in more than one loaded plugin.
-    /// UI callers can use this to decide when a label needs disambiguation.
-    pub fn name_collisions(&self) -> Vec<String> {
-        self.deps.catalog.name_collisions()
-    }
-
     fn object_summary(&self, entry: &ObjectFileEntry, grounded: Option<bool>) -> ObjectSummary {
         let class_info = self.deps.catalog.get_class(&entry.record.class_id);
         let (class_hash, display_name, plugin_name) = match class_info {

--- a/driver/src/driver.rs
+++ b/driver/src/driver.rs
@@ -205,14 +205,12 @@ impl Driver {
             .filter(|action| {
                 query.is_none_or(|query| {
                     query.id.as_ref().is_none_or(|id| &action.id == id)
-                        && query
-                            .input_class_id
-                            .as_ref()
-                            .is_none_or(|class_id| action.total_input_class_ids.contains(class_id))
-                        && query
-                            .output_class_id
-                            .as_ref()
-                            .is_none_or(|class_id| action.total_output_class_ids.contains(class_id))
+                        && query.input_class_id.as_ref().is_none_or(|class_id| {
+                            action.total_inputs.iter().any(|r| &r.id == class_id)
+                        })
+                        && query.output_class_id.as_ref().is_none_or(|class_id| {
+                            action.total_outputs.iter().any(|r| &r.id == class_id)
+                        })
                 })
             })
             .collect())
@@ -269,8 +267,7 @@ impl Driver {
             .collect::<Vec<_>>();
 
         let mut available = Vec::new();
-        let mut missing_class_ids = Vec::new();
-        let mut missing_class_names = Vec::new();
+        let mut missing_inputs = Vec::new();
         let mut used_ids = HashSet::new();
 
         // Apply the same cryptographic check that `resolve_inputs` runs at
@@ -279,12 +276,10 @@ impl Driver {
         // required class hash. Without the hash check, a tampered or
         // stale-migration .dobj would be reported as feasible here and then
         // rejected at execute, wasting proof-generation time.
-        for (slot, required_class_id) in action.total_input_class_ids.iter().enumerate() {
-            let required_class_name = action.total_input_class_names[slot].as_str();
-            let expected_hash =
-                parse_class_hash_hex(action.total_input_class_hashes[slot].as_str());
+        for required in &action.total_inputs {
+            let expected_hash = parse_class_hash_hex(required.hash.as_str());
             let candidate = live_objects.iter().find(|entry| {
-                &entry.record.class_id == required_class_id
+                entry.record.class_id == required.id
                     && !used_ids.contains(&entry.record.id)
                     && matches!(
                         (expected_hash, obj_type_hash(&entry.record.obj)),
@@ -297,24 +292,22 @@ impl Driver {
                 // the action's plugin owns its input classes. No catalog
                 // round-trip needed.
                 available.push(CheckActionCandidate {
-                    class_id: required_class_id.clone(),
-                    class_display_name: required_class_name.to_string(),
+                    class_id: required.id.clone(),
+                    class_display_name: required.display_name.clone(),
                     plugin_name: action.plugin_name.clone(),
                     object_id: entry.record.id.clone(),
                     file_name: entry.file_name.clone(),
                 });
             } else {
-                missing_class_ids.push(required_class_id.clone());
-                missing_class_names.push(required_class_name.to_string());
+                missing_inputs.push(required.clone());
             }
         }
 
         Ok(CheckActionReport {
-            feasible: missing_class_ids.is_empty(),
+            feasible: missing_inputs.is_empty(),
             action_id: action_id.to_string(),
             available_inputs: available,
-            missing_input_class_ids: missing_class_ids,
-            missing_input_class_names: missing_class_names,
+            missing_inputs,
         })
     }
 

--- a/driver/src/execute.rs
+++ b/driver/src/execute.rs
@@ -112,7 +112,7 @@ pub(crate) fn validate_execute_request(
     if input.input_objects.len() != action.total_inputs.len() {
         return Err(anyhow!(
             "{} expects {} inputs, got {}",
-            input.action_id,
+            input.action,
             action.total_inputs.len(),
             input.input_objects.len()
         ));
@@ -157,16 +157,16 @@ pub(crate) fn resolve_inputs(
                 entry.record.id
             ));
         }
-        // Belt-and-suspenders: compare both the qualified class id stored on
+        // Belt-and-suspenders: compare both the qualified class stored on
         // disk AND the on-chain `obj["type"]` predicate hash. Mismatch on
-        // either is fatal — the second check catches files whose class_id
+        // either is fatal — the second check catches files whose class
         // text drifted from the actual pod-level identity.
-        if entry.record.class_id != required.id {
+        if entry.record.class != required.class {
             return Err(anyhow!(
                 "input class mismatch for {}: expected {}, got {}",
                 entry.record.id,
-                required.id,
-                entry.record.class_id
+                required.class,
+                entry.record.class
             ));
         }
         let actual_class_hash = obj_type_hash(&entry.record.obj).ok_or_else(|| {
@@ -196,27 +196,6 @@ pub(crate) fn obj_type_hash(obj: &pod2::middleware::containers::Dictionary) -> O
     Some(Hash(value.raw().0))
 }
 
-/// Build the lowercase filename prefix for a `.dobj` of the given qualified
-/// class id (`<plugin>::<class>`). Plugin names are already restricted to
-/// `[A-Za-z0-9_-]` at catalog load, but class names come from arbitrary
-/// rhai string literals (e.g. `action.output("…")`) so they could in
-/// principle contain path-significant characters. To keep written files
-/// inside `~/.dobj/objects/`, every char outside the allowlist
-/// `[a-z0-9_-]` (after lowercasing) is replaced with `_`.
-pub(crate) fn file_prefix_for_class(class_id: &str) -> String {
-    class_id
-        .chars()
-        .map(|c| {
-            let lower = c.to_ascii_lowercase();
-            if lower.is_ascii_alphanumeric() || lower == '-' || lower == '_' {
-                lower
-            } else {
-                '_'
-            }
-        })
-        .collect()
-}
-
 #[derive(Debug)]
 pub(crate) struct SavedFiles {
     pub(crate) output_files: Vec<String>,
@@ -226,7 +205,6 @@ pub(crate) struct SavedFiles {
 pub(crate) fn save_results(
     paths: &DriverPaths,
     action: &ActionSummary,
-    action_id: &str,
     resolved_inputs: &[ResolvedInput],
     spendable_outputs: &SpendableObjects,
 ) -> Result<SavedFiles> {
@@ -238,7 +216,7 @@ pub(crate) fn save_results(
     if spendable_outputs.objs.len() != action.total_outputs.len() {
         return Err(anyhow!(
             "action {} output mismatch: descriptor expects {}, engine returned {}",
-            action_id,
+            action.action,
             action.total_outputs.len(),
             spendable_outputs.objs.len()
         ));
@@ -246,19 +224,18 @@ pub(crate) fn save_results(
 
     let mut output_files = Vec::new();
     for (index, output) in action.total_outputs.iter().enumerate() {
-        let class_id = &output.id;
         let spendable = spendable_outputs.obj(index);
         let object_id = format!("{:#}", spendable.obj.commitment());
         let file_name = format!(
             "{}_{}.{DOBJ_EXTENSION}",
-            file_prefix_for_class(class_id),
+            output.class.file_prefix(),
             object_id.to_ascii_lowercase()
         );
         output_files.push(file_name.clone());
 
         let live_record = StoredObjectRecord {
             id: object_id,
-            class_id: class_id.clone(),
+            class: output.class.clone(),
             status: ObjectStatus::Unknown,
             tx_hash: None,
             pod: spendable.pod,

--- a/driver/src/execute.rs
+++ b/driver/src/execute.rs
@@ -5,7 +5,8 @@ use common::{
     payload::{Payload, PayloadProof},
     shrink::{ShrunkMainPodSetup, shrink_compress_pod},
 };
-use pod2::middleware::{Hash, Params};
+use hex::FromHex;
+use pod2::middleware::{Hash, Key, Params};
 use sdk::SpendableObjects;
 use txlib::object_nullifier_hash;
 
@@ -108,11 +109,11 @@ pub(crate) fn validate_execute_request(
     input: &ExecuteActionInput,
     action: &ActionSummary,
 ) -> Result<()> {
-    if input.input_objects.len() != action.total_input_classes.len() {
+    if input.input_objects.len() != action.total_input_class_ids.len() {
         return Err(anyhow!(
             "{} expects {} inputs, got {}",
             input.action_id,
-            action.total_input_classes.len(),
+            action.total_input_class_ids.len(),
             input.input_objects.len()
         ));
     }
@@ -146,7 +147,11 @@ pub(crate) fn resolve_inputs(
 ) -> Result<Vec<ResolvedInput>> {
     let mut resolved_inputs = Vec::new();
     for (slot, selector) in input.input_objects.iter().enumerate() {
-        let expected_class = action.total_input_classes[slot].as_str();
+        let expected_class_id = action.total_input_class_ids[slot].as_str();
+        let expected_class_hash_hex = action.total_input_class_hashes[slot].as_str();
+        let expected_class_hash = parse_class_hash_hex(expected_class_hash_hex)
+            .ok_or_else(|| anyhow!("invalid expected class hash {expected_class_hash_hex:?}"))?;
+
         let entry = select_object(entries, selector)?;
         if entry.record.status != ObjectStatus::Live {
             return Err(anyhow!(
@@ -155,12 +160,28 @@ pub(crate) fn resolve_inputs(
                 entry.record.id
             ));
         }
-        if entry.record.class_name != expected_class {
+        // Belt-and-suspenders: compare both the qualified class id stored on
+        // disk AND the on-chain `obj["type"]` predicate hash. Mismatch on
+        // either is fatal — the second check catches files whose class_id
+        // text drifted from the actual pod-level identity.
+        if entry.record.class_id != expected_class_id {
             return Err(anyhow!(
-                "input class mismatch for {}: expected {}, got {}",
+                "input class mismatch for {}: expected {expected_class_id}, got {}",
                 entry.record.id,
-                expected_class,
-                entry.record.class_name
+                entry.record.class_id
+            ));
+        }
+        let actual_class_hash = obj_type_hash(&entry.record.obj).ok_or_else(|| {
+            anyhow!(
+                "input object {} has no readable 'type' field",
+                entry.record.id
+            )
+        })?;
+        if actual_class_hash != expected_class_hash {
+            return Err(anyhow!(
+                "input class hash mismatch for {}: pod 'type' = {:#}, action expects {expected_class_hash_hex}",
+                entry.record.id,
+                actual_class_hash,
             ));
         }
         resolved_inputs.push(ResolvedInput {
@@ -169,6 +190,23 @@ pub(crate) fn resolve_inputs(
         });
     }
     Ok(resolved_inputs)
+}
+
+fn parse_class_hash_hex(s: &str) -> Option<Hash> {
+    let trimmed = s.strip_prefix("0x").unwrap_or(s);
+    Hash::from_hex(trimmed).ok()
+}
+
+fn obj_type_hash(obj: &pod2::middleware::containers::Dictionary) -> Option<Hash> {
+    let value = obj.get(&Key::from("type")).ok()??;
+    Some(Hash(value.raw().0))
+}
+
+/// Build the lowercase filename prefix for a `.dobj` of the given qualified
+/// class id (`<plugin>:<class>`). The colon is replaced with `_` so the
+/// result is filename-safe on every OS we target.
+pub(crate) fn file_prefix_for_class(class_id: &str) -> String {
+    class_id.to_ascii_lowercase().replace(':', "_")
 }
 
 #[derive(Debug)]
@@ -189,29 +227,29 @@ pub(crate) fn save_results(
         .map(|input| input.file_name.clone())
         .collect();
 
-    if spendable_outputs.objs.len() != action.total_output_classes.len() {
+    if spendable_outputs.objs.len() != action.total_output_class_ids.len() {
         return Err(anyhow!(
             "action {} output mismatch: descriptor expects {}, engine returned {}",
             action_id,
-            action.total_output_classes.len(),
+            action.total_output_class_ids.len(),
             spendable_outputs.objs.len()
         ));
     }
 
     let mut output_files = Vec::new();
-    for (index, class_name) in action.total_output_classes.iter().enumerate() {
+    for (index, class_id) in action.total_output_class_ids.iter().enumerate() {
         let spendable = spendable_outputs.obj(index);
         let object_id = format!("{:#}", spendable.obj.commitment());
         let file_name = format!(
             "{}_{}.{DOBJ_EXTENSION}",
-            class_name.to_ascii_lowercase(),
+            file_prefix_for_class(class_id),
             object_id.to_ascii_lowercase()
         );
         output_files.push(file_name.clone());
 
         let live_record = StoredObjectRecord {
             id: object_id,
-            class_name: class_name.clone(),
+            class_id: class_id.clone(),
             status: ObjectStatus::Unknown,
             tx_hash: None,
             pod: spendable.pod,

--- a/driver/src/execute.rs
+++ b/driver/src/execute.rs
@@ -2,10 +2,10 @@ use std::collections::HashSet;
 
 use anyhow::{Result, anyhow};
 use common::{
+    decode_hash_hex,
     payload::{Payload, PayloadProof},
     shrink::{ShrunkMainPodSetup, shrink_compress_pod},
 };
-use hex::FromHex;
 use pod2::middleware::{Hash, Key, Params};
 use sdk::SpendableObjects;
 use txlib::object_nullifier_hash;
@@ -147,8 +147,7 @@ pub(crate) fn resolve_inputs(
 ) -> Result<Vec<ResolvedInput>> {
     let mut resolved_inputs = Vec::new();
     for (selector, required) in input.input_objects.iter().zip(action.total_inputs.iter()) {
-        let expected_class_hash = parse_class_hash_hex(required.hash.as_str())
-            .ok_or_else(|| anyhow!("invalid expected class hash {:?}", required.hash))?;
+        let expected_class_hash = decode_hash_hex(required.hash.as_str())?;
 
         let entry = select_object(entries, selector)?;
         if entry.record.status != ObjectStatus::Live {
@@ -190,11 +189,6 @@ pub(crate) fn resolve_inputs(
         });
     }
     Ok(resolved_inputs)
-}
-
-pub(crate) fn parse_class_hash_hex(s: &str) -> Option<Hash> {
-    let trimmed = s.strip_prefix("0x").unwrap_or(s);
-    Hash::from_hex(trimmed).ok()
 }
 
 pub(crate) fn obj_type_hash(obj: &pod2::middleware::containers::Dictionary) -> Option<Hash> {

--- a/driver/src/execute.rs
+++ b/driver/src/execute.rs
@@ -109,11 +109,11 @@ pub(crate) fn validate_execute_request(
     input: &ExecuteActionInput,
     action: &ActionSummary,
 ) -> Result<()> {
-    if input.input_objects.len() != action.total_input_class_ids.len() {
+    if input.input_objects.len() != action.total_inputs.len() {
         return Err(anyhow!(
             "{} expects {} inputs, got {}",
             input.action_id,
-            action.total_input_class_ids.len(),
+            action.total_inputs.len(),
             input.input_objects.len()
         ));
     }
@@ -146,11 +146,9 @@ pub(crate) fn resolve_inputs(
     action: &ActionSummary,
 ) -> Result<Vec<ResolvedInput>> {
     let mut resolved_inputs = Vec::new();
-    for (slot, selector) in input.input_objects.iter().enumerate() {
-        let expected_class_id = action.total_input_class_ids[slot].as_str();
-        let expected_class_hash_hex = action.total_input_class_hashes[slot].as_str();
-        let expected_class_hash = parse_class_hash_hex(expected_class_hash_hex)
-            .ok_or_else(|| anyhow!("invalid expected class hash {expected_class_hash_hex:?}"))?;
+    for (selector, required) in input.input_objects.iter().zip(action.total_inputs.iter()) {
+        let expected_class_hash = parse_class_hash_hex(required.hash.as_str())
+            .ok_or_else(|| anyhow!("invalid expected class hash {:?}", required.hash))?;
 
         let entry = select_object(entries, selector)?;
         if entry.record.status != ObjectStatus::Live {
@@ -164,10 +162,11 @@ pub(crate) fn resolve_inputs(
         // disk AND the on-chain `obj["type"]` predicate hash. Mismatch on
         // either is fatal — the second check catches files whose class_id
         // text drifted from the actual pod-level identity.
-        if entry.record.class_id != expected_class_id {
+        if entry.record.class_id != required.id {
             return Err(anyhow!(
-                "input class mismatch for {}: expected {expected_class_id}, got {}",
+                "input class mismatch for {}: expected {}, got {}",
                 entry.record.id,
+                required.id,
                 entry.record.class_id
             ));
         }
@@ -179,9 +178,10 @@ pub(crate) fn resolve_inputs(
         })?;
         if actual_class_hash != expected_class_hash {
             return Err(anyhow!(
-                "input class hash mismatch for {}: pod 'type' = {:#}, action expects {expected_class_hash_hex}",
+                "input class hash mismatch for {}: pod 'type' = {:#}, action expects {}",
                 entry.record.id,
                 actual_class_hash,
+                required.hash,
             ));
         }
         resolved_inputs.push(ResolvedInput {
@@ -227,17 +227,18 @@ pub(crate) fn save_results(
         .map(|input| input.file_name.clone())
         .collect();
 
-    if spendable_outputs.objs.len() != action.total_output_class_ids.len() {
+    if spendable_outputs.objs.len() != action.total_outputs.len() {
         return Err(anyhow!(
             "action {} output mismatch: descriptor expects {}, engine returned {}",
             action_id,
-            action.total_output_class_ids.len(),
+            action.total_outputs.len(),
             spendable_outputs.objs.len()
         ));
     }
 
     let mut output_files = Vec::new();
-    for (index, class_id) in action.total_output_class_ids.iter().enumerate() {
+    for (index, output) in action.total_outputs.iter().enumerate() {
+        let class_id = &output.id;
         let spendable = spendable_outputs.obj(index);
         let object_id = format!("{:#}", spendable.obj.commitment());
         let file_name = format!(

--- a/driver/src/execute.rs
+++ b/driver/src/execute.rs
@@ -192,12 +192,12 @@ pub(crate) fn resolve_inputs(
     Ok(resolved_inputs)
 }
 
-fn parse_class_hash_hex(s: &str) -> Option<Hash> {
+pub(crate) fn parse_class_hash_hex(s: &str) -> Option<Hash> {
     let trimmed = s.strip_prefix("0x").unwrap_or(s);
     Hash::from_hex(trimmed).ok()
 }
 
-fn obj_type_hash(obj: &pod2::middleware::containers::Dictionary) -> Option<Hash> {
+pub(crate) fn obj_type_hash(obj: &pod2::middleware::containers::Dictionary) -> Option<Hash> {
     let value = obj.get(&Key::from("type")).ok()??;
     Some(Hash(value.raw().0))
 }

--- a/driver/src/execute.rs
+++ b/driver/src/execute.rs
@@ -197,7 +197,7 @@ pub(crate) fn obj_type_hash(obj: &pod2::middleware::containers::Dictionary) -> O
 }
 
 /// Build the lowercase filename prefix for a `.dobj` of the given qualified
-/// class id (`<plugin>:<class>`). Plugin names are already restricted to
+/// class id (`<plugin>::<class>`). Plugin names are already restricted to
 /// `[A-Za-z0-9_-]` at catalog load, but class names come from arbitrary
 /// rhai string literals (e.g. `action.output("…")`) so they could in
 /// principle contain path-significant characters. To keep written files

--- a/driver/src/execute.rs
+++ b/driver/src/execute.rs
@@ -203,10 +203,24 @@ pub(crate) fn obj_type_hash(obj: &pod2::middleware::containers::Dictionary) -> O
 }
 
 /// Build the lowercase filename prefix for a `.dobj` of the given qualified
-/// class id (`<plugin>:<class>`). The colon is replaced with `_` so the
-/// result is filename-safe on every OS we target.
+/// class id (`<plugin>:<class>`). Plugin names are already restricted to
+/// `[A-Za-z0-9_-]` at catalog load, but class names come from arbitrary
+/// rhai string literals (e.g. `action.output("…")`) so they could in
+/// principle contain path-significant characters. To keep written files
+/// inside `~/.dobj/objects/`, every char outside the allowlist
+/// `[a-z0-9_-]` (after lowercasing) is replaced with `_`.
 pub(crate) fn file_prefix_for_class(class_id: &str) -> String {
-    class_id.to_ascii_lowercase().replace(':', "_")
+    class_id
+        .chars()
+        .map(|c| {
+            let lower = c.to_ascii_lowercase();
+            if lower.is_ascii_alphanumeric() || lower == '-' || lower == '_' {
+                lower
+            } else {
+                '_'
+            }
+        })
+        .collect()
 }
 
 #[derive(Debug)]

--- a/driver/src/lib.rs
+++ b/driver/src/lib.rs
@@ -22,7 +22,8 @@ pub use crate::object_record::parse_object_record_file;
 pub use crate::object_record::{ObjectRecord, ObjectStatus};
 pub use crate::pexe_catalog::PexeCatalog;
 pub use crate::types::{
-    ActionQuery, ActionSummary, CheckActionCandidate, CheckActionReport, ClassSummary, DriverPaths,
-    DriverSettings, ExecuteActionInput, ExecuteActionResult, ExecutionPhase, ExecutionReporter,
-    ExecutionStepContext, NoopExecutionReporter, ObjectQuery, ObjectSelector, ObjectSummary,
+    ActionQuery, ActionSummary, CheckActionCandidate, CheckActionReport, ClassRef, ClassSummary,
+    DriverPaths, DriverSettings, ExecuteActionInput, ExecuteActionResult, ExecutionPhase,
+    ExecutionReporter, ExecutionStepContext, NoopExecutionReporter, ObjectQuery, ObjectSelector,
+    ObjectSummary,
 };

--- a/driver/src/lib.rs
+++ b/driver/src/lib.rs
@@ -6,6 +6,7 @@ mod object_record;
 mod object_store;
 pub mod paths;
 mod pexe_catalog;
+mod qualified_name;
 mod settings;
 mod types;
 
@@ -21,6 +22,7 @@ pub use crate::driver::{Driver, DriverDeps, PayloadBuilder};
 pub use crate::object_record::parse_object_record_file;
 pub use crate::object_record::{ObjectRecord, ObjectStatus};
 pub use crate::pexe_catalog::PexeCatalog;
+pub use crate::qualified_name::QualifiedName;
 pub use crate::types::{
     ActionQuery, ActionSummary, CheckActionCandidate, CheckActionReport, ClassRef, ClassSummary,
     DriverPaths, DriverSettings, ExecuteActionInput, ExecuteActionResult, ExecutionPhase,

--- a/driver/src/object_record.rs
+++ b/driver/src/object_record.rs
@@ -75,10 +75,7 @@ impl ObjectRecord {
     fn to_file_value(&self) -> Result<Value, String> {
         let mut fields = serde_json::Map::new();
         fields.insert("id".to_string(), Value::String(self.id.clone()));
-        fields.insert(
-            "classId".to_string(),
-            Value::String(self.class_id.clone()),
-        );
+        fields.insert("classId".to_string(), Value::String(self.class_id.clone()));
         fields.insert(
             "status".to_string(),
             serde_json::to_value(self.status)

--- a/driver/src/object_record.rs
+++ b/driver/src/object_record.rs
@@ -7,6 +7,8 @@ use serde_json::Value;
 use std::{fs, path::Path};
 use txlib::Tx;
 
+use crate::qualified_name::QualifiedName;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum ObjectStatus {
@@ -19,9 +21,9 @@ pub enum ObjectStatus {
 #[derive(Debug, Clone)]
 pub struct ObjectRecord {
     pub id: String,
-    /// Qualified class id (`<plugin>::<class>`). The bare display name and
-    /// human description are recovered from the catalog at read time.
-    pub class_id: String,
+    /// The class this object belongs to. Plugin-scoped so two plugins with
+    /// the same bare class name stay distinguishable.
+    pub class: QualifiedName,
     /// Lifecycle status of this object.
     pub status: ObjectStatus,
     /// Optional Ethereum transaction hash for the blob that anchored this object.
@@ -75,7 +77,11 @@ impl ObjectRecord {
     fn to_file_value(&self) -> Result<Value, String> {
         let mut fields = serde_json::Map::new();
         fields.insert("id".to_string(), Value::String(self.id.clone()));
-        fields.insert("classId".to_string(), Value::String(self.class_id.clone()));
+        fields.insert(
+            "class".to_string(),
+            serde_json::to_value(&self.class)
+                .map_err(|err| format!("failed to serialize class: {err}"))?,
+        );
         fields.insert(
             "status".to_string(),
             serde_json::to_value(self.status)
@@ -107,7 +113,7 @@ impl ObjectRecord {
             .as_object()
             .ok_or_else(|| "invalid object file: expected JSON object".to_string())?;
         let id = parse_required_field::<String>(fields, "id", "id")?;
-        let class_id = parse_required_field::<String>(fields, "classId", "classId")?;
+        let class = parse_required_field::<QualifiedName>(fields, "class", "class")?;
         let status = parse_required_field::<ObjectStatus>(fields, "status", "status")?;
         let tx_hash: Option<String> = match fields.get("txHash") {
             Some(Value::String(s)) => Some(s.clone()),
@@ -119,7 +125,7 @@ impl ObjectRecord {
 
         Ok(Self {
             id,
-            class_id,
+            class,
             status,
             tx_hash,
             pod,

--- a/driver/src/object_record.rs
+++ b/driver/src/object_record.rs
@@ -19,8 +19,9 @@ pub enum ObjectStatus {
 #[derive(Debug, Clone)]
 pub struct ObjectRecord {
     pub id: String,
-    /// Object class/type name
-    pub class_name: String,
+    /// Qualified class id (`<plugin>:<class>`). The bare display name and
+    /// human description are recovered from the catalog at read time.
+    pub class_id: String,
     /// Lifecycle status of this object.
     pub status: ObjectStatus,
     /// Optional Ethereum transaction hash for the blob that anchored this object.
@@ -75,8 +76,8 @@ impl ObjectRecord {
         let mut fields = serde_json::Map::new();
         fields.insert("id".to_string(), Value::String(self.id.clone()));
         fields.insert(
-            "className".to_string(),
-            Value::String(self.class_name.clone()),
+            "classId".to_string(),
+            Value::String(self.class_id.clone()),
         );
         fields.insert(
             "status".to_string(),
@@ -109,7 +110,7 @@ impl ObjectRecord {
             .as_object()
             .ok_or_else(|| "invalid object file: expected JSON object".to_string())?;
         let id = parse_required_field::<String>(fields, "id", "id")?;
-        let class_name = parse_required_field::<String>(fields, "className", "className")?;
+        let class_id = parse_required_field::<String>(fields, "classId", "classId")?;
         let status = parse_required_field::<ObjectStatus>(fields, "status", "status")?;
         let tx_hash: Option<String> = match fields.get("txHash") {
             Some(Value::String(s)) => Some(s.clone()),
@@ -121,7 +122,7 @@ impl ObjectRecord {
 
         Ok(Self {
             id,
-            class_name,
+            class_id,
             status,
             tx_hash,
             pod,

--- a/driver/src/object_record.rs
+++ b/driver/src/object_record.rs
@@ -19,7 +19,7 @@ pub enum ObjectStatus {
 #[derive(Debug, Clone)]
 pub struct ObjectRecord {
     pub id: String,
-    /// Qualified class id (`<plugin>:<class>`). The bare display name and
+    /// Qualified class id (`<plugin>::<class>`). The bare display name and
     /// human description are recovered from the catalog at read time.
     pub class_id: String,
     /// Lifecycle status of this object.

--- a/driver/src/object_store.rs
+++ b/driver/src/object_store.rs
@@ -171,8 +171,8 @@ pub(crate) fn select_object<'a>(
 }
 
 pub(crate) fn matches_query(entry: &ObjectFileEntry, query: &ObjectQuery) -> bool {
-    if let Some(class_id) = &query.class_id
-        && &entry.record.class_id != class_id
+    if let Some(class) = &query.class
+        && &entry.record.class != class
     {
         return false;
     }
@@ -241,7 +241,7 @@ mod tests {
         .unwrap();
         let outputs = catalog
             .execute_action(
-                "craft-basics::FindLog".to_string(),
+                crate::QualifiedName::new("craft-basics", "FindLog"),
                 dummy_grounding_witness(),
                 vec![],
             )
@@ -249,7 +249,7 @@ mod tests {
         let spendable = outputs.obj(0);
         ObjectRecord {
             id: format!("{:#}", spendable.obj.commitment()),
-            class_id: "craft-basics::Log".to_string(),
+            class: crate::QualifiedName::new("craft-basics", "Log"),
             status: ObjectStatus::Live,
             tx_hash: None,
             pod: spendable.pod,

--- a/driver/src/object_store.rs
+++ b/driver/src/object_store.rs
@@ -241,7 +241,7 @@ mod tests {
         .unwrap();
         let outputs = catalog
             .execute_action(
-                "craft-basics:FindLog".to_string(),
+                "craft-basics::FindLog".to_string(),
                 dummy_grounding_witness(),
                 vec![],
             )
@@ -249,7 +249,7 @@ mod tests {
         let spendable = outputs.obj(0);
         ObjectRecord {
             id: format!("{:#}", spendable.obj.commitment()),
-            class_id: "craft-basics:Log".to_string(),
+            class_id: "craft-basics::Log".to_string(),
             status: ObjectStatus::Live,
             tx_hash: None,
             pod: spendable.pod,

--- a/driver/src/object_store.rs
+++ b/driver/src/object_store.rs
@@ -171,8 +171,8 @@ pub(crate) fn select_object<'a>(
 }
 
 pub(crate) fn matches_query(entry: &ObjectFileEntry, query: &ObjectQuery) -> bool {
-    if let Some(class_name) = &query.class_name
-        && &entry.record.class_name != class_name
+    if let Some(class_id) = &query.class_id
+        && &entry.record.class_id != class_id
     {
         return false;
     }
@@ -240,12 +240,16 @@ mod tests {
         )
         .unwrap();
         let outputs = catalog
-            .execute_action("FindLog".to_string(), dummy_grounding_witness(), vec![])
+            .execute_action(
+                "craft-basics:FindLog".to_string(),
+                dummy_grounding_witness(),
+                vec![],
+            )
             .unwrap();
         let spendable = outputs.obj(0);
         ObjectRecord {
             id: format!("{:#}", spendable.obj.commitment()),
-            class_name: "Log".to_string(),
+            class_id: "craft-basics:Log".to_string(),
             status: ObjectStatus::Live,
             tx_hash: None,
             pod: spendable.pod,

--- a/driver/src/pexe_catalog.rs
+++ b/driver/src/pexe_catalog.rs
@@ -5,13 +5,13 @@
 //! `module_hash`). The compiled module is used to derive action/class hashes and
 //! the podlang source shown in the GUI.
 //!
-//! Classes and actions are keyed by qualified id `<plugin_name>::<name>`,
-//! using the same `::` separator podlang uses for namespaced predicates.
-//! Two plugins may declare a class or action with the same bare name; they
-//! are kept distinct by qualified id and by their on-chain `Is{class}`
-//! predicate hash (which differs between modules because each module has a
-//! unique `module_hash`). Cross-plugin class references are not supported:
-//! an action must reference classes declared in its own plugin.
+//! Classes and actions are keyed by [`QualifiedName`] (`<plugin>::<name>`
+//! when printed). Two plugins may declare a class or action with the same
+//! bare name; they stay distinct because every internal map keys on the full
+//! `QualifiedName` and because their on-chain `Is{class}` predicate hashes
+//! differ (each module has a unique `module_hash`). Cross-plugin class
+//! references are not supported: an action must reference classes declared
+//! in its own plugin.
 //!
 //! The compiled [`sdk::SdkModule`] is not kept — it holds a `Rc<Engine>` and is
 //! therefore `!Send`. `execute_action` re-loads the script from its stored bytes
@@ -28,6 +28,7 @@ use sdk::{Sdk, SpendableObject, SpendableObjects, manifest::Manifest};
 use txlib::GroundingWitness;
 
 use crate::catalog::{ActionCatalog, CatalogClass, extract_predicate};
+use crate::qualified_name::QualifiedName;
 use crate::types::{ActionSummary, ClassRef};
 
 struct Plugin {
@@ -35,28 +36,19 @@ struct Plugin {
     path: PathBuf,
     manifest: Manifest,
     script: String,
-    /// Qualified ids (`<plugin>::<action>`) provided by this plugin. Used
-    /// to route `execute_action` back to the originating script bytes.
-    action_ids: Vec<String>,
 }
 
 pub struct PexeCatalog {
     plugins: Vec<Plugin>,
     actions: Vec<ActionSummary>,
-    actions_by_id: HashMap<String, ActionSummary>,
-    /// Maps qualified action id -> plugin index in `plugins`.
-    action_plugin_idx: HashMap<String, usize>,
+    actions_by_name: HashMap<QualifiedName, ActionSummary>,
+    /// Maps qualified action -> plugin index in `plugins`.
+    action_plugin_idx: HashMap<QualifiedName, usize>,
     classes: Vec<CatalogClass>,
-    classes_by_id: HashMap<String, CatalogClass>,
-    classes_by_hash: HashMap<Hash, String>,
+    classes_by_name: HashMap<QualifiedName, CatalogClass>,
+    classes_by_hash: HashMap<Hash, QualifiedName>,
     combined_podlang_src: String,
     mock_proofs: bool,
-}
-
-/// Compose a qualified class or action id (`<plugin>::<name>`). The `::`
-/// separator matches podlang's convention for namespaced predicates.
-pub fn qualified_id(plugin_name: &str, name: &str) -> String {
-    format!("{plugin_name}::{name}")
 }
 
 impl PexeCatalog {
@@ -80,14 +72,13 @@ impl PexeCatalog {
     }
 
     fn from_plugins(plugins: Vec<Plugin>, mock_proofs: bool) -> Result<Self> {
-        // Validate plugin.name early: it ends up in qualified ids
-        // (`<plugin>::<name>`), in `.dobj` filename prefixes, and in GUI
-        // labels. The allowlist is filename-safe on every OS we target
-        // and rules out `:` (which would let a name straddle the `::`
-        // separator and break `bare_action_name`'s split) and any
-        // path-significant chars (`/`, `\`, `..`) that could otherwise
-        // let a malicious or misconfigured plugin escape the objects
-        // directory.
+        // Validate plugin.name early: it ends up as the `plugin_name`
+        // component of every `QualifiedName`, in `.dobj` filename prefixes,
+        // and in GUI labels. The allowlist is filename-safe on every OS we
+        // target and rules out `:` (which would let a name straddle the
+        // `::` separator when callers stringify), and any path-significant
+        // chars (`/`, `\`, `..`) that could otherwise let a malicious or
+        // misconfigured plugin escape the objects directory.
         let mut seen_plugin_names: HashMap<String, usize> = HashMap::new();
         for (idx, plugin) in plugins.iter().enumerate() {
             let name = &plugin.manifest.plugin.name;
@@ -111,9 +102,9 @@ impl PexeCatalog {
         let mut classes_in_order: Vec<CatalogClass> = Vec::new();
         let mut combined_podlang = String::new();
         let mut enriched_plugins: Vec<Plugin> = Vec::with_capacity(plugins.len());
-        let mut action_plugin_idx: HashMap<String, usize> = HashMap::new();
+        let mut action_plugin_idx: HashMap<QualifiedName, usize> = HashMap::new();
 
-        for mut plugin in plugins {
+        for plugin in plugins {
             let plugin_name = plugin.manifest.plugin.name.clone();
             let module = sdk
                 .load_module_from_src_manifest(&plugin.script, &plugin.manifest)
@@ -148,15 +139,13 @@ impl PexeCatalog {
 
             for class in module.classes() {
                 let bare = &class.name;
-                let qid = qualified_id(&plugin_name, bare);
+                let qname = QualifiedName::new(plugin_name.clone(), bare.clone());
                 let class_hash = class_hashes[bare];
                 let meta = class_meta_by_name.get(bare.as_str());
                 let predicate_source = extract_predicate(&podlang_src, &format!("Is{bare}"))
                     .unwrap_or_else(|| format!("Is{bare}(state) = OR(...)"));
                 classes_in_order.push(CatalogClass {
-                    id: qid,
-                    display_name: bare.clone(),
-                    plugin_name: plugin_name.clone(),
+                    class: qname,
                     emoji: meta.map_or("📦", |m| m.emoji.as_str()).to_string(),
                     hash: format!("{:#}", class_hash),
                     description: meta
@@ -171,7 +160,7 @@ impl PexeCatalog {
             // Build ActionSummary rows. Each input/output class is resolved
             // against this plugin's own class set; cross-plugin references
             // are rejected. Hidden actions are still recorded so their
-            // qualified id routes back to this plugin via execute_action.
+            // qualified name routes back to this plugin via execute_action.
             let action_meta_by_name: HashMap<&str, &sdk::manifest::Action> = plugin
                 .manifest
                 .actions
@@ -179,15 +168,13 @@ impl PexeCatalog {
                 .map(|a| (a.name.as_str(), a))
                 .collect();
             let plugin_idx = enriched_plugins.len();
-            let mut plugin_action_ids: Vec<String> = Vec::new();
 
             for action in module.actions() {
                 let bare = action.name.clone();
-                let qid = qualified_id(&plugin_name, &bare);
-                plugin_action_ids.push(qid.clone());
-                if let Some(prior) = action_plugin_idx.insert(qid.clone(), plugin_idx) {
+                let qname = QualifiedName::new(plugin_name.clone(), bare.clone());
+                if let Some(prior) = action_plugin_idx.insert(qname.clone(), plugin_idx) {
                     return Err(anyhow!(
-                        "internal: duplicate action qualified id {qid} (already mapped to plugin idx {prior})"
+                        "internal: duplicate action qualified name {qname} (already mapped to plugin idx {prior})"
                     ));
                 }
 
@@ -201,8 +188,7 @@ impl PexeCatalog {
                         )
                     })?;
                     Ok(ClassRef {
-                        id: qualified_id(&plugin_name, class_name),
-                        display_name: class_name.to_string(),
+                        class: QualifiedName::new(plugin_name.clone(), class_name.to_string()),
                         hash: format!("{:#}", hash),
                     })
                 };
@@ -225,9 +211,7 @@ impl PexeCatalog {
                     .map(|h| format!("{:#}", h))
                     .unwrap_or_default();
                 all_actions.push(ActionSummary {
-                    id: qid,
-                    display_name: bare.clone(),
-                    plugin_name: plugin_name.clone(),
+                    action: qname,
                     emoji: meta.map_or("⚙️", |m| m.emoji.as_str()).to_string(),
                     hash: action_hash,
                     description: meta
@@ -238,55 +222,55 @@ impl PexeCatalog {
                 });
             }
 
-            plugin.action_ids = plugin_action_ids;
             enriched_plugins.push(plugin);
         }
 
-        // Second pass: fill produced_by / consumed_by per class using qualified ids.
+        // Second pass: fill produced_by / consumed_by per class.
         for class in classes_in_order.iter_mut() {
             class.produced_by = all_actions
                 .iter()
-                .filter(|a| a.total_outputs.iter().any(|r| r.id == class.id))
-                .map(|a| a.id.clone())
+                .filter(|a| a.total_outputs.iter().any(|r| r.class == class.class))
+                .map(|a| a.action.clone())
                 .collect();
             class.consumed_by = all_actions
                 .iter()
-                .filter(|a| a.total_inputs.iter().any(|r| r.id == class.id))
-                .map(|a| a.id.clone())
+                .filter(|a| a.total_inputs.iter().any(|r| r.class == class.class))
+                .map(|a| a.action.clone())
                 .collect();
         }
 
         // Deterministic GUI order: sort by display name, then plugin.
         classes_in_order.sort_by(|a, b| {
-            a.display_name
-                .cmp(&b.display_name)
-                .then_with(|| a.plugin_name.cmp(&b.plugin_name))
+            a.class
+                .name
+                .cmp(&b.class.name)
+                .then_with(|| a.class.plugin_name.cmp(&b.class.plugin_name))
         });
 
-        let actions_by_id: HashMap<String, ActionSummary> = all_actions
+        let actions_by_name: HashMap<QualifiedName, ActionSummary> = all_actions
             .iter()
-            .map(|a| (a.id.clone(), a.clone()))
+            .map(|a| (a.action.clone(), a.clone()))
             .collect();
-        let classes_by_id: HashMap<String, CatalogClass> = classes_in_order
+        let classes_by_name: HashMap<QualifiedName, CatalogClass> = classes_in_order
             .iter()
-            .map(|c| (c.id.clone(), c.clone()))
+            .map(|c| (c.class.clone(), c.clone()))
             .collect();
-        let classes_by_hash: HashMap<Hash, String> = classes_in_order
+        let classes_by_hash: HashMap<Hash, QualifiedName> = classes_in_order
             .iter()
             .filter_map(|c| {
                 decode_hash_hex(&c.hash)
                     .ok()
-                    .map(|hash| (hash, c.id.clone()))
+                    .map(|hash| (hash, c.class.clone()))
             })
             .collect();
 
         Ok(Self {
             plugins: enriched_plugins,
             actions: all_actions,
-            actions_by_id,
+            actions_by_name,
             action_plugin_idx,
             classes: classes_in_order,
-            classes_by_id,
+            classes_by_name,
             classes_by_hash,
             combined_podlang_src: combined_podlang,
             mock_proofs,
@@ -303,36 +287,34 @@ impl ActionCatalog for PexeCatalog {
         self.actions.clone()
     }
 
-    fn get_action(&self, action_id: &str) -> Option<ActionSummary> {
-        self.actions_by_id.get(action_id).cloned()
+    fn get_action(&self, action: &QualifiedName) -> Option<ActionSummary> {
+        self.actions_by_name.get(action).cloned()
     }
 
     fn list_classes(&self) -> Vec<CatalogClass> {
         self.classes.clone()
     }
 
-    fn get_class(&self, class_id: &str) -> Option<CatalogClass> {
-        self.classes_by_id.get(class_id).cloned()
+    fn get_class(&self, class: &QualifiedName) -> Option<CatalogClass> {
+        self.classes_by_name.get(class).cloned()
     }
 
     fn get_class_by_hash(&self, class_hash: &Hash) -> Option<CatalogClass> {
-        let id = self.classes_by_hash.get(class_hash)?;
-        self.classes_by_id.get(id).cloned()
+        let qname = self.classes_by_hash.get(class_hash)?;
+        self.classes_by_name.get(qname).cloned()
     }
 
     fn execute_action(
         &self,
-        action_id: String,
+        action: QualifiedName,
         grounding_witness: GroundingWitness,
         inputs: Vec<SpendableObject>,
     ) -> Result<SpendableObjects> {
         let plugin_idx = *self
             .action_plugin_idx
-            .get(&action_id)
-            .ok_or_else(|| anyhow!("no plugin provides action {action_id}"))?;
+            .get(&action)
+            .ok_or_else(|| anyhow!("no plugin provides action {action}"))?;
         let plugin = &self.plugins[plugin_idx];
-        let bare_name = bare_action_name(&action_id, &plugin.manifest.plugin.name)
-            .ok_or_else(|| anyhow!("invalid qualified action id: {action_id}"))?;
         let sdk = Sdk::default();
         let module = sdk
             .load_module_from_src_manifest(&plugin.script, &plugin.manifest)
@@ -343,7 +325,7 @@ impl ActionCatalog for PexeCatalog {
                 )
             })?;
         let executor = module.executor(self.mock_proofs, Arc::new(grounding_witness));
-        Ok(executor.action(bare_name, inputs)?)
+        Ok(executor.action(&action.name, inputs)?)
     }
 
     fn generated_podlang(&self) -> Option<String> {
@@ -382,7 +364,6 @@ fn load_plugin_from_bytes(path: PathBuf, bytes: &[u8]) -> Result<Plugin> {
         path,
         manifest,
         script,
-        action_ids: Vec::new(),
     })
 }
 
@@ -407,13 +388,6 @@ fn validate_plugin_name(name: &str) -> Result<()> {
     Ok(())
 }
 
-fn bare_action_name<'a>(qualified_id: &'a str, plugin_name: &str) -> Option<&'a str> {
-    qualified_id
-        .strip_prefix(plugin_name)
-        .and_then(|rest| rest.strip_prefix("::"))
-        .filter(|rest| !rest.is_empty())
-}
-
 #[cfg(test)]
 pub(crate) fn test_plugin_bytes() -> Vec<u8> {
     // Pack the live plugin sources in-memory so tests never touch ~/.dobj/actions.
@@ -426,6 +400,10 @@ pub(crate) fn test_plugin_bytes() -> Vec<u8> {
 mod tests {
     use super::*;
 
+    fn craft_basics(name: &str) -> QualifiedName {
+        QualifiedName::new("craft-basics", name)
+    }
+
     fn test_catalog() -> PexeCatalog {
         PexeCatalog::from_bytes(
             std::iter::once((PathBuf::from("craft-basics.pexe"), test_plugin_bytes())),
@@ -437,17 +415,25 @@ mod tests {
     #[test]
     fn test_pexe_catalog_hides_internal_actions() {
         let catalog = test_catalog();
-        let action_ids: Vec<_> = catalog.list_actions().into_iter().map(|a| a.id).collect();
-        assert!(action_ids.contains(&"craft-basics::CraftWood".to_string()));
-        assert!(!action_ids.contains(&"craft-basics::UseWoodPick".to_string()));
+        let names: Vec<_> = catalog
+            .list_actions()
+            .into_iter()
+            .map(|a| a.action)
+            .collect();
+        assert!(names.contains(&craft_basics("CraftWood")));
+        assert!(!names.contains(&craft_basics("UseWoodPick")));
     }
 
     #[test]
     fn test_pexe_catalog_lists_classes() {
         let catalog = test_catalog();
-        let class_ids: Vec<_> = catalog.list_classes().into_iter().map(|c| c.id).collect();
-        assert!(class_ids.contains(&"craft-basics::Log".to_string()));
-        assert!(class_ids.contains(&"craft-basics::WoodPick".to_string()));
+        let classes: Vec<_> = catalog
+            .list_classes()
+            .into_iter()
+            .map(|c| c.class)
+            .collect();
+        assert!(classes.contains(&craft_basics("Log")));
+        assert!(classes.contains(&craft_basics("WoodPick")));
     }
 
     #[test]
@@ -462,13 +448,13 @@ mod tests {
     fn test_get_class_by_hash_round_trip() {
         let catalog = test_catalog();
         let log = catalog
-            .get_class("craft-basics::Log")
+            .get_class(&craft_basics("Log"))
             .expect("Log class present");
         let by_hash = decode_hash_hex(&log.hash)
             .ok()
             .and_then(|h| catalog.get_class_by_hash(&h))
             .expect("class hash resolves back");
-        assert_eq!(by_hash.id, log.id);
+        assert_eq!(by_hash.class, log.class);
     }
 
     #[test]
@@ -503,36 +489,6 @@ mod tests {
     }
 
     #[test]
-    fn test_file_prefix_for_class_sanitizes_path_chars() {
-        use crate::execute::file_prefix_for_class;
-        // Real qualified ids use the `::` separator (each `:` is mapped to
-        // `_`, so the prefix gets a double underscore).
-        assert_eq!(
-            file_prefix_for_class("craft-basics::Wood"),
-            "craft-basics__wood"
-        );
-        // Plugin names are validated upstream, but class names come from
-        // arbitrary rhai literals — the sanitizer must still stay confined
-        // to a single filename component if a class name happens to
-        // contain path-significant characters.
-        assert_eq!(
-            file_prefix_for_class("plugin::weird/class"),
-            "plugin__weird_class"
-        );
-        // `::` (2) + `..` (2) + `\` (1) = 5 underscores between the plugin
-        // name and the class name.
-        assert_eq!(
-            file_prefix_for_class("plugin::..\\Stone"),
-            "plugin_____stone"
-        );
-        let prefix = file_prefix_for_class("p::c");
-        assert!(
-            !prefix.contains('/') && !prefix.contains('\\') && !prefix.contains(':'),
-            "prefix {prefix:?} must be path-safe"
-        );
-    }
-
-    #[test]
     fn test_duplicate_plugin_name_rejected() {
         let result = PexeCatalog::from_bytes(
             [
@@ -558,7 +514,7 @@ mod tests {
     // plugin a different `CustomPredicateBatch` id and therefore different
     // class/action predicate hashes. This is the exact shape the catalog
     // collision bug used to mishandle.
-
+    //
     // Each action introduces a private `key` wildcard so the compiled
     // podlang has a non-empty `private:` clause (an empty one is a syntax
     // error). The literal blueprint string ("FooA" vs "FooB", "BarA" vs
@@ -654,12 +610,14 @@ description = "consume a Foo to make a Bar"
     #[test]
     fn test_two_plugins_same_class_name_keeps_distinct_hashes() {
         let catalog = alpha_beta_catalog();
-        let foo_alpha = catalog.get_class("alpha::Foo").expect("alpha::Foo present");
-        let foo_beta = catalog.get_class("beta::Foo").expect("beta::Foo present");
-        assert_eq!(foo_alpha.display_name, "Foo");
-        assert_eq!(foo_beta.display_name, "Foo");
-        assert_eq!(foo_alpha.plugin_name, "alpha");
-        assert_eq!(foo_beta.plugin_name, "beta");
+        let alpha_foo = QualifiedName::new("alpha", "Foo");
+        let beta_foo = QualifiedName::new("beta", "Foo");
+        let foo_alpha = catalog.get_class(&alpha_foo).expect("alpha::Foo present");
+        let foo_beta = catalog.get_class(&beta_foo).expect("beta::Foo present");
+        assert_eq!(foo_alpha.class.name, "Foo");
+        assert_eq!(foo_beta.class.name, "Foo");
+        assert_eq!(foo_alpha.class.plugin_name, "alpha");
+        assert_eq!(foo_beta.class.plugin_name, "beta");
         assert_ne!(
             foo_alpha.hash, foo_beta.hash,
             "Foo from two different modules must have different IsFoo predicate hashes"
@@ -673,14 +631,18 @@ description = "consume a Foo to make a Bar"
         // Each plugin's MakeFoo produces an output whose obj["type"] is *that
         // plugin's* IsFoo predicate hash. If the catalog routed the wrong
         // script, the type field would be the other plugin's hash.
-        let alpha_foo = catalog.get_class("alpha::Foo").expect("alpha::Foo present");
-        let beta_foo = catalog.get_class("beta::Foo").expect("beta::Foo present");
+        let alpha_foo = catalog
+            .get_class(&QualifiedName::new("alpha", "Foo"))
+            .expect("alpha::Foo present");
+        let beta_foo = catalog
+            .get_class(&QualifiedName::new("beta", "Foo"))
+            .expect("beta::Foo present");
         let alpha_hash = decode_hash_hex(&alpha_foo.hash).expect("alpha::Foo hash parses");
         let beta_hash = decode_hash_hex(&beta_foo.hash).expect("beta::Foo hash parses");
 
         let alpha_out = catalog
             .execute_action(
-                "alpha::MakeFoo".to_string(),
+                QualifiedName::new("alpha", "MakeFoo"),
                 dummy_grounding_witness(),
                 vec![],
             )
@@ -694,7 +656,7 @@ description = "consume a Foo to make a Bar"
 
         let beta_out = catalog
             .execute_action(
-                "beta::MakeFoo".to_string(),
+                QualifiedName::new("beta", "MakeFoo"),
                 dummy_grounding_witness(),
                 vec![],
             )
@@ -709,21 +671,25 @@ description = "consume a Foo to make a Bar"
     #[test]
     fn test_action_input_class_hash_is_module_scoped() {
         let catalog = alpha_beta_catalog();
-        let alpha_foo = catalog.get_class("alpha::Foo").unwrap();
-        let beta_foo = catalog.get_class("beta::Foo").unwrap();
+        let alpha_foo = catalog
+            .get_class(&QualifiedName::new("alpha", "Foo"))
+            .unwrap();
+        let beta_foo = catalog
+            .get_class(&QualifiedName::new("beta", "Foo"))
+            .unwrap();
         assert_ne!(alpha_foo.hash, beta_foo.hash);
 
         let alpha_consume = catalog
-            .get_action("alpha::ConsumeFoo")
+            .get_action(&QualifiedName::new("alpha", "ConsumeFoo"))
             .expect("alpha::ConsumeFoo present");
         let beta_consume = catalog
-            .get_action("beta::ConsumeFoo")
+            .get_action(&QualifiedName::new("beta", "ConsumeFoo"))
             .expect("beta::ConsumeFoo present");
 
         let alpha_input = &alpha_consume.total_inputs[0];
         let beta_input = &beta_consume.total_inputs[0];
-        assert_eq!(alpha_input.id, "alpha::Foo");
-        assert_eq!(beta_input.id, "beta::Foo");
+        assert_eq!(alpha_input.class, QualifiedName::new("alpha", "Foo"));
+        assert_eq!(beta_input.class, QualifiedName::new("beta", "Foo"));
         assert_eq!(
             alpha_input.hash, alpha_foo.hash,
             "alpha::ConsumeFoo's required input hash must be alpha's IsFoo hash"
@@ -738,25 +704,33 @@ description = "consume a Foo to make a Bar"
     fn test_class_cross_references_are_per_plugin() {
         // Each class's `produced_by` / `consumed_by` must list only the
         // actions from its own plugin. If the catalog conflated entries by
-        // bare name, alpha:Foo's `produced_by` could end up containing
-        // `beta:MakeFoo` (and vice versa), which would mis-route GUI
+        // bare name, alpha::Foo's `produced_by` could end up containing
+        // beta::MakeFoo (and vice versa), which would mis-route GUI
         // suggestions and feasibility checks.
         let catalog = alpha_beta_catalog();
-        let alpha_foo = catalog.get_class("alpha::Foo").unwrap();
-        let beta_foo = catalog.get_class("beta::Foo").unwrap();
+        let alpha_foo = catalog
+            .get_class(&QualifiedName::new("alpha", "Foo"))
+            .unwrap();
+        let beta_foo = catalog
+            .get_class(&QualifiedName::new("beta", "Foo"))
+            .unwrap();
 
         assert_eq!(
             alpha_foo.produced_by,
-            vec!["alpha::MakeFoo".to_string()],
-            "alpha::Foo should only be produced by alpha:MakeFoo"
+            vec![QualifiedName::new("alpha", "MakeFoo")]
         );
         assert_eq!(
             alpha_foo.consumed_by,
-            vec!["alpha::ConsumeFoo".to_string()],
-            "alpha::Foo should only be consumed by alpha:ConsumeFoo"
+            vec![QualifiedName::new("alpha", "ConsumeFoo")]
         );
-        assert_eq!(beta_foo.produced_by, vec!["beta::MakeFoo".to_string()]);
-        assert_eq!(beta_foo.consumed_by, vec!["beta::ConsumeFoo".to_string()]);
+        assert_eq!(
+            beta_foo.produced_by,
+            vec![QualifiedName::new("beta", "MakeFoo")]
+        );
+        assert_eq!(
+            beta_foo.consumed_by,
+            vec![QualifiedName::new("beta", "ConsumeFoo")]
+        );
 
         // The predicate source string is also non-empty and looks like an
         // IsFoo predicate. (The IsFoo body itself is the same shape in both

--- a/driver/src/pexe_catalog.rs
+++ b/driver/src/pexe_catalog.rs
@@ -21,7 +21,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use anyhow::{Context, Result, anyhow};
-use hex::FromHex;
+use common::decode_hash_hex;
 use pod2::middleware::Hash;
 use sdk::{Sdk, SpendableObject, SpendableObjects, manifest::Manifest};
 use txlib::GroundingWitness;
@@ -270,7 +270,7 @@ impl PexeCatalog {
         let classes_by_hash: HashMap<Hash, String> = classes_in_order
             .iter()
             .filter_map(|c| {
-                parse_hash_hex(&c.hash)
+                decode_hash_hex(&c.hash)
                     .ok()
                     .map(|hash| (hash, c.id.clone()))
             })
@@ -404,20 +404,10 @@ fn validate_plugin_name(name: &str) -> Result<()> {
 }
 
 fn bare_action_name<'a>(qualified_id: &'a str, plugin_name: &str) -> Option<&'a str> {
-    let prefix_len = plugin_name.len();
-    if qualified_id.len() <= prefix_len + 1 {
-        return None;
-    }
-    let (head, rest) = qualified_id.split_at(prefix_len);
-    if head != plugin_name || !rest.starts_with(':') {
-        return None;
-    }
-    Some(&rest[1..])
-}
-
-fn parse_hash_hex(s: &str) -> Result<Hash> {
-    let trimmed = s.strip_prefix("0x").unwrap_or(s);
-    Hash::from_hex(trimmed).map_err(|err| anyhow!("invalid hash hex {s:?}: {err}"))
+    qualified_id
+        .strip_prefix(plugin_name)
+        .and_then(|rest| rest.strip_prefix(':'))
+        .filter(|rest| !rest.is_empty())
 }
 
 #[cfg(test)]
@@ -470,7 +460,7 @@ mod tests {
         let log = catalog
             .get_class("craft-basics:Log")
             .expect("Log class present");
-        let by_hash = parse_hash_hex(&log.hash)
+        let by_hash = decode_hash_hex(&log.hash)
             .ok()
             .and_then(|h| catalog.get_class_by_hash(&h))
             .expect("class hash resolves back");
@@ -675,8 +665,8 @@ description = "consume a Foo to make a Bar"
         // script, the type field would be the other plugin's hash.
         let alpha_foo = catalog.get_class("alpha:Foo").expect("alpha:Foo present");
         let beta_foo = catalog.get_class("beta:Foo").expect("beta:Foo present");
-        let alpha_hash = parse_hash_hex(&alpha_foo.hash).expect("alpha:Foo hash parses");
-        let beta_hash = parse_hash_hex(&beta_foo.hash).expect("beta:Foo hash parses");
+        let alpha_hash = decode_hash_hex(&alpha_foo.hash).expect("alpha:Foo hash parses");
+        let beta_hash = decode_hash_hex(&beta_foo.hash).expect("beta:Foo hash parses");
 
         let alpha_out = catalog
             .execute_action(

--- a/driver/src/pexe_catalog.rs
+++ b/driver/src/pexe_catalog.rs
@@ -5,12 +5,13 @@
 //! `module_hash`). The compiled module is used to derive action/class hashes and
 //! the podlang source shown in the GUI.
 //!
-//! Classes and actions are keyed by qualified id `<plugin_name>:<name>`. Two
-//! plugins may declare a class or action with the same bare name; they are kept
-//! distinct by qualified id and by their on-chain `Is{class}` predicate hash
-//! (which differs between modules because each module has a unique
-//! `module_hash`). Cross-plugin class references are not supported: an action
-//! must reference classes declared in its own plugin.
+//! Classes and actions are keyed by qualified id `<plugin_name>::<name>`,
+//! using the same `::` separator podlang uses for namespaced predicates.
+//! Two plugins may declare a class or action with the same bare name; they
+//! are kept distinct by qualified id and by their on-chain `Is{class}`
+//! predicate hash (which differs between modules because each module has a
+//! unique `module_hash`). Cross-plugin class references are not supported:
+//! an action must reference classes declared in its own plugin.
 //!
 //! The compiled [`sdk::SdkModule`] is not kept — it holds a `Rc<Engine>` and is
 //! therefore `!Send`. `execute_action` re-loads the script from its stored bytes
@@ -34,8 +35,8 @@ struct Plugin {
     path: PathBuf,
     manifest: Manifest,
     script: String,
-    /// Qualified ids (`<plugin>:<action>`) provided by this plugin. Used to
-    /// route `execute_action` back to the originating script bytes.
+    /// Qualified ids (`<plugin>::<action>`) provided by this plugin. Used
+    /// to route `execute_action` back to the originating script bytes.
     action_ids: Vec<String>,
 }
 
@@ -52,8 +53,10 @@ pub struct PexeCatalog {
     mock_proofs: bool,
 }
 
+/// Compose a qualified class or action id (`<plugin>::<name>`). The `::`
+/// separator matches podlang's convention for namespaced predicates.
 pub fn qualified_id(plugin_name: &str, name: &str) -> String {
-    format!("{plugin_name}:{name}")
+    format!("{plugin_name}::{name}")
 }
 
 impl PexeCatalog {
@@ -78,12 +81,13 @@ impl PexeCatalog {
 
     fn from_plugins(plugins: Vec<Plugin>, mock_proofs: bool) -> Result<Self> {
         // Validate plugin.name early: it ends up in qualified ids
-        // (`<plugin>:<name>`), in `.dobj` filename prefixes, and in GUI
+        // (`<plugin>::<name>`), in `.dobj` filename prefixes, and in GUI
         // labels. The allowlist is filename-safe on every OS we target
-        // and rules out the `:` separator (which would break
-        // `bare_action_name`'s split) and any path-significant chars
-        // (`/`, `\`, `..`) that could otherwise let a malicious or
-        // misconfigured plugin escape the objects directory.
+        // and rules out `:` (which would let a name straddle the `::`
+        // separator and break `bare_action_name`'s split) and any
+        // path-significant chars (`/`, `\`, `..`) that could otherwise
+        // let a malicious or misconfigured plugin escape the objects
+        // directory.
         let mut seen_plugin_names: HashMap<String, usize> = HashMap::new();
         for (idx, plugin) in plugins.iter().enumerate() {
             let name = &plugin.manifest.plugin.name;
@@ -383,10 +387,10 @@ fn load_plugin_from_bytes(path: PathBuf, bytes: &[u8]) -> Result<Plugin> {
 }
 
 /// Allowlist for `manifest.plugin.name`. Must be non-empty and contain only
-/// ASCII alphanumerics, `-`, or `_`. Rules out the qualified-id separator
-/// `:`, every path-significant character (`/`, `\`, `.`), whitespace, and
-/// any reserved/control characters that would otherwise leak into filenames
-/// or split qualified ids unexpectedly.
+/// ASCII alphanumerics, `-`, or `_`. Rules out `:` (which would straddle
+/// the `::` qualified-id separator), every path-significant character
+/// (`/`, `\`, `.`), whitespace, and any reserved/control characters that
+/// would otherwise leak into filenames or split qualified ids unexpectedly.
 fn validate_plugin_name(name: &str) -> Result<()> {
     if name.is_empty() {
         return Err(anyhow!("plugin name must be non-empty"));
@@ -406,7 +410,7 @@ fn validate_plugin_name(name: &str) -> Result<()> {
 fn bare_action_name<'a>(qualified_id: &'a str, plugin_name: &str) -> Option<&'a str> {
     qualified_id
         .strip_prefix(plugin_name)
-        .and_then(|rest| rest.strip_prefix(':'))
+        .and_then(|rest| rest.strip_prefix("::"))
         .filter(|rest| !rest.is_empty())
 }
 
@@ -434,16 +438,16 @@ mod tests {
     fn test_pexe_catalog_hides_internal_actions() {
         let catalog = test_catalog();
         let action_ids: Vec<_> = catalog.list_actions().into_iter().map(|a| a.id).collect();
-        assert!(action_ids.contains(&"craft-basics:CraftWood".to_string()));
-        assert!(!action_ids.contains(&"craft-basics:UseWoodPick".to_string()));
+        assert!(action_ids.contains(&"craft-basics::CraftWood".to_string()));
+        assert!(!action_ids.contains(&"craft-basics::UseWoodPick".to_string()));
     }
 
     #[test]
     fn test_pexe_catalog_lists_classes() {
         let catalog = test_catalog();
         let class_ids: Vec<_> = catalog.list_classes().into_iter().map(|c| c.id).collect();
-        assert!(class_ids.contains(&"craft-basics:Log".to_string()));
-        assert!(class_ids.contains(&"craft-basics:WoodPick".to_string()));
+        assert!(class_ids.contains(&"craft-basics::Log".to_string()));
+        assert!(class_ids.contains(&"craft-basics::WoodPick".to_string()));
     }
 
     #[test]
@@ -458,7 +462,7 @@ mod tests {
     fn test_get_class_by_hash_round_trip() {
         let catalog = test_catalog();
         let log = catalog
-            .get_class("craft-basics:Log")
+            .get_class("craft-basics::Log")
             .expect("Log class present");
         let by_hash = decode_hash_hex(&log.hash)
             .ok()
@@ -501,21 +505,27 @@ mod tests {
     #[test]
     fn test_file_prefix_for_class_sanitizes_path_chars() {
         use crate::execute::file_prefix_for_class;
-        // Plugin names are validated upstream so the colon here is the
-        // only legitimate `:` in a real qualified id, but if a class name
-        // ever contained a path-significant character the prefix must
-        // still stay confined to a single filename component.
+        // Real qualified ids use the `::` separator (each `:` is mapped to
+        // `_`, so the prefix gets a double underscore).
         assert_eq!(
-            file_prefix_for_class("craft-basics:Wood"),
-            "craft-basics_wood"
+            file_prefix_for_class("craft-basics::Wood"),
+            "craft-basics__wood"
         );
+        // Plugin names are validated upstream, but class names come from
+        // arbitrary rhai literals — the sanitizer must still stay confined
+        // to a single filename component if a class name happens to
+        // contain path-significant characters.
         assert_eq!(
-            file_prefix_for_class("plugin:weird/class"),
-            "plugin_weird_class"
+            file_prefix_for_class("plugin::weird/class"),
+            "plugin__weird_class"
         );
-        // `:`, `.`, `.`, `\` all become `_`
-        assert_eq!(file_prefix_for_class("plugin:..\\Stone"), "plugin____stone");
-        let prefix = file_prefix_for_class("p:c");
+        // `::` (2) + `..` (2) + `\` (1) = 5 underscores between the plugin
+        // name and the class name.
+        assert_eq!(
+            file_prefix_for_class("plugin::..\\Stone"),
+            "plugin_____stone"
+        );
+        let prefix = file_prefix_for_class("p::c");
         assert!(
             !prefix.contains('/') && !prefix.contains('\\') && !prefix.contains(':'),
             "prefix {prefix:?} must be path-safe"
@@ -644,8 +654,8 @@ description = "consume a Foo to make a Bar"
     #[test]
     fn test_two_plugins_same_class_name_keeps_distinct_hashes() {
         let catalog = alpha_beta_catalog();
-        let foo_alpha = catalog.get_class("alpha:Foo").expect("alpha:Foo present");
-        let foo_beta = catalog.get_class("beta:Foo").expect("beta:Foo present");
+        let foo_alpha = catalog.get_class("alpha::Foo").expect("alpha::Foo present");
+        let foo_beta = catalog.get_class("beta::Foo").expect("beta::Foo present");
         assert_eq!(foo_alpha.display_name, "Foo");
         assert_eq!(foo_beta.display_name, "Foo");
         assert_eq!(foo_alpha.plugin_name, "alpha");
@@ -663,64 +673,64 @@ description = "consume a Foo to make a Bar"
         // Each plugin's MakeFoo produces an output whose obj["type"] is *that
         // plugin's* IsFoo predicate hash. If the catalog routed the wrong
         // script, the type field would be the other plugin's hash.
-        let alpha_foo = catalog.get_class("alpha:Foo").expect("alpha:Foo present");
-        let beta_foo = catalog.get_class("beta:Foo").expect("beta:Foo present");
-        let alpha_hash = decode_hash_hex(&alpha_foo.hash).expect("alpha:Foo hash parses");
-        let beta_hash = decode_hash_hex(&beta_foo.hash).expect("beta:Foo hash parses");
+        let alpha_foo = catalog.get_class("alpha::Foo").expect("alpha::Foo present");
+        let beta_foo = catalog.get_class("beta::Foo").expect("beta::Foo present");
+        let alpha_hash = decode_hash_hex(&alpha_foo.hash).expect("alpha::Foo hash parses");
+        let beta_hash = decode_hash_hex(&beta_foo.hash).expect("beta::Foo hash parses");
 
         let alpha_out = catalog
             .execute_action(
-                "alpha:MakeFoo".to_string(),
+                "alpha::MakeFoo".to_string(),
                 dummy_grounding_witness(),
                 vec![],
             )
-            .expect("alpha:MakeFoo runs");
+            .expect("alpha::MakeFoo runs");
         let alpha_type =
             obj_type_hash_for_test(&alpha_out.obj(0).obj).expect("alpha output has type");
         assert_eq!(
             alpha_type, alpha_hash,
-            "alpha:MakeFoo output type should be alpha's IsFoo hash"
+            "alpha::MakeFoo output type should be alpha's IsFoo hash"
         );
 
         let beta_out = catalog
             .execute_action(
-                "beta:MakeFoo".to_string(),
+                "beta::MakeFoo".to_string(),
                 dummy_grounding_witness(),
                 vec![],
             )
-            .expect("beta:MakeFoo runs");
+            .expect("beta::MakeFoo runs");
         let beta_type = obj_type_hash_for_test(&beta_out.obj(0).obj).expect("beta output has type");
         assert_eq!(
             beta_type, beta_hash,
-            "beta:MakeFoo output type should be beta's IsFoo hash"
+            "beta::MakeFoo output type should be beta's IsFoo hash"
         );
     }
 
     #[test]
     fn test_action_input_class_hash_is_module_scoped() {
         let catalog = alpha_beta_catalog();
-        let alpha_foo = catalog.get_class("alpha:Foo").unwrap();
-        let beta_foo = catalog.get_class("beta:Foo").unwrap();
+        let alpha_foo = catalog.get_class("alpha::Foo").unwrap();
+        let beta_foo = catalog.get_class("beta::Foo").unwrap();
         assert_ne!(alpha_foo.hash, beta_foo.hash);
 
         let alpha_consume = catalog
-            .get_action("alpha:ConsumeFoo")
-            .expect("alpha:ConsumeFoo present");
+            .get_action("alpha::ConsumeFoo")
+            .expect("alpha::ConsumeFoo present");
         let beta_consume = catalog
-            .get_action("beta:ConsumeFoo")
-            .expect("beta:ConsumeFoo present");
+            .get_action("beta::ConsumeFoo")
+            .expect("beta::ConsumeFoo present");
 
         let alpha_input = &alpha_consume.total_inputs[0];
         let beta_input = &beta_consume.total_inputs[0];
-        assert_eq!(alpha_input.id, "alpha:Foo");
-        assert_eq!(beta_input.id, "beta:Foo");
+        assert_eq!(alpha_input.id, "alpha::Foo");
+        assert_eq!(beta_input.id, "beta::Foo");
         assert_eq!(
             alpha_input.hash, alpha_foo.hash,
-            "alpha:ConsumeFoo's required input hash must be alpha's IsFoo hash"
+            "alpha::ConsumeFoo's required input hash must be alpha's IsFoo hash"
         );
         assert_eq!(
             beta_input.hash, beta_foo.hash,
-            "beta:ConsumeFoo's required input hash must be beta's IsFoo hash"
+            "beta::ConsumeFoo's required input hash must be beta's IsFoo hash"
         );
     }
 
@@ -732,21 +742,21 @@ description = "consume a Foo to make a Bar"
         // `beta:MakeFoo` (and vice versa), which would mis-route GUI
         // suggestions and feasibility checks.
         let catalog = alpha_beta_catalog();
-        let alpha_foo = catalog.get_class("alpha:Foo").unwrap();
-        let beta_foo = catalog.get_class("beta:Foo").unwrap();
+        let alpha_foo = catalog.get_class("alpha::Foo").unwrap();
+        let beta_foo = catalog.get_class("beta::Foo").unwrap();
 
         assert_eq!(
             alpha_foo.produced_by,
-            vec!["alpha:MakeFoo".to_string()],
-            "alpha:Foo should only be produced by alpha:MakeFoo"
+            vec!["alpha::MakeFoo".to_string()],
+            "alpha::Foo should only be produced by alpha:MakeFoo"
         );
         assert_eq!(
             alpha_foo.consumed_by,
-            vec!["alpha:ConsumeFoo".to_string()],
-            "alpha:Foo should only be consumed by alpha:ConsumeFoo"
+            vec!["alpha::ConsumeFoo".to_string()],
+            "alpha::Foo should only be consumed by alpha:ConsumeFoo"
         );
-        assert_eq!(beta_foo.produced_by, vec!["beta:MakeFoo".to_string()]);
-        assert_eq!(beta_foo.consumed_by, vec!["beta:ConsumeFoo".to_string()]);
+        assert_eq!(beta_foo.produced_by, vec!["beta::MakeFoo".to_string()]);
+        assert_eq!(beta_foo.consumed_by, vec!["beta::ConsumeFoo".to_string()]);
 
         // The predicate source string is also non-empty and looks like an
         // IsFoo predicate. (The IsFoo body itself is the same shape in both

--- a/driver/src/pexe_catalog.rs
+++ b/driver/src/pexe_catalog.rs
@@ -27,7 +27,7 @@ use sdk::{Sdk, SpendableObject, SpendableObjects, manifest::Manifest};
 use txlib::GroundingWitness;
 
 use crate::catalog::{ActionCatalog, CatalogClass, extract_predicate};
-use crate::types::ActionSummary;
+use crate::types::{ActionSummary, ClassRef};
 
 struct Plugin {
     #[allow(dead_code)]
@@ -177,7 +177,7 @@ impl PexeCatalog {
                 }
 
                 let meta = action_meta_by_name.get(bare.as_str());
-                let resolve_class = |class_name: &str| -> Result<(String, String, String)> {
+                let resolve_class = |class_name: &str| -> Result<ClassRef> {
                     let hash = class_hashes.get(class_name).ok_or_else(|| {
                         anyhow!(
                             "plugin {plugin_name}: action {bare} references class {class_name:?} \
@@ -185,32 +185,21 @@ impl PexeCatalog {
                              references are not supported yet)"
                         )
                     })?;
-                    Ok((
-                        qualified_id(&plugin_name, class_name),
-                        class_name.to_string(),
-                        format!("{:#}", hash),
-                    ))
+                    Ok(ClassRef {
+                        id: qualified_id(&plugin_name, class_name),
+                        display_name: class_name.to_string(),
+                        hash: format!("{:#}", hash),
+                    })
                 };
 
-                let mut total_input_class_ids = Vec::new();
-                let mut total_input_class_names = Vec::new();
-                let mut total_input_class_hashes = Vec::new();
-                for r in action.total_inputs() {
-                    let (id, name, hash) = resolve_class(&r.class)?;
-                    total_input_class_ids.push(id);
-                    total_input_class_names.push(name);
-                    total_input_class_hashes.push(hash);
-                }
-
-                let mut total_output_class_ids = Vec::new();
-                let mut total_output_class_names = Vec::new();
-                let mut total_output_class_hashes = Vec::new();
-                for r in action.total_outputs() {
-                    let (id, name, hash) = resolve_class(&r.class)?;
-                    total_output_class_ids.push(id);
-                    total_output_class_names.push(name);
-                    total_output_class_hashes.push(hash);
-                }
+                let total_inputs = action
+                    .total_inputs()
+                    .map(|r| resolve_class(&r.class))
+                    .collect::<Result<Vec<_>>>()?;
+                let total_outputs = action
+                    .total_outputs()
+                    .map(|r| resolve_class(&r.class))
+                    .collect::<Result<Vec<_>>>()?;
 
                 if meta.is_some_and(|m| m.hidden) {
                     continue;
@@ -229,12 +218,8 @@ impl PexeCatalog {
                     description: meta
                         .map_or("Pexe action", |m| m.description.as_str())
                         .to_string(),
-                    total_input_class_ids,
-                    total_input_class_names,
-                    total_input_class_hashes,
-                    total_output_class_ids,
-                    total_output_class_names,
-                    total_output_class_hashes,
+                    total_inputs,
+                    total_outputs,
                 });
             }
 
@@ -246,12 +231,12 @@ impl PexeCatalog {
         for class in classes_in_order.iter_mut() {
             class.produced_by = all_actions
                 .iter()
-                .filter(|a| a.total_output_class_ids.contains(&class.id))
+                .filter(|a| a.total_outputs.iter().any(|r| r.id == class.id))
                 .map(|a| a.id.clone())
                 .collect();
             class.consumed_by = all_actions
                 .iter()
-                .filter(|a| a.total_input_class_ids.contains(&class.id))
+                .filter(|a| a.total_inputs.iter().any(|r| r.id == class.id))
                 .map(|a| a.id.clone())
                 .collect();
         }
@@ -648,16 +633,16 @@ description = "consume a Foo to make a Bar"
             .get_action("beta:ConsumeFoo")
             .expect("beta:ConsumeFoo present");
 
-        assert_eq!(alpha_consume.total_input_class_ids, vec!["alpha:Foo"]);
-        assert_eq!(beta_consume.total_input_class_ids, vec!["beta:Foo"]);
+        let alpha_input = &alpha_consume.total_inputs[0];
+        let beta_input = &beta_consume.total_inputs[0];
+        assert_eq!(alpha_input.id, "alpha:Foo");
+        assert_eq!(beta_input.id, "beta:Foo");
         assert_eq!(
-            alpha_consume.total_input_class_hashes,
-            vec![alpha_foo.hash.clone()],
+            alpha_input.hash, alpha_foo.hash,
             "alpha:ConsumeFoo's required input hash must be alpha's IsFoo hash"
         );
         assert_eq!(
-            beta_consume.total_input_class_hashes,
-            vec![beta_foo.hash.clone()],
+            beta_input.hash, beta_foo.hash,
             "beta:ConsumeFoo's required input hash must be beta's IsFoo hash"
         );
     }

--- a/driver/src/pexe_catalog.rs
+++ b/driver/src/pexe_catalog.rs
@@ -77,11 +77,22 @@ impl PexeCatalog {
     }
 
     fn from_plugins(plugins: Vec<Plugin>, mock_proofs: bool) -> Result<Self> {
-        // Reject duplicate plugin.name early: qualified ids are
-        // `<plugin>:<name>` and would otherwise collide silently.
+        // Validate plugin.name early: it ends up in qualified ids
+        // (`<plugin>:<name>`), in `.dobj` filename prefixes, and in GUI
+        // labels. The allowlist is filename-safe on every OS we target
+        // and rules out the `:` separator (which would break
+        // `bare_action_name`'s split) and any path-significant chars
+        // (`/`, `\`, `..`) that could otherwise let a malicious or
+        // misconfigured plugin escape the objects directory.
         let mut seen_plugin_names: HashMap<String, usize> = HashMap::new();
         for (idx, plugin) in plugins.iter().enumerate() {
             let name = &plugin.manifest.plugin.name;
+            validate_plugin_name(name).map_err(|err| {
+                anyhow!(
+                    "invalid plugin name {name:?} in {}: {err}",
+                    plugin.path.display()
+                )
+            })?;
             if let Some(prior) = seen_plugin_names.insert(name.clone(), idx) {
                 return Err(anyhow!(
                     "duplicate plugin name {name:?}: already registered by {} (other entry at index {prior})",
@@ -371,6 +382,27 @@ fn load_plugin_from_bytes(path: PathBuf, bytes: &[u8]) -> Result<Plugin> {
     })
 }
 
+/// Allowlist for `manifest.plugin.name`. Must be non-empty and contain only
+/// ASCII alphanumerics, `-`, or `_`. Rules out the qualified-id separator
+/// `:`, every path-significant character (`/`, `\`, `.`), whitespace, and
+/// any reserved/control characters that would otherwise leak into filenames
+/// or split qualified ids unexpectedly.
+fn validate_plugin_name(name: &str) -> Result<()> {
+    if name.is_empty() {
+        return Err(anyhow!("plugin name must be non-empty"));
+    }
+    if let Some(bad) = name
+        .chars()
+        .find(|c| !(c.is_ascii_alphanumeric() || *c == '-' || *c == '_'))
+    {
+        return Err(anyhow!(
+            "plugin name may only contain ASCII letters, digits, '-', and '_'; \
+             rejected character {bad:?}"
+        ));
+    }
+    Ok(())
+}
+
 fn bare_action_name<'a>(qualified_id: &'a str, plugin_name: &str) -> Option<&'a str> {
     let prefix_len = plugin_name.len();
     if qualified_id.len() <= prefix_len + 1 {
@@ -443,6 +475,61 @@ mod tests {
             .and_then(|h| catalog.get_class_by_hash(&h))
             .expect("class hash resolves back");
         assert_eq!(by_hash.id, log.id);
+    }
+
+    #[test]
+    fn test_invalid_plugin_name_rejected() {
+        // Each of these would either break qualified-id parsing or escape
+        // the objects directory when used as a filename prefix.
+        let cases = [
+            ("weird:plugin", "':' in plugin name"),
+            ("foo/bar", "'/' in plugin name"),
+            ("foo\\bar", "'\\' in plugin name"),
+            ("..", "'..' as plugin name"),
+            ("with space", "whitespace in plugin name"),
+            ("", "empty plugin name"),
+        ];
+        for (name, label) in cases {
+            let bytes = synthetic_plugin_bytes(name, ALPHA_SCRIPT);
+            let result = PexeCatalog::from_bytes(
+                std::iter::once((PathBuf::from(format!("{name}.pexe")), bytes)),
+                true,
+            );
+            match result {
+                Ok(_) => panic!("expected catalog to reject {label}, but load succeeded"),
+                Err(err) => {
+                    let msg = err.to_string();
+                    assert!(
+                        msg.contains("invalid plugin name") || msg.contains("plugin name"),
+                        "unexpected error for {label}: {msg}"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_file_prefix_for_class_sanitizes_path_chars() {
+        use crate::execute::file_prefix_for_class;
+        // Plugin names are validated upstream so the colon here is the
+        // only legitimate `:` in a real qualified id, but if a class name
+        // ever contained a path-significant character the prefix must
+        // still stay confined to a single filename component.
+        assert_eq!(
+            file_prefix_for_class("craft-basics:Wood"),
+            "craft-basics_wood"
+        );
+        assert_eq!(
+            file_prefix_for_class("plugin:weird/class"),
+            "plugin_weird_class"
+        );
+        // `:`, `.`, `.`, `\` all become `_`
+        assert_eq!(file_prefix_for_class("plugin:..\\Stone"), "plugin____stone");
+        let prefix = file_prefix_for_class("p:c");
+        assert!(
+            !prefix.contains('/') && !prefix.contains('\\') && !prefix.contains(':'),
+            "prefix {prefix:?} must be path-safe"
+        );
     }
 
     #[test]

--- a/driver/src/pexe_catalog.rs
+++ b/driver/src/pexe_catalog.rs
@@ -16,7 +16,7 @@
 //! therefore `!Send`. `execute_action` re-loads the script from its stored bytes
 //! on demand, matching the per-call pattern used before.
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -48,8 +48,6 @@ pub struct PexeCatalog {
     classes: Vec<CatalogClass>,
     classes_by_id: HashMap<String, CatalogClass>,
     classes_by_hash: HashMap<Hash, String>,
-    /// Bare class/action names that appear in more than one plugin.
-    name_collisions: Vec<String>,
     combined_podlang_src: String,
     mock_proofs: bool,
 }
@@ -97,11 +95,7 @@ impl PexeCatalog {
         let mut all_actions: Vec<ActionSummary> = Vec::new();
         let mut classes_in_order: Vec<CatalogClass> = Vec::new();
         let mut combined_podlang = String::new();
-        // Track class hash by bare class name within each plugin so we can
-        // resolve action input/output class refs without consulting other
-        // plugins. (Within one module, bare class names are unique.)
         let mut enriched_plugins: Vec<Plugin> = Vec::with_capacity(plugins.len());
-        let mut bare_name_counts: BTreeMap<String, usize> = BTreeMap::new();
         let mut action_plugin_idx: HashMap<String, usize> = HashMap::new();
 
         for mut plugin in plugins {
@@ -139,7 +133,6 @@ impl PexeCatalog {
 
             for class in module.classes() {
                 let bare = &class.name;
-                *bare_name_counts.entry(bare.clone()).or_insert(0) += 1;
                 let qid = qualified_id(&plugin_name, bare);
                 let class_hash = class_hashes[bare];
                 let meta = class_meta_by_name.get(bare.as_str());
@@ -175,7 +168,6 @@ impl PexeCatalog {
 
             for action in module.actions() {
                 let bare = action.name.clone();
-                *bare_name_counts.entry(bare.clone()).or_insert(0) += 1;
                 let qid = qualified_id(&plugin_name, &bare);
                 plugin_action_ids.push(qid.clone());
                 if let Some(prior) = action_plugin_idx.insert(qid.clone(), plugin_idx) {
@@ -287,10 +279,6 @@ impl PexeCatalog {
                     .map(|hash| (hash, c.id.clone()))
             })
             .collect();
-        let name_collisions: Vec<String> = bare_name_counts
-            .into_iter()
-            .filter_map(|(name, count)| (count > 1).then_some(name))
-            .collect();
 
         Ok(Self {
             plugins: enriched_plugins,
@@ -300,7 +288,6 @@ impl PexeCatalog {
             classes: classes_in_order,
             classes_by_id,
             classes_by_hash,
-            name_collisions,
             combined_podlang_src: combined_podlang,
             mock_proofs,
         })
@@ -331,10 +318,6 @@ impl ActionCatalog for PexeCatalog {
     fn get_class_by_hash(&self, class_hash: &Hash) -> Option<CatalogClass> {
         let id = self.classes_by_hash.get(class_hash)?;
         self.classes_by_id.get(id).cloned()
-    }
-
-    fn name_collisions(&self) -> Vec<String> {
-        self.name_collisions.clone()
     }
 
     fn execute_action(
@@ -478,12 +461,6 @@ mod tests {
     }
 
     #[test]
-    fn test_no_collisions_for_single_plugin() {
-        let catalog = test_catalog();
-        assert!(catalog.name_collisions().is_empty());
-    }
-
-    #[test]
     fn test_duplicate_plugin_name_rejected() {
         let result = PexeCatalog::from_bytes(
             [
@@ -614,20 +591,6 @@ description = "consume a Foo to make a Bar"
         assert_ne!(
             foo_alpha.hash, foo_beta.hash,
             "Foo from two different modules must have different IsFoo predicate hashes"
-        );
-        // And the bare-name collision is reported so the GUI can disambiguate.
-        let collisions = catalog.name_collisions();
-        assert!(
-            collisions.contains(&"Foo".to_string()),
-            "expected name_collisions to include Foo, got {collisions:?}"
-        );
-        assert!(
-            collisions.contains(&"Bar".to_string()),
-            "expected name_collisions to include Bar, got {collisions:?}"
-        );
-        assert!(
-            collisions.contains(&"MakeFoo".to_string()),
-            "expected name_collisions to include MakeFoo, got {collisions:?}"
         );
     }
 

--- a/driver/src/pexe_catalog.rs
+++ b/driver/src/pexe_catalog.rs
@@ -500,4 +500,266 @@ mod tests {
             ),
         }
     }
+
+    // --- Synthetic two-plugin fixtures ---------------------------------------
+    //
+    // `alpha` and `beta` both declare classes named `Foo` and `Bar` and actions
+    // named `MakeFoo` and `ConsumeFoo`. The class names collide; the script
+    // bodies differ (`blueprint = "FooA"` vs `"FooB"`), which gives each
+    // plugin a different `CustomPredicateBatch` id and therefore different
+    // class/action predicate hashes. This is the exact shape the catalog
+    // collision bug used to mishandle.
+
+    // Each action introduces a private `key` wildcard so the compiled
+    // podlang has a non-empty `private:` clause (an empty one is a syntax
+    // error). The literal blueprint string ("FooA" vs "FooB", "BarA" vs
+    // "BarB") makes the two modules' predicate batches differ.
+
+    const ALPHA_SCRIPT: &str = r#"
+fn MakeFoo(action) {
+    var foo = action.output("Foo");
+    foo.set([["blueprint", "FooA"]]);
+    var key = action.random();
+    foo.update("key", key);
+}
+
+fn ConsumeFoo(action) {
+    var foo = action.input("Foo");
+    var bar = action.output("Bar");
+    bar.set([["blueprint", "BarA"]]);
+    var key = action.random();
+    bar.update("key", key);
+}
+"#;
+
+    const BETA_SCRIPT: &str = r#"
+fn MakeFoo(action) {
+    var foo = action.output("Foo");
+    foo.set([["blueprint", "FooB"]]);
+    var key = action.random();
+    foo.update("key", key);
+}
+
+fn ConsumeFoo(action) {
+    var foo = action.input("Foo");
+    var bar = action.output("Bar");
+    bar.set([["blueprint", "BarB"]]);
+    var key = action.random();
+    bar.update("key", key);
+}
+"#;
+
+    fn synthetic_plugin_bytes(plugin_name: &str, script: &str) -> Vec<u8> {
+        // Manifest with a placeholder hash; we rewrite it to the real
+        // compiled hash below before packing so the catalog's
+        // `load_module_from_src_manifest` validation passes.
+        let template = format!(
+            r#"[plugin]
+name = "{plugin_name}"
+version = "0.1.0"
+module_hash = "0000000000000000000000000000000000000000000000000000000000000000"
+
+[[classes]]
+name = "Foo"
+emoji = "F"
+description = "test class Foo"
+
+[[classes]]
+name = "Bar"
+emoji = "B"
+description = "test class Bar"
+
+[[actions]]
+name = "MakeFoo"
+emoji = "F"
+description = "make a Foo"
+
+[[actions]]
+name = "ConsumeFoo"
+emoji = "B"
+description = "consume a Foo to make a Bar"
+"#
+        );
+        let manifest: sdk::manifest::Manifest =
+            toml::from_str(&template).expect("synthetic manifest parses");
+        let real_hash =
+            pexe::compile_module_hash(&manifest, script).expect("synthetic script compiles");
+        let with_hash =
+            pexe::set_manifest_hash(&template, &real_hash).expect("rewrite module_hash");
+        pexe::pack(&with_hash, script).expect("pack synthetic plugin")
+    }
+
+    fn alpha_beta_catalog() -> PexeCatalog {
+        let alpha = synthetic_plugin_bytes("alpha", ALPHA_SCRIPT);
+        let beta = synthetic_plugin_bytes("beta", BETA_SCRIPT);
+        PexeCatalog::from_bytes(
+            [
+                (PathBuf::from("alpha.pexe"), alpha),
+                (PathBuf::from("beta.pexe"), beta),
+            ],
+            true,
+        )
+        .expect("alpha + beta catalog loads")
+    }
+
+    #[test]
+    fn test_two_plugins_same_class_name_keeps_distinct_hashes() {
+        let catalog = alpha_beta_catalog();
+        let foo_alpha = catalog
+            .get_class("alpha:Foo")
+            .expect("alpha:Foo present");
+        let foo_beta = catalog
+            .get_class("beta:Foo")
+            .expect("beta:Foo present");
+        assert_eq!(foo_alpha.display_name, "Foo");
+        assert_eq!(foo_beta.display_name, "Foo");
+        assert_eq!(foo_alpha.plugin_name, "alpha");
+        assert_eq!(foo_beta.plugin_name, "beta");
+        assert_ne!(
+            foo_alpha.hash, foo_beta.hash,
+            "Foo from two different modules must have different IsFoo predicate hashes"
+        );
+        // And the bare-name collision is reported so the GUI can disambiguate.
+        let collisions = catalog.name_collisions();
+        assert!(
+            collisions.contains(&"Foo".to_string()),
+            "expected name_collisions to include Foo, got {collisions:?}"
+        );
+        assert!(
+            collisions.contains(&"Bar".to_string()),
+            "expected name_collisions to include Bar, got {collisions:?}"
+        );
+        assert!(
+            collisions.contains(&"MakeFoo".to_string()),
+            "expected name_collisions to include MakeFoo, got {collisions:?}"
+        );
+    }
+
+    #[test]
+    fn test_two_plugins_same_action_name_routes_to_correct_module() {
+        let catalog = alpha_beta_catalog();
+
+        // Each plugin's MakeFoo produces an output whose obj["type"] is *that
+        // plugin's* IsFoo predicate hash. If the catalog routed the wrong
+        // script, the type field would be the other plugin's hash.
+        let alpha_foo = catalog
+            .get_class("alpha:Foo")
+            .expect("alpha:Foo present");
+        let beta_foo = catalog.get_class("beta:Foo").expect("beta:Foo present");
+        let alpha_hash = parse_hash_hex(&alpha_foo.hash).expect("alpha:Foo hash parses");
+        let beta_hash = parse_hash_hex(&beta_foo.hash).expect("beta:Foo hash parses");
+
+        let alpha_out = catalog
+            .execute_action(
+                "alpha:MakeFoo".to_string(),
+                dummy_grounding_witness(),
+                vec![],
+            )
+            .expect("alpha:MakeFoo runs");
+        let alpha_type = obj_type_hash_for_test(&alpha_out.obj(0).obj)
+            .expect("alpha output has type");
+        assert_eq!(
+            alpha_type, alpha_hash,
+            "alpha:MakeFoo output type should be alpha's IsFoo hash"
+        );
+
+        let beta_out = catalog
+            .execute_action(
+                "beta:MakeFoo".to_string(),
+                dummy_grounding_witness(),
+                vec![],
+            )
+            .expect("beta:MakeFoo runs");
+        let beta_type = obj_type_hash_for_test(&beta_out.obj(0).obj)
+            .expect("beta output has type");
+        assert_eq!(
+            beta_type, beta_hash,
+            "beta:MakeFoo output type should be beta's IsFoo hash"
+        );
+    }
+
+    #[test]
+    fn test_action_input_class_hash_is_module_scoped() {
+        let catalog = alpha_beta_catalog();
+        let alpha_foo = catalog.get_class("alpha:Foo").unwrap();
+        let beta_foo = catalog.get_class("beta:Foo").unwrap();
+        assert_ne!(alpha_foo.hash, beta_foo.hash);
+
+        let alpha_consume = catalog
+            .get_action("alpha:ConsumeFoo")
+            .expect("alpha:ConsumeFoo present");
+        let beta_consume = catalog
+            .get_action("beta:ConsumeFoo")
+            .expect("beta:ConsumeFoo present");
+
+        assert_eq!(alpha_consume.total_input_class_ids, vec!["alpha:Foo"]);
+        assert_eq!(beta_consume.total_input_class_ids, vec!["beta:Foo"]);
+        assert_eq!(
+            alpha_consume.total_input_class_hashes,
+            vec![alpha_foo.hash.clone()],
+            "alpha:ConsumeFoo's required input hash must be alpha's IsFoo hash"
+        );
+        assert_eq!(
+            beta_consume.total_input_class_hashes,
+            vec![beta_foo.hash.clone()],
+            "beta:ConsumeFoo's required input hash must be beta's IsFoo hash"
+        );
+    }
+
+    #[test]
+    fn test_class_cross_references_are_per_plugin() {
+        // Each class's `produced_by` / `consumed_by` must list only the
+        // actions from its own plugin. If the catalog conflated entries by
+        // bare name, alpha:Foo's `produced_by` could end up containing
+        // `beta:MakeFoo` (and vice versa), which would mis-route GUI
+        // suggestions and feasibility checks.
+        let catalog = alpha_beta_catalog();
+        let alpha_foo = catalog.get_class("alpha:Foo").unwrap();
+        let beta_foo = catalog.get_class("beta:Foo").unwrap();
+
+        assert_eq!(
+            alpha_foo.produced_by,
+            vec!["alpha:MakeFoo".to_string()],
+            "alpha:Foo should only be produced by alpha:MakeFoo"
+        );
+        assert_eq!(
+            alpha_foo.consumed_by,
+            vec!["alpha:ConsumeFoo".to_string()],
+            "alpha:Foo should only be consumed by alpha:ConsumeFoo"
+        );
+        assert_eq!(beta_foo.produced_by, vec!["beta:MakeFoo".to_string()]);
+        assert_eq!(beta_foo.consumed_by, vec!["beta:ConsumeFoo".to_string()]);
+
+        // The predicate source string is also non-empty and looks like an
+        // IsFoo predicate. (The IsFoo body itself is the same shape in both
+        // plugins, so we don't compare it across plugins — the cryptographic
+        // identity is captured by `hash`, not the printed source.)
+        assert!(
+            alpha_foo.predicate_source.contains("IsFoo"),
+            "alpha IsFoo source should mention IsFoo; got {}",
+            alpha_foo.predicate_source
+        );
+        assert!(
+            beta_foo.predicate_source.contains("IsFoo"),
+            "beta IsFoo source should mention IsFoo; got {}",
+            beta_foo.predicate_source
+        );
+    }
+
+    fn dummy_grounding_witness() -> txlib::GroundingWitness {
+        txlib::GroundingWitness::new(
+            txlib::StateRoot::new(
+                1,
+                pod2::middleware::EMPTY_HASH,
+                pod2::middleware::EMPTY_HASH,
+                pod2::middleware::EMPTY_HASH,
+            ),
+            std::collections::HashMap::new(),
+        )
+    }
+
+    fn obj_type_hash_for_test(obj: &pod2::middleware::containers::Dictionary) -> Option<Hash> {
+        let value = obj.get(&pod2::middleware::Key::from("type")).ok()??;
+        Some(Hash(value.raw().0))
+    }
 }

--- a/driver/src/pexe_catalog.rs
+++ b/driver/src/pexe_catalog.rs
@@ -5,15 +5,24 @@
 //! `module_hash`). The compiled module is used to derive action/class hashes and
 //! the podlang source shown in the GUI.
 //!
+//! Classes and actions are keyed by qualified id `<plugin_name>:<name>`. Two
+//! plugins may declare a class or action with the same bare name; they are kept
+//! distinct by qualified id and by their on-chain `Is{class}` predicate hash
+//! (which differs between modules because each module has a unique
+//! `module_hash`). Cross-plugin class references are not supported: an action
+//! must reference classes declared in its own plugin.
+//!
 //! The compiled [`sdk::SdkModule`] is not kept — it holds a `Rc<Engine>` and is
 //! therefore `!Send`. `execute_action` re-loads the script from its stored bytes
 //! on demand, matching the per-call pattern used before.
 
-use std::collections::{BTreeSet, HashMap};
+use std::collections::{BTreeMap, HashMap};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use anyhow::{Context, Result, anyhow};
+use hex::FromHex;
+use pod2::middleware::Hash;
 use sdk::{Sdk, SpendableObject, SpendableObjects, manifest::Manifest};
 use txlib::GroundingWitness;
 
@@ -25,19 +34,28 @@ struct Plugin {
     path: PathBuf,
     manifest: Manifest,
     script: String,
-    podlang_src: String,
-    /// Names of actions this plugin provides (for lookup by name).
-    action_names: Vec<String>,
+    /// Qualified ids (`<plugin>:<action>`) provided by this plugin. Used to
+    /// route `execute_action` back to the originating script bytes.
+    action_ids: Vec<String>,
 }
 
 pub struct PexeCatalog {
     plugins: Vec<Plugin>,
     actions: Vec<ActionSummary>,
-    actions_by_name: HashMap<String, ActionSummary>,
+    actions_by_id: HashMap<String, ActionSummary>,
+    /// Maps qualified action id -> plugin index in `plugins`.
+    action_plugin_idx: HashMap<String, usize>,
     classes: Vec<CatalogClass>,
-    classes_by_name: HashMap<String, CatalogClass>,
+    classes_by_id: HashMap<String, CatalogClass>,
+    classes_by_hash: HashMap<Hash, String>,
+    /// Bare class/action names that appear in more than one plugin.
+    name_collisions: Vec<String>,
     combined_podlang_src: String,
     mock_proofs: bool,
+}
+
+pub fn qualified_id(plugin_name: &str, name: &str) -> String {
+    format!("{plugin_name}:{name}")
 }
 
 impl PexeCatalog {
@@ -61,171 +79,228 @@ impl PexeCatalog {
     }
 
     fn from_plugins(plugins: Vec<Plugin>, mock_proofs: bool) -> Result<Self> {
+        // Reject duplicate plugin.name early: qualified ids are
+        // `<plugin>:<name>` and would otherwise collide silently.
+        let mut seen_plugin_names: HashMap<String, usize> = HashMap::new();
+        for (idx, plugin) in plugins.iter().enumerate() {
+            let name = &plugin.manifest.plugin.name;
+            if let Some(prior) = seen_plugin_names.insert(name.clone(), idx) {
+                return Err(anyhow!(
+                    "duplicate plugin name {name:?}: already registered by {} (other entry at index {prior})",
+                    plugins[prior].path.display(),
+                ));
+            }
+        }
+
         let sdk = Sdk::default();
 
-        // Compile each plugin's module to derive action/class hashes and podlang.
-        // Discard the Rc<SdkModule> afterwards (Rhai Engine is !Send).
         let mut all_actions: Vec<ActionSummary> = Vec::new();
-        let mut all_classes_ordered: Vec<String> = Vec::new();
-        let mut class_meta: HashMap<String, (String, String)> = HashMap::new(); // name -> (emoji, desc)
-        let mut class_hashes: HashMap<String, String> = HashMap::new();
-        let mut action_signatures: HashMap<String, (Vec<String>, Vec<String>)> = HashMap::new();
+        let mut classes_in_order: Vec<CatalogClass> = Vec::new();
         let mut combined_podlang = String::new();
-
+        // Track class hash by bare class name within each plugin so we can
+        // resolve action input/output class refs without consulting other
+        // plugins. (Within one module, bare class names are unique.)
         let mut enriched_plugins: Vec<Plugin> = Vec::with_capacity(plugins.len());
+        let mut bare_name_counts: BTreeMap<String, usize> = BTreeMap::new();
+        let mut action_plugin_idx: HashMap<String, usize> = HashMap::new();
+
         for mut plugin in plugins {
+            let plugin_name = plugin.manifest.plugin.name.clone();
             let module = sdk
                 .load_module_from_src_manifest(&plugin.script, &plugin.manifest)
-                .map_err(|err| {
-                    anyhow!(
-                        "failed to load plugin {}: {err}",
-                        plugin.manifest.plugin.name
-                    )
-                })?;
+                .map_err(|err| anyhow!("failed to load plugin {plugin_name}: {err}"))?;
             let podlang_src = module.podlang_src().to_string();
             if !combined_podlang.is_empty() {
                 combined_podlang.push_str("\n// ---\n");
             }
-            combined_podlang.push_str(&format!(
-                "// plugin: {}\n{}",
-                plugin.manifest.plugin.name, podlang_src
-            ));
-            plugin.podlang_src = podlang_src;
+            combined_podlang.push_str(&format!("// plugin: {plugin_name}\n{podlang_src}"));
 
-            // Capture class metadata from the manifest.
-            for class in &plugin.manifest.classes {
-                if !class_meta.contains_key(&class.name) {
-                    class_meta.insert(
-                        class.name.clone(),
-                        (class.emoji.clone(), class.description.clone()),
-                    );
-                }
+            // Per-plugin class hash map. Module-scoped: a `Wood` class in
+            // another plugin has a different IsWood predicate hash and lives
+            // in a different `class_hashes` map below.
+            let mut class_hashes: HashMap<String, Hash> = HashMap::new();
+            for class in module.classes() {
+                let hash = module.class_hash(&class.name).ok_or_else(|| {
+                    anyhow!(
+                        "plugin {plugin_name}: class {} has no compiled hash",
+                        class.name
+                    )
+                })?;
+                class_hashes.insert(class.name.clone(), hash);
             }
 
-            // Compute hashes + signatures from the compiled module, and turn
-            // actions into ActionSummary rows.
+            // Build CatalogClass entries from this plugin's classes.
+            let class_meta_by_name: HashMap<&str, &sdk::manifest::Class> = plugin
+                .manifest
+                .classes
+                .iter()
+                .map(|c| (c.name.as_str(), c))
+                .collect();
+
+            for class in module.classes() {
+                let bare = &class.name;
+                *bare_name_counts.entry(bare.clone()).or_insert(0) += 1;
+                let qid = qualified_id(&plugin_name, bare);
+                let class_hash = class_hashes[bare];
+                let meta = class_meta_by_name.get(bare.as_str());
+                let predicate_source = extract_predicate(&podlang_src, &format!("Is{bare}"))
+                    .unwrap_or_else(|| format!("Is{bare}(state) = OR(...)"));
+                classes_in_order.push(CatalogClass {
+                    id: qid,
+                    display_name: bare.clone(),
+                    plugin_name: plugin_name.clone(),
+                    emoji: meta.map_or("📦", |m| m.emoji.as_str()).to_string(),
+                    hash: format!("{:#}", class_hash),
+                    description: meta
+                        .map_or("Unknown class object", |m| m.description.as_str())
+                        .to_string(),
+                    produced_by: Vec::new(), // filled in second pass
+                    consumed_by: Vec::new(), // filled in second pass
+                    predicate_source,
+                });
+            }
+
+            // Build ActionSummary rows. Each input/output class is resolved
+            // against this plugin's own class set; cross-plugin references
+            // are rejected. Hidden actions are still recorded so their
+            // qualified id routes back to this plugin via execute_action.
             let action_meta_by_name: HashMap<&str, &sdk::manifest::Action> = plugin
                 .manifest
                 .actions
                 .iter()
                 .map(|a| (a.name.as_str(), a))
                 .collect();
-
-            plugin.action_names = module.actions().iter().map(|a| a.name.clone()).collect();
+            let plugin_idx = enriched_plugins.len();
+            let mut plugin_action_ids: Vec<String> = Vec::new();
 
             for action in module.actions() {
-                let name = action.name.as_str();
-                let total_input_classes: Vec<String> =
-                    action.total_inputs().map(|r| r.class.clone()).collect();
-                let total_output_classes: Vec<String> =
-                    action.total_outputs().map(|r| r.class.clone()).collect();
-                action_signatures.insert(
-                    name.to_string(),
-                    (total_input_classes.clone(), total_output_classes.clone()),
-                );
+                let bare = action.name.clone();
+                *bare_name_counts.entry(bare.clone()).or_insert(0) += 1;
+                let qid = qualified_id(&plugin_name, &bare);
+                plugin_action_ids.push(qid.clone());
+                if let Some(prior) = action_plugin_idx.insert(qid.clone(), plugin_idx) {
+                    return Err(anyhow!(
+                        "internal: duplicate action qualified id {qid} (already mapped to plugin idx {prior})"
+                    ));
+                }
 
-                let meta = action_meta_by_name.get(name);
+                let meta = action_meta_by_name.get(bare.as_str());
+                let resolve_class = |class_name: &str| -> Result<(String, String, String)> {
+                    let hash = class_hashes.get(class_name).ok_or_else(|| {
+                        anyhow!(
+                            "plugin {plugin_name}: action {bare} references class {class_name:?} \
+                             which is not declared in this plugin (cross-plugin class \
+                             references are not supported yet)"
+                        )
+                    })?;
+                    Ok((
+                        qualified_id(&plugin_name, class_name),
+                        class_name.to_string(),
+                        format!("{:#}", hash),
+                    ))
+                };
+
+                let mut total_input_class_ids = Vec::new();
+                let mut total_input_class_names = Vec::new();
+                let mut total_input_class_hashes = Vec::new();
+                for r in action.total_inputs() {
+                    let (id, name, hash) = resolve_class(&r.class)?;
+                    total_input_class_ids.push(id);
+                    total_input_class_names.push(name);
+                    total_input_class_hashes.push(hash);
+                }
+
+                let mut total_output_class_ids = Vec::new();
+                let mut total_output_class_names = Vec::new();
+                let mut total_output_class_hashes = Vec::new();
+                for r in action.total_outputs() {
+                    let (id, name, hash) = resolve_class(&r.class)?;
+                    total_output_class_ids.push(id);
+                    total_output_class_names.push(name);
+                    total_output_class_hashes.push(hash);
+                }
+
                 if meta.is_some_and(|m| m.hidden) {
                     continue;
                 }
+
                 let action_hash = module
-                    .action_hash(name)
+                    .action_hash(&bare)
                     .map(|h| format!("{:#}", h))
                     .unwrap_or_default();
                 all_actions.push(ActionSummary {
-                    id: name.to_string(),
+                    id: qid,
+                    display_name: bare.clone(),
+                    plugin_name: plugin_name.clone(),
                     emoji: meta.map_or("⚙️", |m| m.emoji.as_str()).to_string(),
                     hash: action_hash,
-                    total_input_class_hashes: Vec::new(), // filled in a second pass
                     description: meta
                         .map_or("Pexe action", |m| m.description.as_str())
                         .to_string(),
-                    total_input_classes,
-                    total_output_classes,
+                    total_input_class_ids,
+                    total_input_class_names,
+                    total_input_class_hashes,
+                    total_output_class_ids,
+                    total_output_class_names,
+                    total_output_class_hashes,
                 });
             }
 
-            for class in module.classes() {
-                let name = &class.name;
-                if !all_classes_ordered.contains(name) {
-                    all_classes_ordered.push(name.clone());
-                }
-                let hash = module
-                    .class_hash(name)
-                    .map(|h| format!("{:#}", h))
-                    .unwrap_or_default();
-                class_hashes.insert(name.clone(), hash);
-            }
-
+            plugin.action_ids = plugin_action_ids;
             enriched_plugins.push(plugin);
         }
 
-        // Second pass: fill in input_class_hashes now that every class hash is known.
-        for action in &mut all_actions {
-            action.total_input_class_hashes = action
-                .total_input_classes
+        // Second pass: fill produced_by / consumed_by per class using qualified ids.
+        for class in classes_in_order.iter_mut() {
+            class.produced_by = all_actions
                 .iter()
-                .map(|c| class_hashes.get(c).cloned().unwrap_or_default())
+                .filter(|a| a.total_output_class_ids.contains(&class.id))
+                .map(|a| a.id.clone())
+                .collect();
+            class.consumed_by = all_actions
+                .iter()
+                .filter(|a| a.total_input_class_ids.contains(&class.id))
+                .map(|a| a.id.clone())
                 .collect();
         }
 
-        // Ensure manifest-declared classes that weren't seen via the compiled
-        // module (shouldn't happen today, but be defensive) still show up.
-        for class_name in class_meta.keys() {
-            if !all_classes_ordered.contains(class_name) {
-                all_classes_ordered.push(class_name.clone());
-            }
-        }
-        // Deterministic order: alphabetical for the GUI.
-        let class_names_sorted: BTreeSet<String> = all_classes_ordered.into_iter().collect();
+        // Deterministic GUI order: sort by display name, then plugin.
+        classes_in_order.sort_by(|a, b| {
+            a.display_name
+                .cmp(&b.display_name)
+                .then_with(|| a.plugin_name.cmp(&b.plugin_name))
+        });
 
-        let classes: Vec<CatalogClass> = class_names_sorted
-            .into_iter()
-            .map(|class_name| {
-                let (emoji, description) = class_meta
-                    .get(&class_name)
-                    .cloned()
-                    .unwrap_or_else(|| ("📦".to_string(), "Unknown class object".to_string()));
-                let produced_by = all_actions
-                    .iter()
-                    .filter(|a| a.total_output_classes.contains(&class_name))
-                    .map(|a| a.id.clone())
-                    .collect();
-                let consumed_by = all_actions
-                    .iter()
-                    .filter(|a| a.total_input_classes.contains(&class_name))
-                    .map(|a| a.id.clone())
-                    .collect();
-                let predicate_source =
-                    extract_predicate(&combined_podlang, &format!("Is{class_name}"))
-                        .unwrap_or_else(|| format!("Is{class_name}(state) = OR(...)"));
-                CatalogClass {
-                    name: class_name.clone(),
-                    emoji,
-                    hash: class_hashes.get(&class_name).cloned().unwrap_or_default(),
-                    description,
-                    produced_by,
-                    consumed_by,
-                    predicate_source,
-                }
-            })
-            .collect();
-
-        let actions_by_name: HashMap<String, ActionSummary> = all_actions
+        let actions_by_id: HashMap<String, ActionSummary> = all_actions
             .iter()
             .map(|a| (a.id.clone(), a.clone()))
             .collect();
-        let classes_by_name: HashMap<String, CatalogClass> = classes
+        let classes_by_id: HashMap<String, CatalogClass> = classes_in_order
             .iter()
-            .map(|c| (c.name.clone(), c.clone()))
+            .map(|c| (c.id.clone(), c.clone()))
+            .collect();
+        let classes_by_hash: HashMap<Hash, String> = classes_in_order
+            .iter()
+            .filter_map(|c| {
+                parse_hash_hex(&c.hash)
+                    .ok()
+                    .map(|hash| (hash, c.id.clone()))
+            })
+            .collect();
+        let name_collisions: Vec<String> = bare_name_counts
+            .into_iter()
+            .filter_map(|(name, count)| (count > 1).then_some(name))
             .collect();
 
         Ok(Self {
             plugins: enriched_plugins,
             actions: all_actions,
-            actions_by_name,
-            classes,
-            classes_by_name,
+            actions_by_id,
+            action_plugin_idx,
+            classes: classes_in_order,
+            classes_by_id,
+            classes_by_hash,
+            name_collisions,
             combined_podlang_src: combined_podlang,
             mock_proofs,
         })
@@ -233,12 +308,6 @@ impl PexeCatalog {
 
     pub fn plugin_count(&self) -> usize {
         self.plugins.len()
-    }
-
-    fn find_plugin_for(&self, action_id: &str) -> Option<&Plugin> {
-        self.plugins
-            .iter()
-            .find(|p| p.action_names.iter().any(|n| n == action_id))
     }
 }
 
@@ -248,15 +317,24 @@ impl ActionCatalog for PexeCatalog {
     }
 
     fn get_action(&self, action_id: &str) -> Option<ActionSummary> {
-        self.actions_by_name.get(action_id).cloned()
+        self.actions_by_id.get(action_id).cloned()
     }
 
     fn list_classes(&self) -> Vec<CatalogClass> {
         self.classes.clone()
     }
 
-    fn get_class(&self, class_name: &str) -> Option<CatalogClass> {
-        self.classes_by_name.get(class_name).cloned()
+    fn get_class(&self, class_id: &str) -> Option<CatalogClass> {
+        self.classes_by_id.get(class_id).cloned()
+    }
+
+    fn get_class_by_hash(&self, class_hash: &Hash) -> Option<CatalogClass> {
+        let id = self.classes_by_hash.get(class_hash)?;
+        self.classes_by_id.get(id).cloned()
+    }
+
+    fn name_collisions(&self) -> Vec<String> {
+        self.name_collisions.clone()
     }
 
     fn execute_action(
@@ -265,9 +343,13 @@ impl ActionCatalog for PexeCatalog {
         grounding_witness: GroundingWitness,
         inputs: Vec<SpendableObject>,
     ) -> Result<SpendableObjects> {
-        let plugin = self
-            .find_plugin_for(&action_id)
+        let plugin_idx = *self
+            .action_plugin_idx
+            .get(&action_id)
             .ok_or_else(|| anyhow!("no plugin provides action {action_id}"))?;
+        let plugin = &self.plugins[plugin_idx];
+        let bare_name = bare_action_name(&action_id, &plugin.manifest.plugin.name)
+            .ok_or_else(|| anyhow!("invalid qualified action id: {action_id}"))?;
         let sdk = Sdk::default();
         let module = sdk
             .load_module_from_src_manifest(&plugin.script, &plugin.manifest)
@@ -278,7 +360,7 @@ impl ActionCatalog for PexeCatalog {
                 )
             })?;
         let executor = module.executor(self.mock_proofs, Arc::new(grounding_witness));
-        Ok(executor.action(&action_id, inputs)?)
+        Ok(executor.action(bare_name, inputs)?)
     }
 
     fn generated_podlang(&self) -> Option<String> {
@@ -317,9 +399,25 @@ fn load_plugin_from_bytes(path: PathBuf, bytes: &[u8]) -> Result<Plugin> {
         path,
         manifest,
         script,
-        podlang_src: String::new(),
-        action_names: Vec::new(),
+        action_ids: Vec::new(),
     })
+}
+
+fn bare_action_name<'a>(qualified_id: &'a str, plugin_name: &str) -> Option<&'a str> {
+    let prefix_len = plugin_name.len();
+    if qualified_id.len() <= prefix_len + 1 {
+        return None;
+    }
+    let (head, rest) = qualified_id.split_at(prefix_len);
+    if head != plugin_name || !rest.starts_with(':') {
+        return None;
+    }
+    Some(&rest[1..])
+}
+
+fn parse_hash_hex(s: &str) -> Result<Hash> {
+    let trimmed = s.strip_prefix("0x").unwrap_or(s);
+    Hash::from_hex(trimmed).map_err(|err| anyhow!("invalid hash hex {s:?}: {err}"))
 }
 
 #[cfg(test)]
@@ -346,16 +444,16 @@ mod tests {
     fn test_pexe_catalog_hides_internal_actions() {
         let catalog = test_catalog();
         let action_ids: Vec<_> = catalog.list_actions().into_iter().map(|a| a.id).collect();
-        assert!(action_ids.contains(&"CraftWood".to_string()));
-        assert!(!action_ids.contains(&"UseWoodPick".to_string()));
+        assert!(action_ids.contains(&"craft-basics:CraftWood".to_string()));
+        assert!(!action_ids.contains(&"craft-basics:UseWoodPick".to_string()));
     }
 
     #[test]
     fn test_pexe_catalog_lists_classes() {
         let catalog = test_catalog();
-        let class_names: Vec<_> = catalog.list_classes().into_iter().map(|c| c.name).collect();
-        assert!(class_names.contains(&"Log".to_string()));
-        assert!(class_names.contains(&"WoodPick".to_string()));
+        let class_ids: Vec<_> = catalog.list_classes().into_iter().map(|c| c.id).collect();
+        assert!(class_ids.contains(&"craft-basics:Log".to_string()));
+        assert!(class_ids.contains(&"craft-basics:WoodPick".to_string()));
     }
 
     #[test]
@@ -364,5 +462,42 @@ mod tests {
         assert_eq!(catalog.plugin_count(), 0);
         assert!(catalog.list_actions().is_empty());
         assert!(catalog.generated_podlang().is_none());
+    }
+
+    #[test]
+    fn test_get_class_by_hash_round_trip() {
+        let catalog = test_catalog();
+        let log = catalog
+            .get_class("craft-basics:Log")
+            .expect("Log class present");
+        let by_hash = parse_hash_hex(&log.hash)
+            .ok()
+            .and_then(|h| catalog.get_class_by_hash(&h))
+            .expect("class hash resolves back");
+        assert_eq!(by_hash.id, log.id);
+    }
+
+    #[test]
+    fn test_no_collisions_for_single_plugin() {
+        let catalog = test_catalog();
+        assert!(catalog.name_collisions().is_empty());
+    }
+
+    #[test]
+    fn test_duplicate_plugin_name_rejected() {
+        let result = PexeCatalog::from_bytes(
+            [
+                (PathBuf::from("a.pexe"), test_plugin_bytes()),
+                (PathBuf::from("b.pexe"), test_plugin_bytes()),
+            ],
+            true,
+        );
+        match result {
+            Ok(_) => panic!("expected duplicate-plugin-name error, but load succeeded"),
+            Err(err) => assert!(
+                err.to_string().contains("duplicate plugin name"),
+                "expected duplicate-plugin-name error, got: {err}"
+            ),
+        }
     }
 }

--- a/driver/src/pexe_catalog.rs
+++ b/driver/src/pexe_catalog.rs
@@ -605,12 +605,8 @@ description = "consume a Foo to make a Bar"
     #[test]
     fn test_two_plugins_same_class_name_keeps_distinct_hashes() {
         let catalog = alpha_beta_catalog();
-        let foo_alpha = catalog
-            .get_class("alpha:Foo")
-            .expect("alpha:Foo present");
-        let foo_beta = catalog
-            .get_class("beta:Foo")
-            .expect("beta:Foo present");
+        let foo_alpha = catalog.get_class("alpha:Foo").expect("alpha:Foo present");
+        let foo_beta = catalog.get_class("beta:Foo").expect("beta:Foo present");
         assert_eq!(foo_alpha.display_name, "Foo");
         assert_eq!(foo_beta.display_name, "Foo");
         assert_eq!(foo_alpha.plugin_name, "alpha");
@@ -642,9 +638,7 @@ description = "consume a Foo to make a Bar"
         // Each plugin's MakeFoo produces an output whose obj["type"] is *that
         // plugin's* IsFoo predicate hash. If the catalog routed the wrong
         // script, the type field would be the other plugin's hash.
-        let alpha_foo = catalog
-            .get_class("alpha:Foo")
-            .expect("alpha:Foo present");
+        let alpha_foo = catalog.get_class("alpha:Foo").expect("alpha:Foo present");
         let beta_foo = catalog.get_class("beta:Foo").expect("beta:Foo present");
         let alpha_hash = parse_hash_hex(&alpha_foo.hash).expect("alpha:Foo hash parses");
         let beta_hash = parse_hash_hex(&beta_foo.hash).expect("beta:Foo hash parses");
@@ -656,8 +650,8 @@ description = "consume a Foo to make a Bar"
                 vec![],
             )
             .expect("alpha:MakeFoo runs");
-        let alpha_type = obj_type_hash_for_test(&alpha_out.obj(0).obj)
-            .expect("alpha output has type");
+        let alpha_type =
+            obj_type_hash_for_test(&alpha_out.obj(0).obj).expect("alpha output has type");
         assert_eq!(
             alpha_type, alpha_hash,
             "alpha:MakeFoo output type should be alpha's IsFoo hash"
@@ -670,8 +664,7 @@ description = "consume a Foo to make a Bar"
                 vec![],
             )
             .expect("beta:MakeFoo runs");
-        let beta_type = obj_type_hash_for_test(&beta_out.obj(0).obj)
-            .expect("beta output has type");
+        let beta_type = obj_type_hash_for_test(&beta_out.obj(0).obj).expect("beta output has type");
         assert_eq!(
             beta_type, beta_hash,
             "beta:MakeFoo output type should be beta's IsFoo hash"

--- a/driver/src/qualified_name.rs
+++ b/driver/src/qualified_name.rs
@@ -1,0 +1,134 @@
+//! `QualifiedName` is the canonical handle for both classes and actions
+//! across the driver. It carries the originating plugin and the bare name as
+//! two separate fields so callers can reason about them directly without
+//! having to remember to keep `(plugin_name, name, id)` triples in sync. The
+//! string presentation `<plugin>::<name>` matches podlang's namespaced
+//! predicates and is produced by [`QualifiedName::id`] when the GUI or a
+//! human reader needs a single string.
+
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+/// A name scoped to a plugin. Used for both classes and actions — both have
+/// the same shape — so `QualifiedName` shows up as the field type in
+/// summaries (`ObjectSummary::class`, `ActionSummary::action`, …).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[serde(rename_all = "camelCase")]
+pub struct QualifiedName {
+    pub plugin_name: String,
+    pub name: String,
+}
+
+impl QualifiedName {
+    pub fn new(plugin_name: impl Into<String>, name: impl Into<String>) -> Self {
+        Self {
+            plugin_name: plugin_name.into(),
+            name: name.into(),
+        }
+    }
+
+    /// Canonical string form `<plugin>::<name>` — matches podlang's
+    /// namespaced-predicate syntax and is what the GUI shows the user.
+    pub fn id(&self) -> String {
+        format!("{}::{}", self.plugin_name, self.name)
+    }
+
+    /// Parse the canonical string form. Errors if the input does not
+    /// contain `::` or if either component is empty.
+    pub fn parse(s: &str) -> Result<Self, String> {
+        let (plugin, name) = s
+            .split_once("::")
+            .ok_or_else(|| format!("invalid qualified name {s:?}: missing '::' separator"))?;
+        if plugin.is_empty() {
+            return Err(format!("invalid qualified name {s:?}: empty plugin"));
+        }
+        if name.is_empty() {
+            return Err(format!("invalid qualified name {s:?}: empty name"));
+        }
+        Ok(Self {
+            plugin_name: plugin.to_string(),
+            name: name.to_string(),
+        })
+    }
+
+    /// Lowercase, filename-safe prefix for `.dobj` files. Plugin names are
+    /// validated against `[A-Za-z0-9_-]` at catalog load, but class names
+    /// come from arbitrary rhai literals and could in principle contain
+    /// path-significant characters — anything outside `[a-z0-9_-]` is
+    /// replaced with `_` so the result stays inside a single filename
+    /// component (no path traversal, no separator escapes).
+    pub fn file_prefix(&self) -> String {
+        let mut out = String::with_capacity(self.plugin_name.len() + 2 + self.name.len());
+        push_safe_lower(&mut out, &self.plugin_name);
+        out.push_str("__");
+        push_safe_lower(&mut out, &self.name);
+        out
+    }
+}
+
+impl fmt::Display for QualifiedName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}::{}", self.plugin_name, self.name)
+    }
+}
+
+fn push_safe_lower(out: &mut String, s: &str) {
+    for ch in s.chars() {
+        let lower = ch.to_ascii_lowercase();
+        if lower.is_ascii_alphanumeric() || lower == '-' || lower == '_' {
+            out.push(lower);
+        } else {
+            out.push('_');
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn id_round_trips_via_parse() {
+        let q = QualifiedName::new("craft-basics", "WoodPick");
+        assert_eq!(q.id(), "craft-basics::WoodPick");
+        assert_eq!(QualifiedName::parse(&q.id()).unwrap(), q);
+    }
+
+    #[test]
+    fn parse_rejects_missing_separator() {
+        assert!(QualifiedName::parse("craft-basics-Wood").is_err());
+    }
+
+    #[test]
+    fn parse_rejects_empty_components() {
+        assert!(QualifiedName::parse("::Wood").is_err());
+        assert!(QualifiedName::parse("craft-basics::").is_err());
+    }
+
+    #[test]
+    fn file_prefix_is_path_safe_for_normal_names() {
+        let q = QualifiedName::new("craft-basics", "Wood");
+        assert_eq!(q.file_prefix(), "craft-basics__wood");
+    }
+
+    #[test]
+    fn file_prefix_sanitizes_path_chars_in_name() {
+        let q = QualifiedName::new("plugin", "weird/class");
+        assert_eq!(q.file_prefix(), "plugin__weird_class");
+        let q = QualifiedName::new("plugin", "..\\Stone");
+        assert_eq!(q.file_prefix(), "plugin_____stone");
+        let q = QualifiedName::new("p", "c");
+        let p = q.file_prefix();
+        assert!(!p.contains(':') && !p.contains('/') && !p.contains('\\'));
+    }
+
+    #[test]
+    fn serde_round_trips_as_object() {
+        let q = QualifiedName::new("craft-basics", "Wood");
+        let json = serde_json::to_string(&q).unwrap();
+        assert_eq!(json, r#"{"pluginName":"craft-basics","name":"Wood"}"#);
+        let back: QualifiedName = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, q);
+    }
+}

--- a/driver/src/qualified_name.rs
+++ b/driver/src/qualified_name.rs
@@ -52,12 +52,15 @@ impl QualifiedName {
         })
     }
 
-    /// Lowercase, filename-safe prefix for `.dobj` files. Plugin names are
-    /// validated against `[A-Za-z0-9_-]` at catalog load, but class names
-    /// come from arbitrary rhai literals and could in principle contain
-    /// path-significant characters — anything outside `[a-z0-9_-]` is
-    /// replaced with `_` so the result stays inside a single filename
-    /// component (no path traversal, no separator escapes).
+    /// Lowercase, filename-safe prefix for `.dobj` files. Both plugin
+    /// names (validated at catalog load) and class names (validated by
+    /// the SDK at module compile time) are already restricted to
+    /// `[A-Za-z0-9_-]`, so the only normalization this needs to do is
+    /// lowercase. The fallback to `_` for any non-allowlisted byte stays
+    /// in place as a defense-in-depth measure: if a future SDK regression
+    /// or an entirely different catalog implementation ever feeds in a
+    /// stray path separator, written files will still be confined to a
+    /// single filename component.
     pub fn file_prefix(&self) -> String {
         let mut out = String::with_capacity(self.plugin_name.len() + 2 + self.name.len());
         push_safe_lower(&mut out, &self.plugin_name);

--- a/driver/src/tests.rs
+++ b/driver/src/tests.rs
@@ -81,13 +81,17 @@ fn make_input_record(file_name: &str) -> (ObjectFileEntry, DriverDeps) {
     ensure_extra_pod_deserializers_registered();
     let catalog = make_catalog();
     let outputs = catalog
-        .execute_action("FindLog".to_string(), dummy_grounding_witness(), vec![])
+        .execute_action(
+            "craft-basics:FindLog".to_string(),
+            dummy_grounding_witness(),
+            vec![],
+        )
         .unwrap();
     let spendable = outputs.obj(0);
     let id = format!("{:#}", spendable.obj.commitment());
     let record = ObjectRecord {
         id,
-        class_name: "Log".to_string(),
+        class_id: "craft-basics:Log".to_string(),
         status: ObjectStatus::Live,
         tx_hash: None,
         pod: spendable.pod,
@@ -248,15 +252,13 @@ fn test_list_actions_filters_by_input_class() {
     let driver = Driver::open_default().unwrap();
     let filtered = driver
         .list_actions(Some(&ActionQuery {
-            input_class: Some("Wood".to_string()),
+            input_class_id: Some("craft-basics:Wood".to_string()),
             ..ActionQuery::default()
         }))
         .unwrap();
-    assert!(
-        filtered
-            .iter()
-            .all(|action| action.total_input_classes.contains(&"Wood".to_string()))
-    );
+    assert!(filtered.iter().all(|action| action
+        .total_input_class_ids
+        .contains(&"craft-basics:Wood".to_string())));
 }
 
 #[test]
@@ -273,7 +275,7 @@ fn test_execute_rolls_back_on_relayer_submit_failure() {
 
     let err = driver
         .execute(ExecuteActionInput {
-            action_id: "CraftWood".to_string(),
+            action_id: "craft-basics:CraftWood".to_string(),
             input_objects: vec![ObjectSelector::FileName("log_1.dobj".to_string())],
         })
         .unwrap_err();
@@ -309,7 +311,7 @@ fn test_execute_keeps_files_after_relayer_accepts() {
 
     let err = driver
         .execute(ExecuteActionInput {
-            action_id: "CraftWood".to_string(),
+            action_id: "craft-basics:CraftWood".to_string(),
             input_objects: vec![ObjectSelector::FileName("log_1.dobj".to_string())],
         })
         .unwrap_err();

--- a/driver/src/tests.rs
+++ b/driver/src/tests.rs
@@ -266,10 +266,15 @@ fn test_list_actions_filters_by_input_class() {
             ..ActionQuery::default()
         }))
         .unwrap();
-    assert!(!filtered.is_empty(), "expected at least one Wood-consuming action");
-    assert!(filtered.iter().all(|action| action
-        .total_input_class_ids
-        .contains(&"craft-basics:Wood".to_string())));
+    assert!(
+        !filtered.is_empty(),
+        "expected at least one Wood-consuming action"
+    );
+    assert!(filtered.iter().all(|action| {
+        action
+            .total_input_class_ids
+            .contains(&"craft-basics:Wood".to_string())
+    }));
 }
 
 #[test]

--- a/driver/src/tests.rs
+++ b/driver/src/tests.rs
@@ -19,6 +19,7 @@ use crate::object_store::{
     ObjectFileEntry, ensure_store_dirs, load_object_files, write_object_file,
 };
 use crate::pexe_catalog::{PexeCatalog, test_plugin_bytes};
+use crate::qualified_name::QualifiedName;
 use crate::{ActionQuery, DriverPaths, ExecuteActionInput, ObjectSelector};
 
 fn temp_paths() -> DriverPaths {
@@ -77,21 +78,21 @@ fn state_root(state: &TestState) -> StateRoot {
     )
 }
 
+fn craft_basics(name: &str) -> QualifiedName {
+    QualifiedName::new("craft-basics", name)
+}
+
 fn make_input_record(file_name: &str) -> (ObjectFileEntry, DriverDeps) {
     ensure_extra_pod_deserializers_registered();
     let catalog = make_catalog();
     let outputs = catalog
-        .execute_action(
-            "craft-basics::FindLog".to_string(),
-            dummy_grounding_witness(),
-            vec![],
-        )
+        .execute_action(craft_basics("FindLog"), dummy_grounding_witness(), vec![])
         .unwrap();
     let spendable = outputs.obj(0);
     let id = format!("{:#}", spendable.obj.commitment());
     let record = ObjectRecord {
         id,
-        class_id: "craft-basics::Log".to_string(),
+        class: craft_basics("Log"),
         status: ObjectStatus::Live,
         tx_hash: None,
         pod: spendable.pod,
@@ -260,9 +261,10 @@ fn test_list_actions_filters_by_input_class() {
         payload_builder: Arc::new(MockPayloadBuilder),
     };
     let driver = Driver::open(paths, deps).unwrap();
+    let wood = craft_basics("Wood");
     let filtered = driver
         .list_actions(Some(&ActionQuery {
-            input_class_id: Some("craft-basics::Wood".to_string()),
+            input_class: Some(wood.clone()),
             ..ActionQuery::default()
         }))
         .unwrap();
@@ -270,12 +272,11 @@ fn test_list_actions_filters_by_input_class() {
         !filtered.is_empty(),
         "expected at least one Wood-consuming action"
     );
-    assert!(filtered.iter().all(|action| {
-        action
-            .total_inputs
+    assert!(
+        filtered
             .iter()
-            .any(|r| r.id == "craft-basics::Wood")
-    }));
+            .all(|action| action.total_inputs.iter().any(|r| r.class == wood))
+    );
 }
 
 #[test]
@@ -292,7 +293,7 @@ fn test_execute_rolls_back_on_relayer_submit_failure() {
 
     let err = driver
         .execute(ExecuteActionInput {
-            action_id: "craft-basics::CraftWood".to_string(),
+            action: craft_basics("CraftWood"),
             input_objects: vec![ObjectSelector::FileName("log_1.dobj".to_string())],
         })
         .unwrap_err();
@@ -314,7 +315,7 @@ fn test_execute_rolls_back_on_relayer_submit_failure() {
     assert_eq!(output.record.status, ObjectStatus::Unknown);
 }
 
-/// A `.dobj` whose `class_id` text matches what an action expects must STILL
+/// A `.dobj` whose `class` text matches what an action expects must STILL
 /// be rejected when its on-chain `obj["type"]` predicate hash disagrees. This
 /// is the regression test for the original collision bug: if two plugins
 /// declared a class `Wood`, the bare-name check used to let the wrong
@@ -323,10 +324,10 @@ fn test_execute_rolls_back_on_relayer_submit_failure() {
 #[test]
 fn test_execute_rejects_class_hash_mismatch_with_matching_class_id() {
     // A real Log object (obj["type"] = IsLog hash) written to disk with a
-    // forged class_id of "craft-basics::Wood". CraftSticks consumes a Wood,
-    // so the bare-id check passes; the cryptographic hash check then fires.
+    // forged class of "craft-basics::Wood". CraftSticks consumes a Wood, so
+    // the qualified-name check passes; the cryptographic hash check then fires.
     let (mut entry, deps) = make_input_record("forged_wood.dobj");
-    entry.record.class_id = "craft-basics::Wood".to_string();
+    entry.record.class = craft_basics("Wood");
     let paths = temp_paths();
     ensure_store_dirs(&paths).unwrap();
     write_object_file(&paths, &entry.record, &entry.file_name).unwrap();
@@ -334,7 +335,7 @@ fn test_execute_rejects_class_hash_mismatch_with_matching_class_id() {
 
     let err = driver
         .execute(ExecuteActionInput {
-            action_id: "craft-basics::CraftSticks".to_string(),
+            action: craft_basics("CraftSticks"),
             input_objects: vec![ObjectSelector::FileName("forged_wood.dobj".to_string())],
         })
         .unwrap_err();
@@ -359,7 +360,7 @@ fn test_execute_keeps_files_after_relayer_accepts() {
 
     let err = driver
         .execute(ExecuteActionInput {
-            action_id: "craft-basics::CraftWood".to_string(),
+            action: craft_basics("CraftWood"),
             input_objects: vec![ObjectSelector::FileName("log_1.dobj".to_string())],
         })
         .unwrap_err();

--- a/driver/src/tests.rs
+++ b/driver/src/tests.rs
@@ -249,13 +249,24 @@ impl RelayerClient for MockRelayer {
 
 #[test]
 fn test_list_actions_filters_by_input_class() {
-    let driver = Driver::open_default().unwrap();
+    // Use the in-memory test catalog so the assertion does not depend on
+    // whatever pexe plugins happen to live under ~/.dobj/actions/.
+    let paths = temp_paths();
+    ensure_store_dirs(&paths).unwrap();
+    let deps = DriverDeps {
+        catalog: Arc::new(make_catalog()),
+        synchronizer: Arc::new(MockSynchronizer::default()),
+        relayer: Arc::new(MockRelayer::default()),
+        payload_builder: Arc::new(MockPayloadBuilder),
+    };
+    let driver = Driver::open(paths, deps).unwrap();
     let filtered = driver
         .list_actions(Some(&ActionQuery {
             input_class_id: Some("craft-basics:Wood".to_string()),
             ..ActionQuery::default()
         }))
         .unwrap();
+    assert!(!filtered.is_empty(), "expected at least one Wood-consuming action");
     assert!(filtered.iter().all(|action| action
         .total_input_class_ids
         .contains(&"craft-basics:Wood".to_string())));

--- a/driver/src/tests.rs
+++ b/driver/src/tests.rs
@@ -308,6 +308,37 @@ fn test_execute_rolls_back_on_relayer_submit_failure() {
     assert_eq!(output.record.status, ObjectStatus::Unknown);
 }
 
+/// A `.dobj` whose `class_id` text matches what an action expects must STILL
+/// be rejected when its on-chain `obj["type"]` predicate hash disagrees. This
+/// is the regression test for the original collision bug: if two plugins
+/// declared a class `Wood`, the bare-name check used to let the wrong
+/// `IsWood@A` object satisfy `IsWood@B`'s requirement and proof generation
+/// would burn minutes before the prover failed.
+#[test]
+fn test_execute_rejects_class_hash_mismatch_with_matching_class_id() {
+    // A real Log object (obj["type"] = IsLog hash) written to disk with a
+    // forged class_id of "craft-basics:Wood". CraftSticks consumes a Wood,
+    // so the bare-id check passes; the cryptographic hash check then fires.
+    let (mut entry, deps) = make_input_record("forged_wood.dobj");
+    entry.record.class_id = "craft-basics:Wood".to_string();
+    let paths = temp_paths();
+    ensure_store_dirs(&paths).unwrap();
+    write_object_file(&paths, &entry.record, &entry.file_name).unwrap();
+    let driver = Driver::open(paths.clone(), deps).unwrap();
+
+    let err = driver
+        .execute(ExecuteActionInput {
+            action_id: "craft-basics:CraftSticks".to_string(),
+            input_objects: vec![ObjectSelector::FileName("forged_wood.dobj".to_string())],
+        })
+        .unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("class hash mismatch"),
+        "expected hash-mismatch error, got: {msg}"
+    );
+}
+
 #[test]
 fn test_execute_keeps_files_after_relayer_accepts() {
     let (entry, mut deps) = make_input_record("log_1.dobj");

--- a/driver/src/tests.rs
+++ b/driver/src/tests.rs
@@ -82,7 +82,7 @@ fn make_input_record(file_name: &str) -> (ObjectFileEntry, DriverDeps) {
     let catalog = make_catalog();
     let outputs = catalog
         .execute_action(
-            "craft-basics:FindLog".to_string(),
+            "craft-basics::FindLog".to_string(),
             dummy_grounding_witness(),
             vec![],
         )
@@ -91,7 +91,7 @@ fn make_input_record(file_name: &str) -> (ObjectFileEntry, DriverDeps) {
     let id = format!("{:#}", spendable.obj.commitment());
     let record = ObjectRecord {
         id,
-        class_id: "craft-basics:Log".to_string(),
+        class_id: "craft-basics::Log".to_string(),
         status: ObjectStatus::Live,
         tx_hash: None,
         pod: spendable.pod,
@@ -262,7 +262,7 @@ fn test_list_actions_filters_by_input_class() {
     let driver = Driver::open(paths, deps).unwrap();
     let filtered = driver
         .list_actions(Some(&ActionQuery {
-            input_class_id: Some("craft-basics:Wood".to_string()),
+            input_class_id: Some("craft-basics::Wood".to_string()),
             ..ActionQuery::default()
         }))
         .unwrap();
@@ -274,7 +274,7 @@ fn test_list_actions_filters_by_input_class() {
         action
             .total_inputs
             .iter()
-            .any(|r| r.id == "craft-basics:Wood")
+            .any(|r| r.id == "craft-basics::Wood")
     }));
 }
 
@@ -292,7 +292,7 @@ fn test_execute_rolls_back_on_relayer_submit_failure() {
 
     let err = driver
         .execute(ExecuteActionInput {
-            action_id: "craft-basics:CraftWood".to_string(),
+            action_id: "craft-basics::CraftWood".to_string(),
             input_objects: vec![ObjectSelector::FileName("log_1.dobj".to_string())],
         })
         .unwrap_err();
@@ -323,10 +323,10 @@ fn test_execute_rolls_back_on_relayer_submit_failure() {
 #[test]
 fn test_execute_rejects_class_hash_mismatch_with_matching_class_id() {
     // A real Log object (obj["type"] = IsLog hash) written to disk with a
-    // forged class_id of "craft-basics:Wood". CraftSticks consumes a Wood,
+    // forged class_id of "craft-basics::Wood". CraftSticks consumes a Wood,
     // so the bare-id check passes; the cryptographic hash check then fires.
     let (mut entry, deps) = make_input_record("forged_wood.dobj");
-    entry.record.class_id = "craft-basics:Wood".to_string();
+    entry.record.class_id = "craft-basics::Wood".to_string();
     let paths = temp_paths();
     ensure_store_dirs(&paths).unwrap();
     write_object_file(&paths, &entry.record, &entry.file_name).unwrap();
@@ -334,7 +334,7 @@ fn test_execute_rejects_class_hash_mismatch_with_matching_class_id() {
 
     let err = driver
         .execute(ExecuteActionInput {
-            action_id: "craft-basics:CraftSticks".to_string(),
+            action_id: "craft-basics::CraftSticks".to_string(),
             input_objects: vec![ObjectSelector::FileName("forged_wood.dobj".to_string())],
         })
         .unwrap_err();
@@ -359,7 +359,7 @@ fn test_execute_keeps_files_after_relayer_accepts() {
 
     let err = driver
         .execute(ExecuteActionInput {
-            action_id: "craft-basics:CraftWood".to_string(),
+            action_id: "craft-basics::CraftWood".to_string(),
             input_objects: vec![ObjectSelector::FileName("log_1.dobj".to_string())],
         })
         .unwrap_err();

--- a/driver/src/tests.rs
+++ b/driver/src/tests.rs
@@ -272,8 +272,9 @@ fn test_list_actions_filters_by_input_class() {
     );
     assert!(filtered.iter().all(|action| {
         action
-            .total_input_class_ids
-            .contains(&"craft-basics:Wood".to_string())
+            .total_inputs
+            .iter()
+            .any(|r| r.id == "craft-basics:Wood")
     }));
 }
 

--- a/driver/src/types.rs
+++ b/driver/src/types.rs
@@ -62,6 +62,22 @@ pub struct ObjectSummary {
     pub fields: HashMap<String, serde_json::Value>,
 }
 
+/// One entry in an action's input/output slot list, or a missing-slot entry
+/// in a feasibility report. Bundles the qualified id, the bare display name,
+/// and the on-chain `Is{class}` predicate hash so callers don't have to keep
+/// three parallel `Vec<String>`s in sync.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ClassRef {
+    /// Qualified class id (`<plugin>:<class>`).
+    pub id: String,
+    /// Bare class name from the producing plugin's manifest.
+    pub display_name: String,
+    /// Hex-encoded `Is{class}` predicate hash. Empty if the catalog could
+    /// not derive it (shouldn't happen for compiled modules).
+    pub hash: String,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct ActionSummary {
@@ -72,12 +88,8 @@ pub struct ActionSummary {
     pub emoji: String,
     pub hash: String,
     pub description: String,
-    pub total_input_class_ids: Vec<String>,
-    pub total_input_class_names: Vec<String>,
-    pub total_input_class_hashes: Vec<String>,
-    pub total_output_class_ids: Vec<String>,
-    pub total_output_class_names: Vec<String>,
-    pub total_output_class_hashes: Vec<String>,
+    pub total_inputs: Vec<ClassRef>,
+    pub total_outputs: Vec<ClassRef>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -113,10 +125,8 @@ pub struct CheckActionReport {
     /// Qualified action id (`<plugin>:<action>`).
     pub action_id: String,
     pub available_inputs: Vec<CheckActionCandidate>,
-    /// Qualified class ids that have no live object in inventory.
-    pub missing_input_class_ids: Vec<String>,
-    /// Bare class names parallel to `missing_input_class_ids`.
-    pub missing_input_class_names: Vec<String>,
+    /// Slots that had no eligible live object in inventory.
+    pub missing_inputs: Vec<ClassRef>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/driver/src/types.rs
+++ b/driver/src/types.rs
@@ -28,7 +28,8 @@ pub enum ObjectSelector {
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct ObjectQuery {
-    pub class_name: Option<String>,
+    /// Qualified class id (`<plugin>:<class>`).
+    pub class_id: Option<String>,
     pub status: Option<ObjectStatus>,
     pub id: Option<String>,
     pub file_name: Option<String>,
@@ -36,9 +37,12 @@ pub struct ObjectQuery {
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct ActionQuery {
-    pub name: Option<String>,
-    pub input_class: Option<String>,
-    pub output_class: Option<String>,
+    /// Qualified action id (`<plugin>:<action>`).
+    pub id: Option<String>,
+    /// Qualified class id (`<plugin>:<class>`).
+    pub input_class_id: Option<String>,
+    /// Qualified class id (`<plugin>:<class>`).
+    pub output_class_id: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -46,7 +50,11 @@ pub struct ActionQuery {
 pub struct ObjectSummary {
     pub id: String,
     pub file_name: String,
-    pub class_name: String,
+    /// Qualified class id (`<plugin>:<class>`).
+    pub class_id: String,
+    /// Bare class name from the producing plugin's manifest.
+    pub class_display_name: String,
+    pub plugin_name: String,
     pub class_hash: String,
     pub status: ObjectStatus,
     pub tx_hash: Option<String>,
@@ -57,19 +65,28 @@ pub struct ObjectSummary {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct ActionSummary {
+    /// Qualified action id (`<plugin>:<action>`).
     pub id: String,
+    pub display_name: String,
+    pub plugin_name: String,
     pub emoji: String,
     pub hash: String,
-    pub total_input_class_hashes: Vec<String>,
     pub description: String,
-    pub total_input_classes: Vec<String>,
-    pub total_output_classes: Vec<String>,
+    pub total_input_class_ids: Vec<String>,
+    pub total_input_class_names: Vec<String>,
+    pub total_input_class_hashes: Vec<String>,
+    pub total_output_class_ids: Vec<String>,
+    pub total_output_class_names: Vec<String>,
+    pub total_output_class_hashes: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct ClassSummary {
-    pub name: String,
+    /// Qualified class id (`<plugin>:<class>`).
+    pub id: String,
+    pub display_name: String,
+    pub plugin_name: String,
     pub emoji: String,
     pub hash: String,
     pub description: String,
@@ -82,7 +99,9 @@ pub struct ClassSummary {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct CheckActionCandidate {
-    pub class_name: String,
+    pub class_id: String,
+    pub class_display_name: String,
+    pub plugin_name: String,
     pub object_id: String,
     pub file_name: String,
 }
@@ -91,9 +110,13 @@ pub struct CheckActionCandidate {
 #[serde(rename_all = "camelCase")]
 pub struct CheckActionReport {
     pub feasible: bool,
+    /// Qualified action id (`<plugin>:<action>`).
     pub action_id: String,
     pub available_inputs: Vec<CheckActionCandidate>,
-    pub missing_inputs: Vec<String>,
+    /// Qualified class ids that have no live object in inventory.
+    pub missing_input_class_ids: Vec<String>,
+    /// Bare class names parallel to `missing_input_class_ids`.
+    pub missing_input_class_names: Vec<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/driver/src/types.rs
+++ b/driver/src/types.rs
@@ -28,7 +28,7 @@ pub enum ObjectSelector {
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct ObjectQuery {
-    /// Qualified class id (`<plugin>:<class>`).
+    /// Qualified class id (`<plugin>::<class>`).
     pub class_id: Option<String>,
     pub status: Option<ObjectStatus>,
     pub id: Option<String>,
@@ -37,11 +37,11 @@ pub struct ObjectQuery {
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct ActionQuery {
-    /// Qualified action id (`<plugin>:<action>`).
+    /// Qualified action id (`<plugin>::<action>`).
     pub id: Option<String>,
-    /// Qualified class id (`<plugin>:<class>`).
+    /// Qualified class id (`<plugin>::<class>`).
     pub input_class_id: Option<String>,
-    /// Qualified class id (`<plugin>:<class>`).
+    /// Qualified class id (`<plugin>::<class>`).
     pub output_class_id: Option<String>,
 }
 
@@ -50,7 +50,7 @@ pub struct ActionQuery {
 pub struct ObjectSummary {
     pub id: String,
     pub file_name: String,
-    /// Qualified class id (`<plugin>:<class>`).
+    /// Qualified class id (`<plugin>::<class>`).
     pub class_id: String,
     /// Bare class name from the producing plugin's manifest.
     pub class_display_name: String,
@@ -69,7 +69,7 @@ pub struct ObjectSummary {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct ClassRef {
-    /// Qualified class id (`<plugin>:<class>`).
+    /// Qualified class id (`<plugin>::<class>`).
     pub id: String,
     /// Bare class name from the producing plugin's manifest.
     pub display_name: String,
@@ -81,7 +81,7 @@ pub struct ClassRef {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct ActionSummary {
-    /// Qualified action id (`<plugin>:<action>`).
+    /// Qualified action id (`<plugin>::<action>`).
     pub id: String,
     pub display_name: String,
     pub plugin_name: String,
@@ -95,7 +95,7 @@ pub struct ActionSummary {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct ClassSummary {
-    /// Qualified class id (`<plugin>:<class>`).
+    /// Qualified class id (`<plugin>::<class>`).
     pub id: String,
     pub display_name: String,
     pub plugin_name: String,
@@ -122,7 +122,7 @@ pub struct CheckActionCandidate {
 #[serde(rename_all = "camelCase")]
 pub struct CheckActionReport {
     pub feasible: bool,
-    /// Qualified action id (`<plugin>:<action>`).
+    /// Qualified action id (`<plugin>::<action>`).
     pub action_id: String,
     pub available_inputs: Vec<CheckActionCandidate>,
     /// Slots that had no eligible live object in inventory.

--- a/driver/src/types.rs
+++ b/driver/src/types.rs
@@ -4,6 +4,7 @@ use std::path::PathBuf;
 use serde::{Deserialize, Serialize};
 
 use crate::object_record::ObjectStatus;
+use crate::qualified_name::QualifiedName;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DriverPaths {
@@ -28,8 +29,7 @@ pub enum ObjectSelector {
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct ObjectQuery {
-    /// Qualified class id (`<plugin>::<class>`).
-    pub class_id: Option<String>,
+    pub class: Option<QualifiedName>,
     pub status: Option<ObjectStatus>,
     pub id: Option<String>,
     pub file_name: Option<String>,
@@ -37,12 +37,9 @@ pub struct ObjectQuery {
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct ActionQuery {
-    /// Qualified action id (`<plugin>::<action>`).
-    pub id: Option<String>,
-    /// Qualified class id (`<plugin>::<class>`).
-    pub input_class_id: Option<String>,
-    /// Qualified class id (`<plugin>::<class>`).
-    pub output_class_id: Option<String>,
+    pub action: Option<QualifiedName>,
+    pub input_class: Option<QualifiedName>,
+    pub output_class: Option<QualifiedName>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -50,11 +47,7 @@ pub struct ActionQuery {
 pub struct ObjectSummary {
     pub id: String,
     pub file_name: String,
-    /// Qualified class id (`<plugin>::<class>`).
-    pub class_id: String,
-    /// Bare class name from the producing plugin's manifest.
-    pub class_display_name: String,
-    pub plugin_name: String,
+    pub class: QualifiedName,
     pub class_hash: String,
     pub status: ObjectStatus,
     pub tx_hash: Option<String>,
@@ -63,16 +56,12 @@ pub struct ObjectSummary {
 }
 
 /// One entry in an action's input/output slot list, or a missing-slot entry
-/// in a feasibility report. Bundles the qualified id, the bare display name,
-/// and the on-chain `Is{class}` predicate hash so callers don't have to keep
-/// three parallel `Vec<String>`s in sync.
+/// in a feasibility report. Pairs the class identity with its on-chain
+/// `Is{class}` predicate hash.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct ClassRef {
-    /// Qualified class id (`<plugin>::<class>`).
-    pub id: String,
-    /// Bare class name from the producing plugin's manifest.
-    pub display_name: String,
+    pub class: QualifiedName,
     /// Hex-encoded `Is{class}` predicate hash. Empty if the catalog could
     /// not derive it (shouldn't happen for compiled modules).
     pub hash: String,
@@ -81,10 +70,7 @@ pub struct ClassRef {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct ActionSummary {
-    /// Qualified action id (`<plugin>::<action>`).
-    pub id: String,
-    pub display_name: String,
-    pub plugin_name: String,
+    pub action: QualifiedName,
     pub emoji: String,
     pub hash: String,
     pub description: String,
@@ -95,25 +81,20 @@ pub struct ActionSummary {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct ClassSummary {
-    /// Qualified class id (`<plugin>::<class>`).
-    pub id: String,
-    pub display_name: String,
-    pub plugin_name: String,
+    pub class: QualifiedName,
     pub emoji: String,
     pub hash: String,
     pub description: String,
     pub live_count: usize,
-    pub produced_by: Vec<String>,
-    pub consumed_by: Vec<String>,
+    pub produced_by: Vec<QualifiedName>,
+    pub consumed_by: Vec<QualifiedName>,
     pub predicate_source: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct CheckActionCandidate {
-    pub class_id: String,
-    pub class_display_name: String,
-    pub plugin_name: String,
+    pub class: QualifiedName,
     pub object_id: String,
     pub file_name: String,
 }
@@ -122,8 +103,7 @@ pub struct CheckActionCandidate {
 #[serde(rename_all = "camelCase")]
 pub struct CheckActionReport {
     pub feasible: bool,
-    /// Qualified action id (`<plugin>::<action>`).
-    pub action_id: String,
+    pub action: QualifiedName,
     pub available_inputs: Vec<CheckActionCandidate>,
     /// Slots that had no eligible live object in inventory.
     pub missing_inputs: Vec<ClassRef>,
@@ -131,7 +111,7 @@ pub struct CheckActionReport {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ExecuteActionInput {
-    pub action_id: String,
+    pub action: QualifiedName,
     pub input_objects: Vec<ObjectSelector>,
 }
 

--- a/mcp/src/mock.rs
+++ b/mcp/src/mock.rs
@@ -6,6 +6,12 @@ use anyhow::{anyhow, bail};
 use crate::ops::CraftOps;
 use crate::types::*;
 
+const PLUGIN: &str = "craft-basics";
+
+fn qid(name: &str) -> String {
+    format!("{PLUGIN}:{name}")
+}
+
 /// Mock implementation of CraftOps for testing.
 /// Returns realistic fixtures matching the zk-craft game.
 pub struct MockCraftOps {
@@ -58,32 +64,35 @@ impl CraftOps for MockCraftOps {
         let mut classes: Vec<ClassSummary> = KNOWN_CLASSES
             .iter()
             .map(|&name| {
+                let class_id = qid(name);
                 let live_count = self
                     .inventory
                     .iter()
-                    .filter(|o| o.class_name == name && o.status == "live")
+                    .filter(|o| o.class_id == class_id && o.status == "live")
                     .count();
                 let produced_by = self
                     .actions
                     .iter()
-                    .filter(|a| a.total_output_classes.contains(&name.to_string()))
+                    .filter(|a| a.total_output_class_ids.contains(&class_id))
                     .map(|a| a.id.clone())
                     .collect();
                 let consumed_by = self
                     .actions
                     .iter()
-                    .filter(|a| a.total_input_classes.contains(&name.to_string()))
+                    .filter(|a| a.total_input_class_ids.contains(&class_id))
                     .map(|a| a.id.clone())
                     .collect();
                 ClassSummary {
-                    name: name.to_string(),
+                    id: class_id,
+                    display_name: name.to_string(),
+                    plugin_name: PLUGIN.to_string(),
                     live_count,
                     produced_by,
                     consumed_by,
                 }
             })
             .collect();
-        classes.sort_by(|a, b| a.name.cmp(&b.name));
+        classes.sort_by(|a, b| a.display_name.cmp(&b.display_name));
         Ok(classes)
     }
 
@@ -100,34 +109,41 @@ impl CraftOps for MockCraftOps {
 
         Ok(ObjectDetail {
             id: obj.id.clone(),
-            class_name: obj.class_name.clone(),
+            class_id: obj.class_id.clone(),
+            class_display_name: obj.class_display_name.clone(),
+            plugin_name: obj.plugin_name.clone(),
             status: obj.status.clone(),
             tx_hash: obj.tx_hash.clone(),
             state: obj.fields.clone(),
-            predicate_source: predicate_source_for(&obj.class_name),
+            predicate_source: predicate_source_for(&obj.class_display_name),
         })
     }
 
-    fn inspect_class(&self, class_name: &str) -> anyhow::Result<ClassDetail> {
+    fn inspect_class(&self, class_id: &str) -> anyhow::Result<ClassDetail> {
         let actions = &self.actions;
         let produced_by = actions
             .iter()
-            .filter(|a| a.total_output_classes.contains(&class_name.to_string()))
+            .filter(|a| a.total_output_class_ids.contains(&class_id.to_string()))
             .map(|a| a.id.clone())
             .collect();
         let consumed_by = actions
             .iter()
-            .filter(|a| a.total_input_classes.contains(&class_name.to_string()))
+            .filter(|a| a.total_input_class_ids.contains(&class_id.to_string()))
             .map(|a| a.id.clone())
             .collect();
 
-        if !is_known_class(class_name) {
-            bail!("unknown class: {class_name}");
+        let display_name = class_id
+            .strip_prefix(&format!("{PLUGIN}:"))
+            .unwrap_or(class_id);
+        if !is_known_class(display_name) {
+            bail!("unknown class: {class_id}");
         }
 
         Ok(ClassDetail {
-            class_name: class_name.to_string(),
-            predicate_source: predicate_source_for(class_name),
+            class_id: class_id.to_string(),
+            class_display_name: display_name.to_string(),
+            plugin_name: PLUGIN.to_string(),
+            predicate_source: predicate_source_for(display_name),
             produced_by,
             consumed_by,
         })
@@ -153,8 +169,10 @@ impl CraftOps for MockCraftOps {
             message: format!("Action {} completed successfully", input.action_id),
             outputs: vec![InventoryObject {
                 id: "0xnew1234567890abcdef".to_string(),
-                class_name: "Wood".to_string(),
-                file_name: "Wood.dobj".to_string(),
+                class_id: qid("Wood"),
+                class_display_name: "Wood".to_string(),
+                plugin_name: PLUGIN.to_string(),
+                file_name: "craft-basics_wood_0xnew.dobj".to_string(),
                 status: "live".to_string(),
                 tx_hash: Some("0xmocktxnew12345678".to_string()),
                 fields: HashMap::from([
@@ -180,183 +198,171 @@ impl CraftOps for MockCraftOps {
             .ok_or_else(|| anyhow!("unknown action: {action_id}"))?;
 
         let mut available = Vec::new();
-        let mut missing = Vec::new();
+        let mut missing_class_ids = Vec::new();
+        let mut missing_class_names = Vec::new();
 
-        for required_class in &action.total_input_classes {
+        for (slot, required_class_id) in action.total_input_class_ids.iter().enumerate() {
             if let Some(obj) = self
                 .inventory
                 .iter()
-                .find(|o| &o.class_name == required_class && o.status == "live")
+                .find(|o| &o.class_id == required_class_id && o.status == "live")
             {
                 available.push(FeasibilityInput {
-                    class_name: obj.class_name.clone(),
+                    class_id: obj.class_id.clone(),
+                    class_display_name: obj.class_display_name.clone(),
+                    plugin_name: obj.plugin_name.clone(),
                     object_id: obj.id.clone(),
                     file_name: obj.file_name.clone(),
                 });
             } else {
-                missing.push(required_class.clone());
+                missing_class_ids.push(required_class_id.clone());
+                missing_class_names
+                    .push(action.total_input_class_names[slot].clone());
             }
         }
 
         Ok(FeasibilityReport {
-            feasible: missing.is_empty(),
+            feasible: missing_class_ids.is_empty(),
             action_id: action_id.to_string(),
             available_inputs: available,
-            missing_inputs: missing,
+            missing_input_class_ids: missing_class_ids,
+            missing_input_class_names: missing_class_names,
         })
+    }
+}
+
+fn make_obj(id: &str, class: &str, file_name: &str, tx_hash: &str, status: &str, extra: Vec<(&str, serde_json::Value)>) -> InventoryObject {
+    let mut fields = HashMap::from([
+        (
+            "blueprint".to_string(),
+            serde_json::Value::String(class.to_string()),
+        ),
+        (
+            "key".to_string(),
+            serde_json::Value::String(id.to_string()),
+        ),
+    ]);
+    for (k, v) in extra {
+        fields.insert(k.to_string(), v);
+    }
+    InventoryObject {
+        id: id.to_string(),
+        class_id: qid(class),
+        class_display_name: class.to_string(),
+        plugin_name: PLUGIN.to_string(),
+        file_name: file_name.to_string(),
+        status: status.to_string(),
+        tx_hash: Some(tx_hash.to_string()),
+        fields,
     }
 }
 
 fn default_inventory() -> Vec<InventoryObject> {
     vec![
-        InventoryObject {
-            id: "0xabc1111111111111".to_string(),
-            class_name: "Log".to_string(),
-            file_name: "Log.dobj".to_string(),
-            status: "live".to_string(),
-            tx_hash: Some("0xmocktx1111111111".to_string()),
-            fields: HashMap::from([
-                (
-                    "blueprint".to_string(),
-                    serde_json::Value::String("Log".to_string()),
-                ),
-                (
-                    "key".to_string(),
-                    serde_json::Value::String("0xabc1111111111111".to_string()),
-                ),
-            ]),
-        },
-        InventoryObject {
-            id: "0xabc2222222222222".to_string(),
-            class_name: "Wood".to_string(),
-            file_name: "Wood.dobj".to_string(),
-            status: "live".to_string(),
-            tx_hash: Some("0xmocktx2222222222".to_string()),
-            fields: HashMap::from([
-                (
-                    "blueprint".to_string(),
-                    serde_json::Value::String("Wood".to_string()),
-                ),
-                (
-                    "key".to_string(),
-                    serde_json::Value::String("0xabc2222222222222".to_string()),
-                ),
-            ]),
-        },
-        InventoryObject {
-            id: "0xabc3333333333333".to_string(),
-            class_name: "Stick".to_string(),
-            file_name: "Stick.dobj".to_string(),
-            status: "live".to_string(),
-            tx_hash: Some("0xmocktx3333333333".to_string()),
-            fields: HashMap::from([
-                (
-                    "blueprint".to_string(),
-                    serde_json::Value::String("Stick".to_string()),
-                ),
-                (
-                    "key".to_string(),
-                    serde_json::Value::String("0xabc3333333333333".to_string()),
-                ),
-            ]),
-        },
-        InventoryObject {
-            id: "0xabc4444444444444".to_string(),
-            class_name: "WoodPick".to_string(),
-            file_name: "WoodPick.dobj".to_string(),
-            status: "live".to_string(),
-            tx_hash: Some("0xmocktx4444444444".to_string()),
-            fields: HashMap::from([
-                (
-                    "blueprint".to_string(),
-                    serde_json::Value::String("WoodPick".to_string()),
-                ),
-                (
-                    "durability".to_string(),
-                    serde_json::Value::Number(3.into()),
-                ),
-                (
-                    "key".to_string(),
-                    serde_json::Value::String("0xabc4444444444444".to_string()),
-                ),
-            ]),
-        },
-        InventoryObject {
-            id: "0xabc5555555555555".to_string(),
-            class_name: "Stone".to_string(),
-            file_name: "Stone.dobj".to_string(),
-            status: "live".to_string(),
-            tx_hash: Some("0xmocktx5555555555".to_string()),
-            fields: HashMap::from([
-                (
-                    "blueprint".to_string(),
-                    serde_json::Value::String("Stone".to_string()),
-                ),
-                (
-                    "key".to_string(),
-                    serde_json::Value::String("0xabc5555555555555".to_string()),
-                ),
-            ]),
-        },
+        make_obj(
+            "0xabc1111111111111",
+            "Log",
+            "craft-basics_log_0xabc1.dobj",
+            "0xmocktx1111111111",
+            "live",
+            vec![],
+        ),
+        make_obj(
+            "0xabc2222222222222",
+            "Wood",
+            "craft-basics_wood_0xabc2.dobj",
+            "0xmocktx2222222222",
+            "live",
+            vec![],
+        ),
+        make_obj(
+            "0xabc3333333333333",
+            "Stick",
+            "craft-basics_stick_0xabc3.dobj",
+            "0xmocktx3333333333",
+            "live",
+            vec![],
+        ),
+        make_obj(
+            "0xabc4444444444444",
+            "WoodPick",
+            "craft-basics_woodpick_0xabc4.dobj",
+            "0xmocktx4444444444",
+            "live",
+            vec![("durability", serde_json::Value::Number(3.into()))],
+        ),
+        make_obj(
+            "0xabc5555555555555",
+            "Stone",
+            "craft-basics_stone_0xabc5.dobj",
+            "0xmocktx5555555555",
+            "live",
+            vec![],
+        ),
         // A nullified object to test liveness filtering
-        InventoryObject {
-            id: "0xdead000000000000".to_string(),
-            class_name: "Log".to_string(),
-            file_name: "Log_old.dobj".to_string(),
-            status: "nullified".to_string(),
-            tx_hash: Some("0xmocktxdead000000".to_string()),
-            fields: HashMap::from([(
-                "blueprint".to_string(),
-                serde_json::Value::String("Log".to_string()),
-            )]),
-        },
+        make_obj(
+            "0xdead000000000000",
+            "Log",
+            "craft-basics_log_0xdead.dobj",
+            "0xmocktxdead000000",
+            "nullified",
+            vec![],
+        ),
     ]
+}
+
+fn make_action(
+    name: &str,
+    description: &str,
+    inputs: &[&str],
+    outputs: &[&str],
+) -> Action {
+    Action {
+        id: qid(name),
+        display_name: name.to_string(),
+        plugin_name: PLUGIN.to_string(),
+        description: description.to_string(),
+        total_input_class_ids: inputs.iter().map(|c| qid(c)).collect(),
+        total_input_class_names: inputs.iter().map(|c| c.to_string()).collect(),
+        total_output_class_ids: outputs.iter().map(|c| qid(c)).collect(),
+        total_output_class_names: outputs.iter().map(|c| c.to_string()).collect(),
+    }
 }
 
 fn default_actions() -> Vec<Action> {
     vec![
-        Action {
-            id: "FindLog".to_string(),
-            description: "Discover a log by proving a short VDF".to_string(),
-            total_input_classes: vec![],
-            total_output_classes: vec!["Log".to_string()],
-        },
-        Action {
-            id: "CraftWood".to_string(),
-            description: "Refine one log into wood".to_string(),
-            total_input_classes: vec!["Log".to_string()],
-            total_output_classes: vec!["Wood".to_string()],
-        },
-        Action {
-            id: "CraftSticks".to_string(),
-            description: "Split one wood into two sticks".to_string(),
-            total_input_classes: vec!["Wood".to_string()],
-            total_output_classes: vec!["Stick".to_string(), "Stick".to_string()],
-        },
-        Action {
-            id: "CraftWoodPick".to_string(),
-            description: "Combine wood and stick to craft a wood pickaxe".to_string(),
-            total_input_classes: vec!["Wood".to_string(), "Stick".to_string()],
-            total_output_classes: vec!["WoodPick".to_string()],
-        },
-        Action {
-            id: "CraftStonePick".to_string(),
-            description: "Combine stone and stick to craft a stone pickaxe".to_string(),
-            total_input_classes: vec!["Stone".to_string(), "Stick".to_string()],
-            total_output_classes: vec!["StonePick".to_string()],
-        },
-        Action {
-            id: "MineStoneWithWoodPick".to_string(),
-            description: "Mine stone using a wood pick (consumes durability)".to_string(),
-            total_input_classes: vec!["WoodPick".to_string()],
-            total_output_classes: vec!["Stone".to_string(), "WoodPick".to_string()],
-        },
-        Action {
-            id: "MineStoneWithStonePick".to_string(),
-            description: "Mine stone using a stone pick (consumes durability)".to_string(),
-            total_input_classes: vec!["StonePick".to_string()],
-            total_output_classes: vec!["Stone".to_string(), "StonePick".to_string()],
-        },
+        make_action("FindLog", "Discover a log by proving a short VDF", &[], &["Log"]),
+        make_action("CraftWood", "Refine one log into wood", &["Log"], &["Wood"]),
+        make_action(
+            "CraftSticks",
+            "Split one wood into two sticks",
+            &["Wood"],
+            &["Stick", "Stick"],
+        ),
+        make_action(
+            "CraftWoodPick",
+            "Combine wood and stick to craft a wood pickaxe",
+            &["Wood", "Stick"],
+            &["WoodPick"],
+        ),
+        make_action(
+            "CraftStonePick",
+            "Combine stone and stick to craft a stone pickaxe",
+            &["Stone", "Stick"],
+            &["StonePick"],
+        ),
+        make_action(
+            "MineStoneWithWoodPick",
+            "Mine stone using a wood pick (consumes durability)",
+            &["WoodPick"],
+            &["Stone", "WoodPick"],
+        ),
+        make_action(
+            "MineStoneWithStonePick",
+            "Mine stone using a stone pick (consumes durability)",
+            &["StonePick"],
+            &["Stone", "StonePick"],
+        ),
     ]
 }
 
@@ -395,19 +401,19 @@ mod tests {
     fn test_default_inventory_has_all_classes() {
         let mock = MockCraftOps::new();
         let inv = mock.list_inventory().unwrap();
-        let classes: Vec<&str> = inv.iter().map(|o| o.class_name.as_str()).collect();
-        assert!(classes.contains(&"Log"));
-        assert!(classes.contains(&"Wood"));
-        assert!(classes.contains(&"Stick"));
-        assert!(classes.contains(&"WoodPick"));
-        assert!(classes.contains(&"Stone"));
+        let names: Vec<&str> = inv.iter().map(|o| o.class_display_name.as_str()).collect();
+        assert!(names.contains(&"Log"));
+        assert!(names.contains(&"Wood"));
+        assert!(names.contains(&"Stick"));
+        assert!(names.contains(&"WoodPick"));
+        assert!(names.contains(&"Stone"));
     }
 
     #[test]
     fn test_inspect_object_found() {
         let mock = MockCraftOps::new();
         let detail = mock.inspect_object("0xabc1111111111111").unwrap();
-        assert_eq!(detail.class_name, "Log");
+        assert_eq!(detail.class_display_name, "Log");
         assert_eq!(detail.status, "live");
         assert!(detail.predicate_source.contains("FindLog"));
     }
@@ -421,31 +427,31 @@ mod tests {
     #[test]
     fn test_inspect_class() {
         let mock = MockCraftOps::new();
-        let detail = mock.inspect_class("Wood").unwrap();
-        assert!(detail.produced_by.contains(&"CraftWood".to_string()));
-        assert!(detail.consumed_by.contains(&"CraftSticks".to_string()));
-        assert!(detail.consumed_by.contains(&"CraftWoodPick".to_string()));
+        let detail = mock.inspect_class("craft-basics:Wood").unwrap();
+        assert!(detail.produced_by.contains(&qid("CraftWood")));
+        assert!(detail.consumed_by.contains(&qid("CraftSticks")));
+        assert!(detail.consumed_by.contains(&qid("CraftWoodPick")));
     }
 
     #[test]
     fn test_inspect_unknown_class() {
         let mock = MockCraftOps::new();
-        assert!(mock.inspect_class("Diamond").is_err());
+        assert!(mock.inspect_class("craft-basics:Diamond").is_err());
     }
 
     #[test]
     fn test_check_feasibility_feasible() {
         let mock = MockCraftOps::new();
-        let report = mock.check_feasibility("CraftWoodPick").unwrap();
+        let report = mock.check_feasibility(&qid("CraftWoodPick")).unwrap();
         assert!(report.feasible);
-        assert!(report.missing_inputs.is_empty());
+        assert!(report.missing_input_class_ids.is_empty());
         assert_eq!(report.available_inputs.len(), 2);
     }
 
     #[test]
     fn test_check_feasibility_missing() {
         let mock = MockCraftOps::new();
-        let report = mock.check_feasibility("CraftStonePick").unwrap();
+        let report = mock.check_feasibility(&qid("CraftStonePick")).unwrap();
         // We have Stone and Stick, so this should be feasible
         assert!(report.feasible);
     }
@@ -453,7 +459,7 @@ mod tests {
     #[test]
     fn test_check_feasibility_unknown_action() {
         let mock = MockCraftOps::new();
-        assert!(mock.check_feasibility("CraftDiamond").is_err());
+        assert!(mock.check_feasibility(&qid("CraftDiamond")).is_err());
     }
 
     #[test]
@@ -461,8 +467,8 @@ mod tests {
         let mock = MockCraftOps::new();
         let result = mock
             .run_action(RunActionInput {
-                action_id: "CraftWood".to_string(),
-                input_object_paths: vec!["Log.dobj".to_string()],
+                action_id: qid("CraftWood"),
+                input_object_paths: vec!["craft-basics_log_0xabc1.dobj".to_string()],
             })
             .unwrap();
         assert!(result.success);
@@ -472,8 +478,8 @@ mod tests {
     fn test_run_action_already_in_progress() {
         let mock = MockCraftOps::new().with_action_in_progress();
         let result = mock.run_action(RunActionInput {
-            action_id: "CraftWood".to_string(),
-            input_object_paths: vec!["Log.dobj".to_string()],
+            action_id: qid("CraftWood"),
+            input_object_paths: vec!["craft-basics_log_0xabc1.dobj".to_string()],
         });
         assert!(result.is_err());
         assert!(
@@ -488,7 +494,7 @@ mod tests {
     fn test_run_action_unknown() {
         let mock = MockCraftOps::new();
         let result = mock.run_action(RunActionInput {
-            action_id: "CraftDiamond".to_string(),
+            action_id: qid("CraftDiamond"),
             input_object_paths: vec![],
         });
         assert!(result.is_err());

--- a/mcp/src/mock.rs
+++ b/mcp/src/mock.rs
@@ -9,7 +9,7 @@ use crate::types::*;
 const PLUGIN: &str = "craft-basics";
 
 fn qid(name: &str) -> String {
-    format!("{PLUGIN}:{name}")
+    format!("{PLUGIN}::{name}")
 }
 
 /// Mock implementation of CraftOps for testing.
@@ -133,7 +133,7 @@ impl CraftOps for MockCraftOps {
             .collect();
 
         let display_name = class_id
-            .strip_prefix(&format!("{PLUGIN}:"))
+            .strip_prefix(&format!("{PLUGIN}::"))
             .unwrap_or(class_id);
         if !is_known_class(display_name) {
             bail!("unknown class: {class_id}");
@@ -172,7 +172,7 @@ impl CraftOps for MockCraftOps {
                 class_id: qid("Wood"),
                 class_display_name: "Wood".to_string(),
                 plugin_name: PLUGIN.to_string(),
-                file_name: "craft-basics_wood_0xnew.dobj".to_string(),
+                file_name: "craft-basics__wood_0xnew.dobj".to_string(),
                 status: "live".to_string(),
                 tx_hash: Some("0xmocktxnew12345678".to_string()),
                 fields: HashMap::from([
@@ -262,7 +262,7 @@ fn default_inventory() -> Vec<InventoryObject> {
         make_obj(
             "0xabc1111111111111",
             "Log",
-            "craft-basics_log_0xabc1.dobj",
+            "craft-basics__log_0xabc1.dobj",
             "0xmocktx1111111111",
             "live",
             vec![],
@@ -270,7 +270,7 @@ fn default_inventory() -> Vec<InventoryObject> {
         make_obj(
             "0xabc2222222222222",
             "Wood",
-            "craft-basics_wood_0xabc2.dobj",
+            "craft-basics__wood_0xabc2.dobj",
             "0xmocktx2222222222",
             "live",
             vec![],
@@ -278,7 +278,7 @@ fn default_inventory() -> Vec<InventoryObject> {
         make_obj(
             "0xabc3333333333333",
             "Stick",
-            "craft-basics_stick_0xabc3.dobj",
+            "craft-basics__stick_0xabc3.dobj",
             "0xmocktx3333333333",
             "live",
             vec![],
@@ -286,7 +286,7 @@ fn default_inventory() -> Vec<InventoryObject> {
         make_obj(
             "0xabc4444444444444",
             "WoodPick",
-            "craft-basics_woodpick_0xabc4.dobj",
+            "craft-basics__woodpick_0xabc4.dobj",
             "0xmocktx4444444444",
             "live",
             vec![("durability", serde_json::Value::Number(3.into()))],
@@ -294,7 +294,7 @@ fn default_inventory() -> Vec<InventoryObject> {
         make_obj(
             "0xabc5555555555555",
             "Stone",
-            "craft-basics_stone_0xabc5.dobj",
+            "craft-basics__stone_0xabc5.dobj",
             "0xmocktx5555555555",
             "live",
             vec![],
@@ -303,7 +303,7 @@ fn default_inventory() -> Vec<InventoryObject> {
         make_obj(
             "0xdead000000000000",
             "Log",
-            "craft-basics_log_0xdead.dobj",
+            "craft-basics__log_0xdead.dobj",
             "0xmocktxdead000000",
             "nullified",
             vec![],
@@ -435,7 +435,7 @@ mod tests {
     #[test]
     fn test_inspect_class() {
         let mock = MockCraftOps::new();
-        let detail = mock.inspect_class("craft-basics:Wood").unwrap();
+        let detail = mock.inspect_class("craft-basics::Wood").unwrap();
         assert!(detail.produced_by.contains(&qid("CraftWood")));
         assert!(detail.consumed_by.contains(&qid("CraftSticks")));
         assert!(detail.consumed_by.contains(&qid("CraftWoodPick")));
@@ -444,7 +444,7 @@ mod tests {
     #[test]
     fn test_inspect_unknown_class() {
         let mock = MockCraftOps::new();
-        assert!(mock.inspect_class("craft-basics:Diamond").is_err());
+        assert!(mock.inspect_class("craft-basics::Diamond").is_err());
     }
 
     #[test]
@@ -476,7 +476,7 @@ mod tests {
         let result = mock
             .run_action(RunActionInput {
                 action_id: qid("CraftWood"),
-                input_object_paths: vec!["craft-basics_log_0xabc1.dobj".to_string()],
+                input_object_paths: vec!["craft-basics__log_0xabc1.dobj".to_string()],
             })
             .unwrap();
         assert!(result.success);
@@ -487,7 +487,7 @@ mod tests {
         let mock = MockCraftOps::new().with_action_in_progress();
         let result = mock.run_action(RunActionInput {
             action_id: qid("CraftWood"),
-            input_object_paths: vec!["craft-basics_log_0xabc1.dobj".to_string()],
+            input_object_paths: vec!["craft-basics__log_0xabc1.dobj".to_string()],
         });
         assert!(result.is_err());
         assert!(

--- a/mcp/src/mock.rs
+++ b/mcp/src/mock.rs
@@ -151,7 +151,11 @@ impl CraftOps for MockCraftOps {
 
         // Validate the action exists
         if !self.actions.iter().any(|a| a.action == input.action) {
-            bail!("unknown action: {}::{}", input.action.plugin_name, input.action.name);
+            bail!(
+                "unknown action: {}::{}",
+                input.action.plugin_name,
+                input.action.name
+            );
         }
 
         *in_progress = true;

--- a/mcp/src/mock.rs
+++ b/mcp/src/mock.rs
@@ -8,8 +8,11 @@ use crate::types::*;
 
 const PLUGIN: &str = "craft-basics";
 
-fn qid(name: &str) -> String {
-    format!("{PLUGIN}::{name}")
+fn qname(name: &str) -> QualifiedName {
+    QualifiedName {
+        plugin_name: PLUGIN.to_string(),
+        name: name.to_string(),
+    }
 }
 
 /// Mock implementation of CraftOps for testing.
@@ -64,35 +67,33 @@ impl CraftOps for MockCraftOps {
         let mut classes: Vec<ClassSummary> = KNOWN_CLASSES
             .iter()
             .map(|&name| {
-                let class_id = qid(name);
+                let class = qname(name);
                 let live_count = self
                     .inventory
                     .iter()
-                    .filter(|o| o.class_id == class_id && o.status == "live")
+                    .filter(|o| o.class == class && o.status == "live")
                     .count();
                 let produced_by = self
                     .actions
                     .iter()
-                    .filter(|a| a.total_outputs.iter().any(|r| r.id == class_id))
-                    .map(|a| a.id.clone())
+                    .filter(|a| a.total_outputs.iter().any(|r| r.class == class))
+                    .map(|a| a.action.clone())
                     .collect();
                 let consumed_by = self
                     .actions
                     .iter()
-                    .filter(|a| a.total_inputs.iter().any(|r| r.id == class_id))
-                    .map(|a| a.id.clone())
+                    .filter(|a| a.total_inputs.iter().any(|r| r.class == class))
+                    .map(|a| a.action.clone())
                     .collect();
                 ClassSummary {
-                    id: class_id,
-                    display_name: name.to_string(),
-                    plugin_name: PLUGIN.to_string(),
+                    class,
                     live_count,
                     produced_by,
                     consumed_by,
                 }
             })
             .collect();
-        classes.sort_by(|a, b| a.display_name.cmp(&b.display_name));
+        classes.sort_by(|a, b| a.class.name.cmp(&b.class.name));
         Ok(classes)
     }
 
@@ -109,41 +110,34 @@ impl CraftOps for MockCraftOps {
 
         Ok(ObjectDetail {
             id: obj.id.clone(),
-            class_id: obj.class_id.clone(),
-            class_display_name: obj.class_display_name.clone(),
-            plugin_name: obj.plugin_name.clone(),
+            class: obj.class.clone(),
             status: obj.status.clone(),
             tx_hash: obj.tx_hash.clone(),
             state: obj.fields.clone(),
-            predicate_source: predicate_source_for(&obj.class_display_name),
+            predicate_source: predicate_source_for(&obj.class.name),
         })
     }
 
-    fn inspect_class(&self, class_id: &str) -> anyhow::Result<ClassDetail> {
+    fn inspect_class(&self, class: &QualifiedName) -> anyhow::Result<ClassDetail> {
         let actions = &self.actions;
         let produced_by = actions
             .iter()
-            .filter(|a| a.total_outputs.iter().any(|r| r.id == class_id))
-            .map(|a| a.id.clone())
+            .filter(|a| a.total_outputs.iter().any(|r| r.class == *class))
+            .map(|a| a.action.clone())
             .collect();
         let consumed_by = actions
             .iter()
-            .filter(|a| a.total_inputs.iter().any(|r| r.id == class_id))
-            .map(|a| a.id.clone())
+            .filter(|a| a.total_inputs.iter().any(|r| r.class == *class))
+            .map(|a| a.action.clone())
             .collect();
 
-        let display_name = class_id
-            .strip_prefix(&format!("{PLUGIN}::"))
-            .unwrap_or(class_id);
-        if !is_known_class(display_name) {
-            bail!("unknown class: {class_id}");
+        if class.plugin_name != PLUGIN || !is_known_class(&class.name) {
+            bail!("unknown class: {}::{}", class.plugin_name, class.name);
         }
 
         Ok(ClassDetail {
-            class_id: class_id.to_string(),
-            class_display_name: display_name.to_string(),
-            plugin_name: PLUGIN.to_string(),
-            predicate_source: predicate_source_for(display_name),
+            class: class.clone(),
+            predicate_source: predicate_source_for(&class.name),
             produced_by,
             consumed_by,
         })
@@ -156,8 +150,8 @@ impl CraftOps for MockCraftOps {
         }
 
         // Validate the action exists
-        if !self.actions.iter().any(|a| a.id == input.action_id) {
-            bail!("unknown action: {}", input.action_id);
+        if !self.actions.iter().any(|a| a.action == input.action) {
+            bail!("unknown action: {}::{}", input.action.plugin_name, input.action.name);
         }
 
         *in_progress = true;
@@ -166,12 +160,13 @@ impl CraftOps for MockCraftOps {
 
         Ok(RunActionResult {
             success: true,
-            message: format!("Action {} completed successfully", input.action_id),
+            message: format!(
+                "Action {}::{} completed successfully",
+                input.action.plugin_name, input.action.name
+            ),
             outputs: vec![InventoryObject {
                 id: "0xnew1234567890abcdef".to_string(),
-                class_id: qid("Wood"),
-                class_display_name: "Wood".to_string(),
-                plugin_name: PLUGIN.to_string(),
+                class: qname("Wood"),
                 file_name: "craft-basics__wood_0xnew.dobj".to_string(),
                 status: "live".to_string(),
                 tx_hash: Some("0xmocktxnew12345678".to_string()),
@@ -190,26 +185,24 @@ impl CraftOps for MockCraftOps {
         })
     }
 
-    fn check_feasibility(&self, action_id: &str) -> anyhow::Result<FeasibilityReport> {
-        let action = self
+    fn check_feasibility(&self, action: &QualifiedName) -> anyhow::Result<FeasibilityReport> {
+        let action_summary = self
             .actions
             .iter()
-            .find(|a| a.id == action_id)
-            .ok_or_else(|| anyhow!("unknown action: {action_id}"))?;
+            .find(|a| a.action == *action)
+            .ok_or_else(|| anyhow!("unknown action: {}::{}", action.plugin_name, action.name))?;
 
         let mut available = Vec::new();
         let mut missing_inputs = Vec::new();
 
-        for required in &action.total_inputs {
+        for required in &action_summary.total_inputs {
             if let Some(obj) = self
                 .inventory
                 .iter()
-                .find(|o| o.class_id == required.id && o.status == "live")
+                .find(|o| o.class == required.class && o.status == "live")
             {
                 available.push(FeasibilityInput {
-                    class_id: obj.class_id.clone(),
-                    class_display_name: obj.class_display_name.clone(),
-                    plugin_name: obj.plugin_name.clone(),
+                    class: obj.class.clone(),
                     object_id: obj.id.clone(),
                     file_name: obj.file_name.clone(),
                 });
@@ -220,7 +213,7 @@ impl CraftOps for MockCraftOps {
 
         Ok(FeasibilityReport {
             feasible: missing_inputs.is_empty(),
-            action_id: action_id.to_string(),
+            action: action.clone(),
             available_inputs: available,
             missing_inputs,
         })
@@ -229,7 +222,7 @@ impl CraftOps for MockCraftOps {
 
 fn make_obj(
     id: &str,
-    class: &str,
+    class_name: &str,
     file_name: &str,
     tx_hash: &str,
     status: &str,
@@ -238,7 +231,7 @@ fn make_obj(
     let mut fields = HashMap::from([
         (
             "blueprint".to_string(),
-            serde_json::Value::String(class.to_string()),
+            serde_json::Value::String(class_name.to_string()),
         ),
         ("key".to_string(), serde_json::Value::String(id.to_string())),
     ]);
@@ -247,9 +240,7 @@ fn make_obj(
     }
     InventoryObject {
         id: id.to_string(),
-        class_id: qid(class),
-        class_display_name: class.to_string(),
-        plugin_name: PLUGIN.to_string(),
+        class: qname(class_name),
         file_name: file_name.to_string(),
         status: status.to_string(),
         tx_hash: Some(tx_hash.to_string()),
@@ -316,16 +307,13 @@ fn make_action(name: &str, description: &str, inputs: &[&str], outputs: &[&str])
         classes
             .iter()
             .map(|c| ClassRef {
-                id: qid(c),
-                display_name: c.to_string(),
+                class: qname(c),
                 hash: format!("0x{}", "0".repeat(64)),
             })
             .collect()
     };
     Action {
-        id: qid(name),
-        display_name: name.to_string(),
-        plugin_name: PLUGIN.to_string(),
+        action: qname(name),
         description: description.to_string(),
         total_inputs: to_refs(inputs),
         total_outputs: to_refs(outputs),
@@ -409,7 +397,7 @@ mod tests {
     fn test_default_inventory_has_all_classes() {
         let mock = MockCraftOps::new();
         let inv = mock.list_inventory().unwrap();
-        let names: Vec<&str> = inv.iter().map(|o| o.class_display_name.as_str()).collect();
+        let names: Vec<&str> = inv.iter().map(|o| o.class.name.as_str()).collect();
         assert!(names.contains(&"Log"));
         assert!(names.contains(&"Wood"));
         assert!(names.contains(&"Stick"));
@@ -421,7 +409,7 @@ mod tests {
     fn test_inspect_object_found() {
         let mock = MockCraftOps::new();
         let detail = mock.inspect_object("0xabc1111111111111").unwrap();
-        assert_eq!(detail.class_display_name, "Log");
+        assert_eq!(detail.class.name, "Log");
         assert_eq!(detail.status, "live");
         assert!(detail.predicate_source.contains("FindLog"));
     }
@@ -435,22 +423,22 @@ mod tests {
     #[test]
     fn test_inspect_class() {
         let mock = MockCraftOps::new();
-        let detail = mock.inspect_class("craft-basics::Wood").unwrap();
-        assert!(detail.produced_by.contains(&qid("CraftWood")));
-        assert!(detail.consumed_by.contains(&qid("CraftSticks")));
-        assert!(detail.consumed_by.contains(&qid("CraftWoodPick")));
+        let detail = mock.inspect_class(&qname("Wood")).unwrap();
+        assert!(detail.produced_by.contains(&qname("CraftWood")));
+        assert!(detail.consumed_by.contains(&qname("CraftSticks")));
+        assert!(detail.consumed_by.contains(&qname("CraftWoodPick")));
     }
 
     #[test]
     fn test_inspect_unknown_class() {
         let mock = MockCraftOps::new();
-        assert!(mock.inspect_class("craft-basics::Diamond").is_err());
+        assert!(mock.inspect_class(&qname("Diamond")).is_err());
     }
 
     #[test]
     fn test_check_feasibility_feasible() {
         let mock = MockCraftOps::new();
-        let report = mock.check_feasibility(&qid("CraftWoodPick")).unwrap();
+        let report = mock.check_feasibility(&qname("CraftWoodPick")).unwrap();
         assert!(report.feasible);
         assert!(report.missing_inputs.is_empty());
         assert_eq!(report.available_inputs.len(), 2);
@@ -459,7 +447,7 @@ mod tests {
     #[test]
     fn test_check_feasibility_missing() {
         let mock = MockCraftOps::new();
-        let report = mock.check_feasibility(&qid("CraftStonePick")).unwrap();
+        let report = mock.check_feasibility(&qname("CraftStonePick")).unwrap();
         // We have Stone and Stick, so this should be feasible
         assert!(report.feasible);
     }
@@ -467,7 +455,7 @@ mod tests {
     #[test]
     fn test_check_feasibility_unknown_action() {
         let mock = MockCraftOps::new();
-        assert!(mock.check_feasibility(&qid("CraftDiamond")).is_err());
+        assert!(mock.check_feasibility(&qname("CraftDiamond")).is_err());
     }
 
     #[test]
@@ -475,7 +463,7 @@ mod tests {
         let mock = MockCraftOps::new();
         let result = mock
             .run_action(RunActionInput {
-                action_id: qid("CraftWood"),
+                action: qname("CraftWood"),
                 input_object_paths: vec!["craft-basics__log_0xabc1.dobj".to_string()],
             })
             .unwrap();
@@ -486,7 +474,7 @@ mod tests {
     fn test_run_action_already_in_progress() {
         let mock = MockCraftOps::new().with_action_in_progress();
         let result = mock.run_action(RunActionInput {
-            action_id: qid("CraftWood"),
+            action: qname("CraftWood"),
             input_object_paths: vec!["craft-basics__log_0xabc1.dobj".to_string()],
         });
         assert!(result.is_err());
@@ -502,7 +490,7 @@ mod tests {
     fn test_run_action_unknown() {
         let mock = MockCraftOps::new();
         let result = mock.run_action(RunActionInput {
-            action_id: qid("CraftDiamond"),
+            action: qname("CraftDiamond"),
             input_object_paths: vec![],
         });
         assert!(result.is_err());

--- a/mcp/src/mock.rs
+++ b/mcp/src/mock.rs
@@ -216,8 +216,7 @@ impl CraftOps for MockCraftOps {
                 });
             } else {
                 missing_class_ids.push(required_class_id.clone());
-                missing_class_names
-                    .push(action.total_input_class_names[slot].clone());
+                missing_class_names.push(action.total_input_class_names[slot].clone());
             }
         }
 
@@ -231,16 +230,20 @@ impl CraftOps for MockCraftOps {
     }
 }
 
-fn make_obj(id: &str, class: &str, file_name: &str, tx_hash: &str, status: &str, extra: Vec<(&str, serde_json::Value)>) -> InventoryObject {
+fn make_obj(
+    id: &str,
+    class: &str,
+    file_name: &str,
+    tx_hash: &str,
+    status: &str,
+    extra: Vec<(&str, serde_json::Value)>,
+) -> InventoryObject {
     let mut fields = HashMap::from([
         (
             "blueprint".to_string(),
             serde_json::Value::String(class.to_string()),
         ),
-        (
-            "key".to_string(),
-            serde_json::Value::String(id.to_string()),
-        ),
+        ("key".to_string(), serde_json::Value::String(id.to_string())),
     ]);
     for (k, v) in extra {
         fields.insert(k.to_string(), v);
@@ -311,12 +314,7 @@ fn default_inventory() -> Vec<InventoryObject> {
     ]
 }
 
-fn make_action(
-    name: &str,
-    description: &str,
-    inputs: &[&str],
-    outputs: &[&str],
-) -> Action {
+fn make_action(name: &str, description: &str, inputs: &[&str], outputs: &[&str]) -> Action {
     Action {
         id: qid(name),
         display_name: name.to_string(),
@@ -331,7 +329,12 @@ fn make_action(
 
 fn default_actions() -> Vec<Action> {
     vec![
-        make_action("FindLog", "Discover a log by proving a short VDF", &[], &["Log"]),
+        make_action(
+            "FindLog",
+            "Discover a log by proving a short VDF",
+            &[],
+            &["Log"],
+        ),
         make_action("CraftWood", "Refine one log into wood", &["Log"], &["Wood"]),
         make_action(
             "CraftSticks",

--- a/mcp/src/mock.rs
+++ b/mcp/src/mock.rs
@@ -73,13 +73,13 @@ impl CraftOps for MockCraftOps {
                 let produced_by = self
                     .actions
                     .iter()
-                    .filter(|a| a.total_output_class_ids.contains(&class_id))
+                    .filter(|a| a.total_outputs.iter().any(|r| r.id == class_id))
                     .map(|a| a.id.clone())
                     .collect();
                 let consumed_by = self
                     .actions
                     .iter()
-                    .filter(|a| a.total_input_class_ids.contains(&class_id))
+                    .filter(|a| a.total_inputs.iter().any(|r| r.id == class_id))
                     .map(|a| a.id.clone())
                     .collect();
                 ClassSummary {
@@ -123,12 +123,12 @@ impl CraftOps for MockCraftOps {
         let actions = &self.actions;
         let produced_by = actions
             .iter()
-            .filter(|a| a.total_output_class_ids.contains(&class_id.to_string()))
+            .filter(|a| a.total_outputs.iter().any(|r| r.id == class_id))
             .map(|a| a.id.clone())
             .collect();
         let consumed_by = actions
             .iter()
-            .filter(|a| a.total_input_class_ids.contains(&class_id.to_string()))
+            .filter(|a| a.total_inputs.iter().any(|r| r.id == class_id))
             .map(|a| a.id.clone())
             .collect();
 
@@ -198,14 +198,13 @@ impl CraftOps for MockCraftOps {
             .ok_or_else(|| anyhow!("unknown action: {action_id}"))?;
 
         let mut available = Vec::new();
-        let mut missing_class_ids = Vec::new();
-        let mut missing_class_names = Vec::new();
+        let mut missing_inputs = Vec::new();
 
-        for (slot, required_class_id) in action.total_input_class_ids.iter().enumerate() {
+        for required in &action.total_inputs {
             if let Some(obj) = self
                 .inventory
                 .iter()
-                .find(|o| &o.class_id == required_class_id && o.status == "live")
+                .find(|o| o.class_id == required.id && o.status == "live")
             {
                 available.push(FeasibilityInput {
                     class_id: obj.class_id.clone(),
@@ -215,17 +214,15 @@ impl CraftOps for MockCraftOps {
                     file_name: obj.file_name.clone(),
                 });
             } else {
-                missing_class_ids.push(required_class_id.clone());
-                missing_class_names.push(action.total_input_class_names[slot].clone());
+                missing_inputs.push(required.clone());
             }
         }
 
         Ok(FeasibilityReport {
-            feasible: missing_class_ids.is_empty(),
+            feasible: missing_inputs.is_empty(),
             action_id: action_id.to_string(),
             available_inputs: available,
-            missing_input_class_ids: missing_class_ids,
-            missing_input_class_names: missing_class_names,
+            missing_inputs,
         })
     }
 }
@@ -315,15 +312,23 @@ fn default_inventory() -> Vec<InventoryObject> {
 }
 
 fn make_action(name: &str, description: &str, inputs: &[&str], outputs: &[&str]) -> Action {
+    let to_refs = |classes: &[&str]| -> Vec<ClassRef> {
+        classes
+            .iter()
+            .map(|c| ClassRef {
+                id: qid(c),
+                display_name: c.to_string(),
+                hash: format!("0x{}", "0".repeat(64)),
+            })
+            .collect()
+    };
     Action {
         id: qid(name),
         display_name: name.to_string(),
         plugin_name: PLUGIN.to_string(),
         description: description.to_string(),
-        total_input_class_ids: inputs.iter().map(|c| qid(c)).collect(),
-        total_input_class_names: inputs.iter().map(|c| c.to_string()).collect(),
-        total_output_class_ids: outputs.iter().map(|c| qid(c)).collect(),
-        total_output_class_names: outputs.iter().map(|c| c.to_string()).collect(),
+        total_inputs: to_refs(inputs),
+        total_outputs: to_refs(outputs),
     }
 }
 
@@ -447,7 +452,7 @@ mod tests {
         let mock = MockCraftOps::new();
         let report = mock.check_feasibility(&qid("CraftWoodPick")).unwrap();
         assert!(report.feasible);
-        assert!(report.missing_input_class_ids.is_empty());
+        assert!(report.missing_inputs.is_empty());
         assert_eq!(report.available_inputs.len(), 2);
     }
 

--- a/mcp/src/ops.rs
+++ b/mcp/src/ops.rs
@@ -9,9 +9,9 @@ pub trait CraftOps: Send + Sync + 'static {
     fn list_classes(&self) -> anyhow::Result<Vec<ClassSummary>>;
     fn get_state_root(&self) -> anyhow::Result<String>;
     fn inspect_object(&self, object_id: &str) -> anyhow::Result<ObjectDetail>;
-    fn inspect_class(&self, class_id: &str) -> anyhow::Result<ClassDetail>;
+    fn inspect_class(&self, class: &QualifiedName) -> anyhow::Result<ClassDetail>;
     fn run_action(&self, input: RunActionInput) -> anyhow::Result<RunActionResult>;
-    fn check_feasibility(&self, action_id: &str) -> anyhow::Result<FeasibilityReport>;
+    fn check_feasibility(&self, action: &QualifiedName) -> anyhow::Result<FeasibilityReport>;
 
     /// Returns the generated podlang source for all actions and classes,
     /// or None if not available (e.g. in mock mode).

--- a/mcp/src/ops.rs
+++ b/mcp/src/ops.rs
@@ -9,7 +9,7 @@ pub trait CraftOps: Send + Sync + 'static {
     fn list_classes(&self) -> anyhow::Result<Vec<ClassSummary>>;
     fn get_state_root(&self) -> anyhow::Result<String>;
     fn inspect_object(&self, object_id: &str) -> anyhow::Result<ObjectDetail>;
-    fn inspect_class(&self, class_name: &str) -> anyhow::Result<ClassDetail>;
+    fn inspect_class(&self, class_id: &str) -> anyhow::Result<ClassDetail>;
     fn run_action(&self, input: RunActionInput) -> anyhow::Result<RunActionResult>;
     fn check_feasibility(&self, action_id: &str) -> anyhow::Result<FeasibilityReport>;
 

--- a/mcp/src/server.rs
+++ b/mcp/src/server.rs
@@ -414,7 +414,7 @@ mod tests {
             }))
             .unwrap();
         assert!(!report.feasible);
-        assert!(!report.missing_input_class_ids.is_empty());
+        assert!(!report.missing_inputs.is_empty());
     }
 
     #[tokio::test]

--- a/mcp/src/server.rs
+++ b/mcp/src/server.rs
@@ -41,14 +41,16 @@ pub struct InspectObjectParams {
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct InspectClassParams {
-    /// The qualified class id to inspect, e.g. "craft-basics::WoodPick"
-    pub class_id: String,
+    /// The plugin-scoped class to inspect, e.g.
+    /// `{ "pluginName": "craft-basics", "name": "WoodPick" }`.
+    pub class: QualifiedName,
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct CheckFeasibilityParams {
-    /// The qualified action id to check, e.g. "craft-basics::CraftWoodPick"
-    pub action_id: String,
+    /// The plugin-scoped action to check, e.g.
+    /// `{ "pluginName": "craft-basics", "name": "CraftWoodPick" }`.
+    pub action: QualifiedName,
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -120,7 +122,7 @@ impl<T: CraftOps> CraftMcpService<T> {
         Parameters(params): Parameters<InspectClassParams>,
     ) -> Result<Json<ClassDetail>, String> {
         self.ops
-            .inspect_class(&params.class_id)
+            .inspect_class(&params.class)
             .map(Json)
             .map_err(|e| e.to_string())
     }
@@ -150,7 +152,7 @@ impl<T: CraftOps> CraftMcpService<T> {
         Parameters(params): Parameters<CheckFeasibilityParams>,
     ) -> Result<Json<FeasibilityReport>, String> {
         self.ops
-            .check_feasibility(&params.action_id)
+            .check_feasibility(&params.action)
             .map(Json)
             .map_err(|e| e.to_string())
     }
@@ -301,12 +303,19 @@ mod tests {
         assert!(info.instructions.unwrap().contains("ZK-Craft MCP Server"));
     }
 
+    fn craft_basics(name: &str) -> QualifiedName {
+        QualifiedName {
+            plugin_name: "craft-basics".to_string(),
+            name: name.to_string(),
+        }
+    }
+
     #[test]
     fn test_list_inventory_returns_structured() {
         let service = make_service();
         let Json(list) = service.list_inventory().unwrap();
         assert!(!list.objects.is_empty());
-        assert!(list.objects.iter().any(|o| o.class_display_name == "Log"));
+        assert!(list.objects.iter().any(|o| o.class.name == "Log"));
     }
 
     #[test]
@@ -317,7 +326,7 @@ mod tests {
         assert!(
             list.actions
                 .iter()
-                .any(|a| a.id == "craft-basics::CraftWoodPick")
+                .any(|a| a.action == craft_basics("CraftWoodPick"))
         );
     }
 
@@ -336,7 +345,7 @@ mod tests {
                 object_id: "0xabc4444444444444".to_string(),
             }))
             .unwrap();
-        assert_eq!(detail.class_display_name, "WoodPick");
+        assert_eq!(detail.class.name, "WoodPick");
         assert!(detail.predicate_source.contains("CraftWoodPick"));
     }
 
@@ -355,15 +364,11 @@ mod tests {
         let service = make_service();
         let Json(detail) = service
             .inspect_class(Parameters(InspectClassParams {
-                class_id: "craft-basics::Stick".to_string(),
+                class: craft_basics("Stick"),
             }))
             .unwrap();
-        assert_eq!(detail.class_display_name, "Stick");
-        assert!(
-            detail
-                .produced_by
-                .contains(&"craft-basics::CraftSticks".to_string())
-        );
+        assert_eq!(detail.class.name, "Stick");
+        assert!(detail.produced_by.contains(&craft_basics("CraftSticks")));
     }
 
     #[tokio::test]
@@ -371,7 +376,7 @@ mod tests {
         let service = make_service();
         let Json(result) = service
             .run_action(Parameters(RunActionInput {
-                action_id: "craft-basics::FindLog".to_string(),
+                action: craft_basics("FindLog"),
                 input_object_paths: vec![],
             }))
             .await
@@ -384,7 +389,7 @@ mod tests {
         let service = CraftMcpService::new(Arc::new(MockCraftOps::new().with_action_in_progress()));
         let result = service
             .run_action(Parameters(RunActionInput {
-                action_id: "craft-basics::FindLog".to_string(),
+                action: craft_basics("FindLog"),
                 input_object_paths: vec![],
             }))
             .await;
@@ -397,7 +402,7 @@ mod tests {
         let service = make_service();
         let Json(report) = service
             .check_feasibility(Parameters(CheckFeasibilityParams {
-                action_id: "craft-basics::CraftWoodPick".to_string(),
+                action: craft_basics("CraftWoodPick"),
             }))
             .unwrap();
         assert!(report.feasible);
@@ -410,7 +415,7 @@ mod tests {
         let service = CraftMcpService::new(Arc::new(mock));
         let Json(report) = service
             .check_feasibility(Parameters(CheckFeasibilityParams {
-                action_id: "craft-basics::CraftWoodPick".to_string(),
+                action: craft_basics("CraftWoodPick"),
             }))
             .unwrap();
         assert!(!report.feasible);

--- a/mcp/src/server.rs
+++ b/mcp/src/server.rs
@@ -41,13 +41,13 @@ pub struct InspectObjectParams {
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct InspectClassParams {
-    /// The qualified class id to inspect, e.g. "craft-basics:WoodPick"
+    /// The qualified class id to inspect, e.g. "craft-basics::WoodPick"
     pub class_id: String,
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct CheckFeasibilityParams {
-    /// The qualified action id to check, e.g. "craft-basics:CraftWoodPick"
+    /// The qualified action id to check, e.g. "craft-basics::CraftWoodPick"
     pub action_id: String,
 }
 
@@ -317,7 +317,7 @@ mod tests {
         assert!(
             list.actions
                 .iter()
-                .any(|a| a.id == "craft-basics:CraftWoodPick")
+                .any(|a| a.id == "craft-basics::CraftWoodPick")
         );
     }
 
@@ -355,14 +355,14 @@ mod tests {
         let service = make_service();
         let Json(detail) = service
             .inspect_class(Parameters(InspectClassParams {
-                class_id: "craft-basics:Stick".to_string(),
+                class_id: "craft-basics::Stick".to_string(),
             }))
             .unwrap();
         assert_eq!(detail.class_display_name, "Stick");
         assert!(
             detail
                 .produced_by
-                .contains(&"craft-basics:CraftSticks".to_string())
+                .contains(&"craft-basics::CraftSticks".to_string())
         );
     }
 
@@ -371,7 +371,7 @@ mod tests {
         let service = make_service();
         let Json(result) = service
             .run_action(Parameters(RunActionInput {
-                action_id: "craft-basics:FindLog".to_string(),
+                action_id: "craft-basics::FindLog".to_string(),
                 input_object_paths: vec![],
             }))
             .await
@@ -384,7 +384,7 @@ mod tests {
         let service = CraftMcpService::new(Arc::new(MockCraftOps::new().with_action_in_progress()));
         let result = service
             .run_action(Parameters(RunActionInput {
-                action_id: "craft-basics:FindLog".to_string(),
+                action_id: "craft-basics::FindLog".to_string(),
                 input_object_paths: vec![],
             }))
             .await;
@@ -397,7 +397,7 @@ mod tests {
         let service = make_service();
         let Json(report) = service
             .check_feasibility(Parameters(CheckFeasibilityParams {
-                action_id: "craft-basics:CraftWoodPick".to_string(),
+                action_id: "craft-basics::CraftWoodPick".to_string(),
             }))
             .unwrap();
         assert!(report.feasible);
@@ -410,7 +410,7 @@ mod tests {
         let service = CraftMcpService::new(Arc::new(mock));
         let Json(report) = service
             .check_feasibility(Parameters(CheckFeasibilityParams {
-                action_id: "craft-basics:CraftWoodPick".to_string(),
+                action_id: "craft-basics::CraftWoodPick".to_string(),
             }))
             .unwrap();
         assert!(!report.feasible);

--- a/mcp/src/server.rs
+++ b/mcp/src/server.rs
@@ -41,13 +41,13 @@ pub struct InspectObjectParams {
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct InspectClassParams {
-    /// The class name to inspect, e.g. "WoodPick"
-    pub class_name: String,
+    /// The qualified class id to inspect, e.g. "craft-basics:WoodPick"
+    pub class_id: String,
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct CheckFeasibilityParams {
-    /// The action ID to check, e.g. "CraftWoodPick"
+    /// The qualified action id to check, e.g. "craft-basics:CraftWoodPick"
     pub action_id: String,
 }
 
@@ -120,7 +120,7 @@ impl<T: CraftOps> CraftMcpService<T> {
         Parameters(params): Parameters<InspectClassParams>,
     ) -> Result<Json<ClassDetail>, String> {
         self.ops
-            .inspect_class(&params.class_name)
+            .inspect_class(&params.class_id)
             .map(Json)
             .map_err(|e| e.to_string())
     }
@@ -306,7 +306,7 @@ mod tests {
         let service = make_service();
         let Json(list) = service.list_inventory().unwrap();
         assert!(!list.objects.is_empty());
-        assert!(list.objects.iter().any(|o| o.class_name == "Log"));
+        assert!(list.objects.iter().any(|o| o.class_display_name == "Log"));
     }
 
     #[test]
@@ -314,7 +314,11 @@ mod tests {
         let service = make_service();
         let Json(list) = service.list_actions().unwrap();
         assert!(!list.actions.is_empty());
-        assert!(list.actions.iter().any(|a| a.id == "CraftWoodPick"));
+        assert!(
+            list.actions
+                .iter()
+                .any(|a| a.id == "craft-basics:CraftWoodPick")
+        );
     }
 
     #[test]
@@ -332,7 +336,7 @@ mod tests {
                 object_id: "0xabc4444444444444".to_string(),
             }))
             .unwrap();
-        assert_eq!(detail.class_name, "WoodPick");
+        assert_eq!(detail.class_display_name, "WoodPick");
         assert!(detail.predicate_source.contains("CraftWoodPick"));
     }
 
@@ -351,11 +355,15 @@ mod tests {
         let service = make_service();
         let Json(detail) = service
             .inspect_class(Parameters(InspectClassParams {
-                class_name: "Stick".to_string(),
+                class_id: "craft-basics:Stick".to_string(),
             }))
             .unwrap();
-        assert_eq!(detail.class_name, "Stick");
-        assert!(detail.produced_by.contains(&"CraftSticks".to_string()));
+        assert_eq!(detail.class_display_name, "Stick");
+        assert!(
+            detail
+                .produced_by
+                .contains(&"craft-basics:CraftSticks".to_string())
+        );
     }
 
     #[tokio::test]
@@ -363,7 +371,7 @@ mod tests {
         let service = make_service();
         let Json(result) = service
             .run_action(Parameters(RunActionInput {
-                action_id: "FindLog".to_string(),
+                action_id: "craft-basics:FindLog".to_string(),
                 input_object_paths: vec![],
             }))
             .await
@@ -376,7 +384,7 @@ mod tests {
         let service = CraftMcpService::new(Arc::new(MockCraftOps::new().with_action_in_progress()));
         let result = service
             .run_action(Parameters(RunActionInput {
-                action_id: "FindLog".to_string(),
+                action_id: "craft-basics:FindLog".to_string(),
                 input_object_paths: vec![],
             }))
             .await;
@@ -389,7 +397,7 @@ mod tests {
         let service = make_service();
         let Json(report) = service
             .check_feasibility(Parameters(CheckFeasibilityParams {
-                action_id: "CraftWoodPick".to_string(),
+                action_id: "craft-basics:CraftWoodPick".to_string(),
             }))
             .unwrap();
         assert!(report.feasible);
@@ -402,11 +410,11 @@ mod tests {
         let service = CraftMcpService::new(Arc::new(mock));
         let Json(report) = service
             .check_feasibility(Parameters(CheckFeasibilityParams {
-                action_id: "CraftWoodPick".to_string(),
+                action_id: "craft-basics:CraftWoodPick".to_string(),
             }))
             .unwrap();
         assert!(!report.feasible);
-        assert!(!report.missing_inputs.is_empty());
+        assert!(!report.missing_input_class_ids.is_empty());
     }
 
     #[tokio::test]

--- a/mcp/src/types.rs
+++ b/mcp/src/types.rs
@@ -29,13 +29,17 @@ pub struct ClassList {
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct ClassSummary {
-    /// Class name, e.g. "WoodPick"
-    pub name: String,
+    /// Qualified class id, e.g. "craft-basics:WoodPick"
+    pub id: String,
+    /// Bare class name, e.g. "WoodPick"
+    pub display_name: String,
+    /// Plugin that declares this class
+    pub plugin_name: String,
     /// Number of live objects of this class in inventory
     pub live_count: usize,
-    /// Actions that produce objects of this class
+    /// Qualified action ids that produce objects of this class
     pub produced_by: Vec<String>,
-    /// Actions that consume objects of this class
+    /// Qualified action ids that consume objects of this class
     pub consumed_by: Vec<String>,
 }
 
@@ -46,9 +50,13 @@ pub struct ClassSummary {
 pub struct InventoryObject {
     /// Unique object identifier (hex hash)
     pub id: String,
-    /// Object class name, e.g. "WoodPick"
-    pub class_name: String,
-    /// The .dobj filename, e.g. "WoodPick.dobj"
+    /// Qualified class id, e.g. "craft-basics:WoodPick"
+    pub class_id: String,
+    /// Bare class name, e.g. "WoodPick"
+    pub class_display_name: String,
+    /// Plugin that declares this object's class
+    pub plugin_name: String,
+    /// The .dobj filename
     pub file_name: String,
     /// Lifecycle status: "unknown", "pending", "live", or "nullified"
     pub status: String,
@@ -61,14 +69,22 @@ pub struct InventoryObject {
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct Action {
-    /// Action identifier, e.g. "CraftWoodPick"
+    /// Qualified action id, e.g. "craft-basics:CraftWoodPick"
     pub id: String,
+    /// Bare action name, e.g. "CraftWoodPick"
+    pub display_name: String,
+    /// Plugin that provides this action
+    pub plugin_name: String,
     /// Human-readable description
     pub description: String,
-    /// Class names required as inputs
-    pub total_input_classes: Vec<String>,
-    /// Class names produced as outputs
-    pub total_output_classes: Vec<String>,
+    /// Qualified class ids required as inputs
+    pub total_input_class_ids: Vec<String>,
+    /// Bare class names parallel to `total_input_class_ids`
+    pub total_input_class_names: Vec<String>,
+    /// Qualified class ids produced as outputs
+    pub total_output_class_ids: Vec<String>,
+    /// Bare class names parallel to `total_output_class_ids`
+    pub total_output_class_names: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
@@ -85,8 +101,12 @@ pub struct StateRootResponse {
 pub struct ObjectDetail {
     /// Unique object identifier (hex hash)
     pub id: String,
-    /// Object class name
-    pub class_name: String,
+    /// Qualified class id, e.g. "craft-basics:WoodPick"
+    pub class_id: String,
+    /// Bare class name, e.g. "WoodPick"
+    pub class_display_name: String,
+    /// Plugin that declares this object's class
+    pub plugin_name: String,
     /// Lifecycle status: "unknown", "pending", "live", or "nullified"
     pub status: String,
     /// Transaction commitment hash (hex) if this object has been submitted
@@ -100,13 +120,17 @@ pub struct ObjectDetail {
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct ClassDetail {
-    /// Class name
-    pub class_name: String,
+    /// Qualified class id, e.g. "craft-basics:WoodPick"
+    pub class_id: String,
+    /// Bare class name
+    pub class_display_name: String,
+    /// Plugin that declares this class
+    pub plugin_name: String,
     /// Predicate definition in podlang source
     pub predicate_source: String,
-    /// Actions that produce objects of this class
+    /// Qualified action ids that produce objects of this class
     pub produced_by: Vec<String>,
-    /// Actions that consume objects of this class
+    /// Qualified action ids that consume objects of this class
     pub consumed_by: Vec<String>,
 }
 
@@ -115,7 +139,7 @@ pub struct ClassDetail {
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct RunActionInput {
-    /// The action to execute, e.g. "CraftWoodPick"
+    /// The qualified action id to execute, e.g. "craft-basics:CraftWoodPick"
     pub action_id: String,
     /// Paths to .dobj files to use as inputs
     pub input_object_paths: Vec<String>,
@@ -139,19 +163,25 @@ pub struct RunActionResult {
 pub struct FeasibilityReport {
     /// Whether the action can be executed with current inventory
     pub feasible: bool,
-    /// The action being checked
+    /// The qualified action id being checked
     pub action_id: String,
     /// Objects available to satisfy input requirements
     pub available_inputs: Vec<FeasibilityInput>,
-    /// Input classes that have no matching object in inventory
-    pub missing_inputs: Vec<String>,
+    /// Qualified class ids that have no matching object in inventory
+    pub missing_input_class_ids: Vec<String>,
+    /// Bare class names parallel to `missing_input_class_ids`
+    pub missing_input_class_names: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct FeasibilityInput {
-    /// Class name of the available object
-    pub class_name: String,
+    /// Qualified class id of the available object
+    pub class_id: String,
+    /// Bare class name
+    pub class_display_name: String,
+    /// Plugin that declares the class
+    pub plugin_name: String,
     /// Object identifier
     pub object_id: String,
     /// The .dobj filename

--- a/mcp/src/types.rs
+++ b/mcp/src/types.rs
@@ -3,6 +3,20 @@ use std::collections::HashMap;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
+/// A name scoped to a plugin. Both classes and actions are identified by a
+/// `(plugin_name, name)` pair; the printable form `<plugin>::<name>` matches
+/// podlang's namespaced-predicate syntax. The MCP crate carries its own
+/// mirror of `driver::QualifiedName` so the MCP boundary doesn't pull in
+/// the rest of the driver crate.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct QualifiedName {
+    /// Originating plugin, e.g. "craft-basics".
+    pub plugin_name: String,
+    /// Bare class or action name, e.g. "WoodPick".
+    pub name: String,
+}
+
 // -- List response wrappers (MCP outputSchema requires root type "object") --
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
@@ -29,18 +43,14 @@ pub struct ClassList {
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct ClassSummary {
-    /// Qualified class id, e.g. "craft-basics::WoodPick"
-    pub id: String,
-    /// Bare class name, e.g. "WoodPick"
-    pub display_name: String,
-    /// Plugin that declares this class
-    pub plugin_name: String,
+    /// Plugin-scoped class identity.
+    pub class: QualifiedName,
     /// Number of live objects of this class in inventory
     pub live_count: usize,
-    /// Qualified action ids that produce objects of this class
-    pub produced_by: Vec<String>,
-    /// Qualified action ids that consume objects of this class
-    pub consumed_by: Vec<String>,
+    /// Actions that produce objects of this class
+    pub produced_by: Vec<QualifiedName>,
+    /// Actions that consume objects of this class
+    pub consumed_by: Vec<QualifiedName>,
 }
 
 // -- Inventory / State --
@@ -50,12 +60,8 @@ pub struct ClassSummary {
 pub struct InventoryObject {
     /// Unique object identifier (hex hash)
     pub id: String,
-    /// Qualified class id, e.g. "craft-basics::WoodPick"
-    pub class_id: String,
-    /// Bare class name, e.g. "WoodPick"
-    pub class_display_name: String,
-    /// Plugin that declares this object's class
-    pub plugin_name: String,
+    /// Plugin-scoped class identity.
+    pub class: QualifiedName,
     /// The .dobj filename
     pub file_name: String,
     /// Lifecycle status: "unknown", "pending", "live", or "nullified"
@@ -69,10 +75,8 @@ pub struct InventoryObject {
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct ClassRef {
-    /// Qualified class id, e.g. "craft-basics::WoodPick"
-    pub id: String,
-    /// Bare class name, e.g. "WoodPick"
-    pub display_name: String,
+    /// Plugin-scoped class identity.
+    pub class: QualifiedName,
     /// Hex-encoded `Is{class}` predicate hash
     pub hash: String,
 }
@@ -80,12 +84,8 @@ pub struct ClassRef {
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct Action {
-    /// Qualified action id, e.g. "craft-basics::CraftWoodPick"
-    pub id: String,
-    /// Bare action name, e.g. "CraftWoodPick"
-    pub display_name: String,
-    /// Plugin that provides this action
-    pub plugin_name: String,
+    /// Plugin-scoped action identity.
+    pub action: QualifiedName,
     /// Human-readable description
     pub description: String,
     /// Classes required as inputs
@@ -108,12 +108,8 @@ pub struct StateRootResponse {
 pub struct ObjectDetail {
     /// Unique object identifier (hex hash)
     pub id: String,
-    /// Qualified class id, e.g. "craft-basics::WoodPick"
-    pub class_id: String,
-    /// Bare class name, e.g. "WoodPick"
-    pub class_display_name: String,
-    /// Plugin that declares this object's class
-    pub plugin_name: String,
+    /// Plugin-scoped class identity.
+    pub class: QualifiedName,
     /// Lifecycle status: "unknown", "pending", "live", or "nullified"
     pub status: String,
     /// Transaction commitment hash (hex) if this object has been submitted
@@ -127,18 +123,14 @@ pub struct ObjectDetail {
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct ClassDetail {
-    /// Qualified class id, e.g. "craft-basics::WoodPick"
-    pub class_id: String,
-    /// Bare class name
-    pub class_display_name: String,
-    /// Plugin that declares this class
-    pub plugin_name: String,
+    /// Plugin-scoped class identity.
+    pub class: QualifiedName,
     /// Predicate definition in podlang source
     pub predicate_source: String,
-    /// Qualified action ids that produce objects of this class
-    pub produced_by: Vec<String>,
-    /// Qualified action ids that consume objects of this class
-    pub consumed_by: Vec<String>,
+    /// Actions that produce objects of this class
+    pub produced_by: Vec<QualifiedName>,
+    /// Actions that consume objects of this class
+    pub consumed_by: Vec<QualifiedName>,
 }
 
 // -- Actions --
@@ -146,8 +138,8 @@ pub struct ClassDetail {
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct RunActionInput {
-    /// The qualified action id to execute, e.g. "craft-basics::CraftWoodPick"
-    pub action_id: String,
+    /// Plugin-scoped action to execute, e.g. `{pluginName: "craft-basics", name: "CraftWoodPick"}`.
+    pub action: QualifiedName,
     /// Paths to .dobj files to use as inputs
     pub input_object_paths: Vec<String>,
 }
@@ -170,8 +162,8 @@ pub struct RunActionResult {
 pub struct FeasibilityReport {
     /// Whether the action can be executed with current inventory
     pub feasible: bool,
-    /// The qualified action id being checked
-    pub action_id: String,
+    /// The action being checked
+    pub action: QualifiedName,
     /// Objects available to satisfy input requirements
     pub available_inputs: Vec<FeasibilityInput>,
     /// Slots that had no eligible object in inventory
@@ -181,12 +173,8 @@ pub struct FeasibilityReport {
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct FeasibilityInput {
-    /// Qualified class id of the available object
-    pub class_id: String,
-    /// Bare class name
-    pub class_display_name: String,
-    /// Plugin that declares the class
-    pub plugin_name: String,
+    /// Plugin-scoped class identity of the available object.
+    pub class: QualifiedName,
     /// Object identifier
     pub object_id: String,
     /// The .dobj filename

--- a/mcp/src/types.rs
+++ b/mcp/src/types.rs
@@ -68,6 +68,17 @@ pub struct InventoryObject {
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
+pub struct ClassRef {
+    /// Qualified class id, e.g. "craft-basics:WoodPick"
+    pub id: String,
+    /// Bare class name, e.g. "WoodPick"
+    pub display_name: String,
+    /// Hex-encoded `Is{class}` predicate hash
+    pub hash: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct Action {
     /// Qualified action id, e.g. "craft-basics:CraftWoodPick"
     pub id: String,
@@ -77,14 +88,10 @@ pub struct Action {
     pub plugin_name: String,
     /// Human-readable description
     pub description: String,
-    /// Qualified class ids required as inputs
-    pub total_input_class_ids: Vec<String>,
-    /// Bare class names parallel to `total_input_class_ids`
-    pub total_input_class_names: Vec<String>,
-    /// Qualified class ids produced as outputs
-    pub total_output_class_ids: Vec<String>,
-    /// Bare class names parallel to `total_output_class_ids`
-    pub total_output_class_names: Vec<String>,
+    /// Classes required as inputs
+    pub total_inputs: Vec<ClassRef>,
+    /// Classes produced as outputs
+    pub total_outputs: Vec<ClassRef>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
@@ -167,10 +174,8 @@ pub struct FeasibilityReport {
     pub action_id: String,
     /// Objects available to satisfy input requirements
     pub available_inputs: Vec<FeasibilityInput>,
-    /// Qualified class ids that have no matching object in inventory
-    pub missing_input_class_ids: Vec<String>,
-    /// Bare class names parallel to `missing_input_class_ids`
-    pub missing_input_class_names: Vec<String>,
+    /// Slots that had no eligible object in inventory
+    pub missing_inputs: Vec<ClassRef>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]

--- a/mcp/src/types.rs
+++ b/mcp/src/types.rs
@@ -29,7 +29,7 @@ pub struct ClassList {
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct ClassSummary {
-    /// Qualified class id, e.g. "craft-basics:WoodPick"
+    /// Qualified class id, e.g. "craft-basics::WoodPick"
     pub id: String,
     /// Bare class name, e.g. "WoodPick"
     pub display_name: String,
@@ -50,7 +50,7 @@ pub struct ClassSummary {
 pub struct InventoryObject {
     /// Unique object identifier (hex hash)
     pub id: String,
-    /// Qualified class id, e.g. "craft-basics:WoodPick"
+    /// Qualified class id, e.g. "craft-basics::WoodPick"
     pub class_id: String,
     /// Bare class name, e.g. "WoodPick"
     pub class_display_name: String,
@@ -69,7 +69,7 @@ pub struct InventoryObject {
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct ClassRef {
-    /// Qualified class id, e.g. "craft-basics:WoodPick"
+    /// Qualified class id, e.g. "craft-basics::WoodPick"
     pub id: String,
     /// Bare class name, e.g. "WoodPick"
     pub display_name: String,
@@ -80,7 +80,7 @@ pub struct ClassRef {
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct Action {
-    /// Qualified action id, e.g. "craft-basics:CraftWoodPick"
+    /// Qualified action id, e.g. "craft-basics::CraftWoodPick"
     pub id: String,
     /// Bare action name, e.g. "CraftWoodPick"
     pub display_name: String,
@@ -108,7 +108,7 @@ pub struct StateRootResponse {
 pub struct ObjectDetail {
     /// Unique object identifier (hex hash)
     pub id: String,
-    /// Qualified class id, e.g. "craft-basics:WoodPick"
+    /// Qualified class id, e.g. "craft-basics::WoodPick"
     pub class_id: String,
     /// Bare class name, e.g. "WoodPick"
     pub class_display_name: String,
@@ -127,7 +127,7 @@ pub struct ObjectDetail {
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct ClassDetail {
-    /// Qualified class id, e.g. "craft-basics:WoodPick"
+    /// Qualified class id, e.g. "craft-basics::WoodPick"
     pub class_id: String,
     /// Bare class name
     pub class_display_name: String,
@@ -146,7 +146,7 @@ pub struct ClassDetail {
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct RunActionInput {
-    /// The qualified action id to execute, e.g. "craft-basics:CraftWoodPick"
+    /// The qualified action id to execute, e.g. "craft-basics::CraftWoodPick"
     pub action_id: String,
     /// Paths to .dobj files to use as inputs
     pub input_object_paths: Vec<String>,

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -79,6 +79,31 @@ fn class_predicate_name(class: &str) -> String {
     format!("Is{class}")
 }
 
+/// Allowlist for class names declared via `action.output("…")` /
+/// `action.input("…")` / `action.mutate("…")` in plugin scripts. Must be
+/// non-empty and contain only ASCII alphanumerics, `-`, or `_`.
+///
+/// Class names appear inside qualified ids (`<plugin>::<name>`) and inside
+/// `.dobj` filename prefixes, so they need to be filename-safe and never
+/// straddle the `::` separator. Validating here — at the earliest entry
+/// point — means a malformed class name fails to compile rather than only
+/// being caught downstream by catalog/filename sanitization.
+fn validate_class_name(class: &str) -> Result<(), String> {
+    if class.is_empty() {
+        return Err("class name must be non-empty".to_string());
+    }
+    if let Some(bad) = class
+        .chars()
+        .find(|c| !(c.is_ascii_alphanumeric() || *c == '-' || *c == '_'))
+    {
+        return Err(format!(
+            "class name {class:?} may only contain ASCII letters, digits, '-', and '_'; \
+             rejected character {bad:?}"
+        ));
+    }
+    Ok(())
+}
+
 /// An instruction records the structural shape of one rhai-level
 /// operation. Pure Load-time data, enough to render podlang and to
 /// derive metadata. Statement-producing operations push their
@@ -410,6 +435,9 @@ impl ActionHandle {
         })
     }
     fn obj_io(self, io: ObjectIO, class: String) -> RuntimeResult<ArgHandle> {
+        if let Err(msg) = validate_class_name(&class) {
+            return Err(msg.into());
+        }
         let arg = Rc::new(RefCell::new(VarOrValue::var(Type::Dict)));
         let mut ctx = self.0.borrow_mut();
         let mut original: Option<Dictionary> = None;

--- a/sdk/src/tests.rs
+++ b/sdk/src/tests.rs
@@ -309,3 +309,42 @@ fn test_action_no_private_args() {
         module.podlang_src
     );
 }
+
+/// Class names go straight into qualified ids (`<plugin>::<class>`) and
+/// `.dobj` filename prefixes. The SDK refuses to compile a script that
+/// declares a class name outside the `[A-Za-z0-9_-]` allowlist so a
+/// malformed name can never reach the catalog or the filesystem in the
+/// first place.
+#[test]
+fn test_class_name_rejects_invalid_chars() {
+    let cases = [
+        // (script body, what makes it invalid)
+        (r#"action.output("Foo/bar");"#, "'/' in class name"),
+        (r#"action.output("Foo\\bar");"#, "'\\' in class name"),
+        (r#"action.output("..");"#, "'..' as class name"),
+        (r#"action.output("weird:class");"#, "':' in class name"),
+        (r#"action.input("with space");"#, "whitespace in class name"),
+        (r#"action.mutate("");"#, "empty class name"),
+    ];
+    let sdk = Sdk::default();
+    for (body, label) in cases {
+        let craft_src = format!(
+            r#"
+fn Bad(action) {{
+    {body}
+}}
+"#
+        );
+        let result = sdk.load_module_from_src_actions(&craft_src, &["Bad"]);
+        match result {
+            Ok(_) => panic!("expected SDK to reject {label}, but the script compiled"),
+            Err(err) => {
+                let msg = err.to_string();
+                assert!(
+                    msg.contains("class name"),
+                    "unexpected error for {label}: {msg}"
+                );
+            }
+        }
+    }
+}

--- a/synchronizer/src/api.rs
+++ b/synchronizer/src/api.rs
@@ -7,7 +7,6 @@ use axum::{
     routing::{get, post},
     Json, Router,
 };
-use hex::FromHex;
 use pod2::{backends::plonky2::primitives::merkletree::MerkleProof, middleware::Hash};
 use synchronizer::api_types::{
     GroundingWitnessRequest, GroundingWitnessResponse, HealthResponse, MembershipRequest,
@@ -23,7 +22,7 @@ use crate::{
     head::CanonicalRoots,
     sync_db::{CurrentSnapshot, SyncDb},
 };
-use common::encode_hash_hex;
+use common::{decode_hash_hex, encode_hash_hex};
 
 const MAX_HASH_QUERY_ITEMS: usize = 256;
 
@@ -419,13 +418,7 @@ fn nullifier_contains_entries(
 }
 
 fn parse_hash_hex(value: &str) -> Result<Hash, (StatusCode, String)> {
-    let trimmed = value.trim().strip_prefix("0x").unwrap_or(value.trim());
-    Hash::from_hex(trimmed).map_err(|err| {
-        (
-            StatusCode::BAD_REQUEST,
-            format!("invalid hash `{value}`: {err}"),
-        )
-    })
+    decode_hash_hex(value.trim()).map_err(|err| (StatusCode::BAD_REQUEST, err.to_string()))
 }
 
 fn internal_error(err: anyhow::Error) -> (StatusCode, String) {


### PR DESCRIPTION
Fixes https://github.com/dobjlabs/zk-craft/issues/80

- Qualified id `<plugin>::<class|action>` (e.g. `craft-basics::CraftWood`) is the canonical handle on disk, in MCP, and across the Tauri wire. Plugin-name uniqueness is enforced at catalog load.
- Display name is the bare label, paired with `pluginName`
- The cryptographic source of truth remains `obj["type"]`, ie the on-chain `Is{class}` predicate hash, which is module-scoped because it derives from the plugin's `module_hash`.