### PR TITLE
Use a Record for state root in txlib

### DIFF
--- a/plugins/craft-basics/manifest.toml
+++ b/plugins/craft-basics/manifest.toml
@@ -2,7 +2,7 @@
 name = "craft-basics"
 version = "0.1.0"
 # Rewritten by `cargo run -p pexe -- build plugins/craft-basics`.
-module_hash = "8a6b9f36768d5bbea8cc1c68d06d52e9d06f5331464c890c3533bb55daba3c75"
+module_hash = "97ee84293bdec99d5dd41a1005e39a2cdefcead01ec6719dd8b9ce8c4d7c6c78"
 
 [[classes]]
 name = "Log"

--- a/plugins/craft-basics/manifest.toml
+++ b/plugins/craft-basics/manifest.toml
@@ -2,7 +2,7 @@
 name = "craft-basics"
 version = "0.1.0"
 # Rewritten by `cargo run -p pexe -- build plugins/craft-basics`.
-module_hash = "1763727958c5c53a93ac5d8ada1363f6a53cb085f9e351e3db77887612f18078"
+module_hash = "8a6b9f36768d5bbea8cc1c68d06d52e9d06f5331464c890c3533bb55daba3c75"
 
 [[classes]]
 name = "Log"

--- a/sdk/src/tests.rs
+++ b/sdk/src/tests.rs
@@ -246,7 +246,7 @@ fn test_sdk_2() {
         [plugin]
         name = "test"
         version = "0.1.0"
-        module_hash = "2d35c4b66e08964e9680cb93a3e8418a77315b421a4e85aba322cefdccbd2c5b"
+        module_hash = "4b73f3a8fa7f2bed3032bedfacd11c9909af751067b7bc4cdb5a92b7389a6168"
 
         [[classes]]
         name = "Log"

--- a/sdk/src/tests.rs
+++ b/sdk/src/tests.rs
@@ -246,7 +246,7 @@ fn test_sdk_2() {
         [plugin]
         name = "test"
         version = "0.1.0"
-        module_hash = "374744f110e3e6b619343aafbe20a927f6fd0cd476b39f15045a6be3f3fe5982"
+        module_hash = "2d35c4b66e08964e9680cb93a3e8418a77315b421a4e85aba322cefdccbd2c5b"
 
         [[classes]]
         name = "Log"

--- a/txlib/src/lib.rs
+++ b/txlib/src/lib.rs
@@ -34,7 +34,7 @@ use pod2::{
     frontend::{Operation, OperationArg},
     middleware::{
         EMPTY_VALUE, Hash, NativeOperation, OperationAux, OperationType, Statement, StrKey, Value,
-        containers::{Dictionary, Set},
+        containers::{Array, Dictionary, Set},
         hash_values,
     },
 };
@@ -75,23 +75,32 @@ impl StateRoot {
         }
     }
 
-    /// Merkleized dictionary view; its commitment is the canonical GSR.
+    /// Padded-array view used as the canonical state root record. Slot
+    /// layout matches the `record StateRoot` declaration in txlib.podlang.
     /// Predicates access fields via anchored-key syntax (e.g.
     /// `state_root.transactions`).
-    pub fn dict(&self) -> Dictionary {
-        dict!({
-            "block_number" => self.block_number,
-            "transactions" => self.transactions_root,
-            "nullifiers" => self.nullifiers_root,
-            "gsrs" => self.gsrs_root
-        })
+    pub fn array(&self) -> Array {
+        Array::new(vec![
+            Value::from(0_i64),
+            Value::from(self.block_number),
+            Value::from(self.transactions_root),
+            Value::from(self.nullifiers_root),
+            Value::from(self.gsrs_root),
+        ])
     }
 
-    /// Commitment of the state root dictionary.
+    /// Commitment of the state root array.
     pub fn hash(&self) -> Hash {
-        self.dict().commitment()
+        self.array().commitment()
     }
 }
+
+/// Slot indices for the `StateRoot` record. Slot 0 is `_pad` (works
+/// around pod2 issue #513); real fields start at slot 1.
+pub const STATE_ROOT_BLOCK_NUMBER_SLOT: usize = 1;
+pub const STATE_ROOT_TRANSACTIONS_SLOT: usize = 2;
+pub const STATE_ROOT_NULLIFIERS_SLOT: usize = 3;
+pub const STATE_ROOT_GSRS_SLOT: usize = 4;
 
 /// Proof-bearing grounding data required to build a new transaction.
 ///
@@ -893,13 +902,13 @@ impl TxBuilder {
         grounding: &GroundingWitness,
     ) -> (Statement, Set, TxStats) {
         let mut stats = TxStats::new();
-        let state_root_dict = grounding.state_root.dict();
+        let state_root_arr = grounding.state_root.array();
 
         if inputs.is_empty() {
             // Base case: empty inputs. state_root is unconstrained here.
             let st = st_custom!(
                 ctx,
-                InputsGrounded(state_root = state_root_dict) = (
+                InputsGrounded(state_root = state_root_arr) = (
                     Equal(set!(), set!()),
                     Statement::None,
                     Statement::None,
@@ -912,18 +921,18 @@ impl TxBuilder {
             return (st, set!(), stats);
         }
 
-        // One DictContains witness for `state_root.transactions`, reused
+        // One ArrayContains witness for `state_root.transactions`, reused
         // as the anchored-key arg for every per-input SetContains below.
-        let (_, txns_proof) = state_root_dict
-            .prove(&StrKey::from("transactions"))
-            .expect("state_root dict has 'transactions' field");
+        let (_, txns_proof) = state_root_arr
+            .prove(STATE_ROOT_TRANSACTIONS_SLOT)
+            .expect("state_root array has transactions slot");
         let st_state_root_transactions = ctx
             .builder
             .priv_op(Operation(
-                OperationType::Native(NativeOperation::DictContainsFromEntries),
+                OperationType::Native(NativeOperation::ArrayContainsFromEntries),
                 vec![
-                    Value::from(state_root_dict.commitment()).into(),
-                    Value::from("transactions").into(),
+                    Value::from(state_root_arr.commitment()).into(),
+                    Value::from(STATE_ROOT_TRANSACTIONS_SLOT as i64).into(),
                     Value::from(grounding.state_root.transactions_root).into(),
                 ],
                 OperationAux::MerkleProof(txns_proof),
@@ -966,7 +975,7 @@ impl TxBuilder {
             record(&mut stats, "InputsGroundedSingle");
             let st = st_custom!(
                 ctx,
-                InputsGrounded(state_root = state_root_dict) = (
+                InputsGrounded(state_root = state_root_arr) = (
                     Statement::None,
                     st_single,
                     Statement::None,
@@ -1018,7 +1027,7 @@ impl TxBuilder {
             record(&mut stats, "InputsGroundedPair");
             let st = st_custom!(
                 ctx,
-                InputsGrounded(state_root = state_root_dict) = (
+                InputsGrounded(state_root = state_root_arr) = (
                     Statement::None,
                     Statement::None,
                     st_pair,
@@ -1061,7 +1070,7 @@ impl TxBuilder {
 
         let mut st = st_custom!(
             ctx,
-            InputsGrounded(state_root = state_root_dict) = (
+            InputsGrounded(state_root = state_root_arr) = (
                 Statement::None,
                 Statement::None,
                 Statement::None,
@@ -1284,9 +1293,9 @@ mod tests {
     }
 
     #[test]
-    fn state_root_hash_matches_dict_commitment() {
+    fn state_root_hash_matches_array_commitment() {
         let sr = StateRoot::new(7, test_hash(1), test_hash(2), test_hash(3));
-        assert_eq!(sr.hash(), sr.dict().commitment());
+        assert_eq!(sr.hash(), sr.array().commitment());
     }
 
     #[test]

--- a/txlib/src/lib.rs
+++ b/txlib/src/lib.rs
@@ -75,19 +75,21 @@ impl StateRoot {
         }
     }
 
-    /// 3-layer hash:
-    ///   H(H(txns_root, nullifiers_root), H(block_number, gsrs_root))
+    /// Merkleized dictionary view; its commitment is the canonical GSR.
+    /// Predicates access fields via anchored-key syntax (e.g.
+    /// `state_root.transactions`).
+    pub fn dict(&self) -> Dictionary {
+        dict!({
+            "block_number" => self.block_number,
+            "transactions" => self.transactions_root,
+            "nullifiers" => self.nullifiers_root,
+            "gsrs" => self.gsrs_root
+        })
+    }
+
+    /// Commitment of the state root dictionary.
     pub fn hash(&self) -> Hash {
-        let txn_nullifiers_hash = hash_values(&[
-            Value::from(self.transactions_root),
-            Value::from(self.nullifiers_root),
-        ]);
-        let block_number_gsrs_hash =
-            hash_values(&[Value::from(self.block_number), Value::from(self.gsrs_root)]);
-        hash_values(&[
-            Value::from(txn_nullifiers_hash),
-            Value::from(block_number_gsrs_hash),
-        ])
+        self.dict().commitment()
     }
 }
 
@@ -891,18 +893,13 @@ impl TxBuilder {
         grounding: &GroundingWitness,
     ) -> (Statement, Set, TxStats) {
         let mut stats = TxStats::new();
-        let state_root = &grounding.state_root;
-        let state_root_hash = state_root.hash();
-        let block_number = state_root.block_number;
-        let transactions_root = state_root.transactions_root;
-        let nullifiers_root = state_root.nullifiers_root;
-        let gsrs_root = state_root.gsrs_root;
+        let state_root_dict = grounding.state_root.dict();
 
         if inputs.is_empty() {
-            // Base case: empty inputs. state_root_hash is unconstrained here.
+            // Base case: empty inputs. state_root is unconstrained here.
             let st = st_custom!(
                 ctx,
-                InputsGrounded(state_root_hash = state_root_hash) = (
+                InputsGrounded(state_root = state_root_dict) = (
                     Equal(set!(), set!()),
                     Statement::None,
                     Statement::None,
@@ -915,28 +912,22 @@ impl TxBuilder {
             return (st, set!(), stats);
         }
 
-        // Intermediate hashes for the 3-layer state-root commitment.
-        let txn_null_hash =
-            hash_values(&[Value::from(transactions_root), Value::from(nullifiers_root)]);
-        let bn_gsrs_hash = hash_values(&[Value::from(block_number), Value::from(gsrs_root)]);
-
-        // Build the three HashOf statements that unpack the state-root
-        // hash once; reused as sub-clauses by each TxInStateRoot below.
-        let st_h_txn_null = ctx
+        // One DictContains witness for `state_root.transactions`, reused
+        // as the anchored-key arg for every per-input SetContains below.
+        let (_, txns_proof) = state_root_dict
+            .prove(&StrKey::from("transactions"))
+            .expect("state_root dict has 'transactions' field");
+        let st_state_root_transactions = ctx
             .builder
-            .priv_op(op!(HashOf(
-                txn_null_hash,
-                transactions_root,
-                nullifiers_root
-            )))
-            .unwrap();
-        let st_h_bn_gsrs = ctx
-            .builder
-            .priv_op(op!(HashOf(bn_gsrs_hash, block_number, gsrs_root)))
-            .unwrap();
-        let st_h_state_root = ctx
-            .builder
-            .priv_op(op!(HashOf(state_root_hash, txn_null_hash, bn_gsrs_hash)))
+            .priv_op(Operation(
+                OperationType::Native(NativeOperation::DictContainsFromEntries),
+                vec![
+                    Value::from(state_root_dict.commitment()).into(),
+                    Value::from("transactions").into(),
+                    Value::from(grounding.state_root.transactions_root).into(),
+                ],
+                OperationAux::MerkleProof(txns_proof),
+            ))
             .unwrap();
 
         let extend_set = |set: &Set, obj: &Dictionary| -> Set {
@@ -946,31 +937,23 @@ impl TxBuilder {
         };
 
         let prove_input = |ctx: &mut BuildContext,
-                           stats: &mut TxStats,
                            evidence: &GroundingEvidence,
                            obj: &Dictionary|
          -> (Statement, Statement) {
-            let st_tx_membership =
-                prove_source_tx_membership(ctx, grounding, transactions_root, evidence.tx_final);
-            let st_tx_in_sr = st_custom!(
+            let st_tx_in_transactions = prove_source_tx_membership(
                 ctx,
-                TxInStateRoot() = (
-                    st_h_txn_null.clone(),
-                    st_h_bn_gsrs.clone(),
-                    st_h_state_root.clone(),
-                    st_tx_membership
-                )
-            )
-            .unwrap();
-            record(stats, "TxInStateRoot");
+                &st_state_root_transactions,
+                grounding,
+                evidence.tx_final,
+            );
             let st_set_contains_live = prove_obj_in_source_tx_live(ctx, evidence, obj);
-            (st_tx_in_sr, st_set_contains_live)
+            (st_tx_in_transactions, st_set_contains_live)
         };
 
         if inputs.len() == 1 {
             let (obj, evidence) = &inputs[0];
             let inputs_set = extend_set(&set!(), obj);
-            let (st_tx_in_sr, st_set_contains_live) = prove_input(ctx, &mut stats, evidence, obj);
+            let (st_tx_in_sr, st_set_contains_live) = prove_input(ctx, evidence, obj);
             let st_single = st_custom!(
                 ctx,
                 InputsGroundedSingle() = (
@@ -983,7 +966,7 @@ impl TxBuilder {
             record(&mut stats, "InputsGroundedSingle");
             let st = st_custom!(
                 ctx,
-                InputsGrounded(state_root_hash = state_root_hash) = (
+                InputsGrounded(state_root = state_root_dict) = (
                     Statement::None,
                     st_single,
                     Statement::None,
@@ -1005,7 +988,7 @@ impl TxBuilder {
 
         let set_first = extend_set(&set!(), first_obj);
         let (st_first_tx_in_sr, st_first_set_contains_live) =
-            prove_input(ctx, &mut stats, first_evidence, first_obj);
+            prove_input(ctx, first_evidence, first_obj);
         let st_igsv = st_custom!(
             ctx,
             InputsGroundedSingleVar() = (
@@ -1019,7 +1002,7 @@ impl TxBuilder {
 
         let inputs_pair = extend_set(&set_first, second_obj);
         let (st_second_tx_in_sr, st_second_set_contains_live) =
-            prove_input(ctx, &mut stats, second_evidence, second_obj);
+            prove_input(ctx, second_evidence, second_obj);
 
         if inputs.len() == 2 {
             let st_pair = st_custom!(
@@ -1035,7 +1018,7 @@ impl TxBuilder {
             record(&mut stats, "InputsGroundedPair");
             let st = st_custom!(
                 ctx,
-                InputsGrounded(state_root_hash = state_root_hash) = (
+                InputsGrounded(state_root = state_root_dict) = (
                     Statement::None,
                     Statement::None,
                     st_pair,
@@ -1063,7 +1046,7 @@ impl TxBuilder {
         let (third_obj, third_evidence) = &inputs[2];
         let inputs_triple = extend_set(&inputs_pair, third_obj);
         let (st_third_tx_in_sr, st_third_set_contains_live) =
-            prove_input(ctx, &mut stats, third_evidence, third_obj);
+            prove_input(ctx, third_evidence, third_obj);
         let st_triple = st_custom!(
             ctx,
             InputsGroundedTriple() = (
@@ -1078,7 +1061,7 @@ impl TxBuilder {
 
         let mut st = st_custom!(
             ctx,
-            InputsGrounded(state_root_hash = state_root_hash) = (
+            InputsGrounded(state_root = state_root_dict) = (
                 Statement::None,
                 Statement::None,
                 Statement::None,
@@ -1092,7 +1075,7 @@ impl TxBuilder {
 
         for (obj, evidence) in &inputs[3..] {
             let next_set = extend_set(&prev_set, obj);
-            let (st_tx_in_sr, st_set_contains_live) = prove_input(ctx, &mut stats, evidence, obj);
+            let (st_tx_in_sr, st_set_contains_live) = prove_input(ctx, evidence, obj);
             let st_rec = st_custom!(
                 ctx,
                 InputsGroundedRecursive() = (
@@ -1122,24 +1105,27 @@ impl TxBuilder {
     }
 }
 
-/// Prove `SetContains(transactions_root, tx_final)` using a Merkle proof
-/// supplied by the grounding witness. The source tx is identified by its
-/// commitment alone (the literal `ctx` dict is not required).
+/// Prove `SetContains(state_root.transactions, tx_hash)`. The supplied
+/// statement must already witness `state_root["transactions"]` so we can
+/// use it for the anchored key.
 fn prove_source_tx_membership(
     ctx: &mut BuildContext,
+    st_state_root_transactions: &Statement,
     grounding: &GroundingWitness,
-    transactions_root: Hash,
-    tx_final: Hash,
+    tx_hash: Hash,
 ) -> Statement {
     let proof = grounding
         .source_tx_proofs
-        .get(&tx_final)
+        .get(&tx_hash)
         .cloned()
         .expect("missing source tx proof in grounding witness");
     ctx.builder
         .priv_op(Operation(
             OperationType::Native(NativeOperation::SetContainsFromEntries),
-            vec![transactions_root.into(), Value::from(tx_final).into()],
+            vec![
+                OperationArg::Statement(st_state_root_transactions.clone()),
+                Value::from(tx_hash).into(),
+            ],
             OperationAux::MerkleProof(proof),
         ))
         .unwrap()
@@ -1190,8 +1176,6 @@ fn prove_obj_in_source_tx_live(
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashSet;
-
     use hex::FromHex;
     use pod2::{
         backends::plonky2::mock::mainpod::MockProver,
@@ -1300,28 +1284,9 @@ mod tests {
     }
 
     #[test]
-    fn state_root_hash_matches_legacy_commitments() {
-        let txns = [test_hash(1), test_hash(2)]
-            .into_iter()
-            .collect::<HashSet<_>>();
-        let nullifiers = [test_hash(3)].into_iter().collect::<HashSet<_>>();
-        let prior_gsrs = [test_hash(4), test_hash(5)];
-
-        let txs = Set::new(txns.iter().map(|hash| Value::from(*hash)).collect());
-        let nulls = Set::new(nullifiers.iter().map(|hash| Value::from(*hash)).collect());
-        let gsrs = Array::new(prior_gsrs.iter().map(|hash| Value::from(*hash)).collect());
-        let compact = StateRoot::new(7, txs.commitment(), nulls.commitment(), gsrs.commitment());
-        let legacy_hash = hash_values(&[
-            Value::from(hash_values(&[
-                Value::from(txs.commitment()),
-                Value::from(nulls.commitment()),
-            ])),
-            Value::from(hash_values(&[
-                Value::from(7_i64),
-                Value::from(gsrs.commitment()),
-            ])),
-        ]);
-        assert_eq!(compact.hash(), legacy_hash);
+    fn state_root_hash_matches_dict_commitment() {
+        let sr = StateRoot::new(7, test_hash(1), test_hash(2), test_hash(3));
+        assert_eq!(sr.hash(), sr.dict().commitment());
     }
 
     #[test]

--- a/txlib/src/predicates/txlib.podlang
+++ b/txlib/src/predicates/txlib.podlang
@@ -18,7 +18,7 @@
 
   4. TxFinalized -- the public entry point. Ties input grounding,
      chain seeding, and full replay together. Exposes
-     (state_root_hash, tx_final, nullifiers) publicly.
+     (state_root, tx_final, nullifiers) publicly.
 
   State convention: most predicates thread four public arguments:
   (before_tx, after_tx, before_chain, after_chain). Each step
@@ -304,10 +304,11 @@ ReplayDelete(before_tx, after_tx, before_chain, after_chain,
 // Inputs Grounded
 // ========================================================
 //
-// The state root is a Merkleized dictionary
-//   { block_number, transactions, nullifiers, gsrs }
-// whose commitment is the canonical GSR. Predicates access its
-// fields via anchored-key syntax (e.g. `state_root.transactions`).
+// The state root is a Record (typed padded array) whose commitment
+// is the canonical GSR. Slot 0 is `_pad` (workaround for pod2 issue
+// #513); real entries are `block_number`, `transactions`, `nullifiers`,
+// `gsrs`. Predicates access fields via anchored-key syntax (e.g.
+// `state_root.transactions` resolves to the transactions set).
 //
 // InputsGrounded proves each input object was live in some prior
 // finalized transaction in `state_root.transactions`.
@@ -320,7 +321,9 @@ ReplayDelete(before_tx, after_tx, before_chain, after_chain,
 // `(inputs, state_root)` signature; Pair/Triple chain through
 // them to expose additional inputs as public args along the way.
 
-InputsGrounded(inputs, state_root) = OR(
+record StateRoot = (_pad, block_number, transactions, nullifiers, gsrs)
+
+InputsGrounded(inputs, state_root StateRoot) = OR(
   // Base case: empty inputs. state_root is intentionally
   // unconstrained -- an empty-input tx needs no prior state.
   Equal(inputs, {})
@@ -332,7 +335,7 @@ InputsGrounded(inputs, state_root) = OR(
 
 // Single-input fast path: avoids the cost of a recursive
 // InputsGrounded call.
-InputsGroundedSingle(inputs, state_root,
+InputsGroundedSingle(inputs, state_root StateRoot,
     private: input, source_tx) = AND(
   SetContains(state_root.transactions, source_tx)
   SetContains(source_tx.live, input)
@@ -343,7 +346,7 @@ InputsGroundedSingle(inputs, state_root,
 // caller (e.g. InputsGroundedPair) can reuse it in a subsequent SetInsert.
 // Not eligible for the InputsGrounded OR directly because the OR requires
 // all branches to share the (inputs, state_root) signature.
-InputsGroundedSingleVar(inputs, state_root, input,
+InputsGroundedSingleVar(inputs, state_root StateRoot, input,
     private: source_tx) = AND(
   SetContains(state_root.transactions, source_tx)
   SetContains(source_tx.live, input)
@@ -354,7 +357,7 @@ InputsGroundedSingleVar(inputs, state_root, input,
 // IG-dispatch + one IGR vs. the recursive chain for N=2.
 // IGSV builds the {first} singleton; the second input is verified inline
 // and inserted into the singleton to form `inputs`.
-InputsGroundedPair(inputs, state_root,
+InputsGroundedPair(inputs, state_root StateRoot,
     private: first_input, second_input, set_first, source_tx_second) = AND(
   InputsGroundedSingleVar(set_first, state_root, first_input)
   SetContains(state_root.transactions, source_tx_second)
@@ -366,7 +369,7 @@ InputsGroundedPair(inputs, state_root,
 // public args so a caller (InputsGroundedTriple) can chain through them.
 // Not eligible for the InputsGrounded OR directly because the OR requires
 // all branches to share the (inputs, state_root) signature.
-InputsGroundedPairVar(inputs, state_root, first_input, second_input,
+InputsGroundedPairVar(inputs, state_root StateRoot, first_input, second_input,
     private: set_first, source_tx_second) = AND(
   InputsGroundedSingleVar(set_first, state_root, first_input)
   SetContains(state_root.transactions, source_tx_second)
@@ -375,9 +378,9 @@ InputsGroundedPairVar(inputs, state_root, first_input, second_input,
 )
 
 // Three-input fast path: grounds three inputs in 4 statements (IG + IGT +
-// IGPV + IGSV). Used directly for N=3, or as the bottom-out for N>=4
-// (after IGR peels off the outer inputs).
-InputsGroundedTriple(inputs, state_root,
+// IGPV + IGSV). Used directly for N=3, or as the bottom-out for N>=4 (after
+// IGR peels off the outer inputs).
+InputsGroundedTriple(inputs, state_root StateRoot,
     private: first_input, second_input, third_input, set_pair,
              source_tx_third) = AND(
   InputsGroundedPairVar(set_pair, state_root, first_input, second_input)
@@ -389,7 +392,7 @@ InputsGroundedTriple(inputs, state_root,
 // 4+ inputs: ground one input, then recurse for the rest. Bottoms out at
 // InputsGroundedTriple for N=4, or at a further IGR -> ... -> IGT chain
 // for larger N.
-InputsGroundedRecursive(inputs, state_root,
+InputsGroundedRecursive(inputs, state_root StateRoot,
     private: input, prev_inputs, source_tx) = AND(
   SetContains(state_root.transactions, source_tx)
   SetContains(source_tx.live, input)
@@ -406,8 +409,8 @@ InputsGroundedRecursive(inputs, state_root,
 // event sequence that produced it.
 
 // Exposes (state_root, tx_final, nullifiers) publicly. The verifier
-// sees `state_root` as a single hash -- the commitment of the state
-// root dictionary { block_number, transactions, nullifiers, gsrs }.
+// sees `state_root` as a single hash -- the commitment of the
+// `StateRoot` record.
 // tx_final is the after_tx dictionary commitment, which binds the
 // live set, nullifiers, and final chain_start/chain_end together. The
 // live set and chain are private. The top-level walker is
@@ -421,8 +424,8 @@ InputsGroundedRecursive(inputs, state_root,
 // values for those two fields (they pass through ReplayActions
 // verbatim into `tx_final`, since ReplayAction only updates the
 // `live` and `nullifiers` keys).
-TxFinalized(state_root, tx_final, nullifiers,
-    private: before_tx, chain_start, chain_final) = AND(
+TxFinalized(state_root StateRoot, tx_final, nullifiers,
+     private: before_tx, chain_start, chain_final) = AND(
   InputsGrounded(before_tx.live, state_root)
   HashOf(chain_start, before_tx.live, 0)
   DictInsert(before_tx, {"nullifiers": {}, "chain_start": 0, "chain_end": 0}, "live", before_tx.live)

--- a/txlib/src/predicates/txlib.podlang
+++ b/txlib/src/predicates/txlib.podlang
@@ -301,60 +301,40 @@ ReplayDelete(before_tx, after_tx, before_chain, after_chain,
 )
 
 // ========================================================
-// State Root
-// ========================================================
-//
-// A state root commits to (block_number, transactions_root,
-// nullifiers_root, gsrs_root) via a 3-layer hash:
-//   state_root = H(H(txns_root, nullifiers_root),
-//                  H(block_number, gsrs_root))
-// block_number anchors the root to an execution block; gsrs_root
-// commits to a prior-GSR history array used by time-based predicates.
-
-// Holds iff `source_txn` is recorded in the transactions set of
-// the state root whose hash is `state_root_hash`. Unpacks the 3-layer
-// state-root hash inline (avoiding a separate StateRoot predicate).
-TxInStateRoot(state_root_hash, source_txn,
-    private: transactions, nullifiers, block_number, gsrs_root,
-             txn_nullifiers_hash, block_number_gsrs_hash) = AND(
-  HashOf(txn_nullifiers_hash, transactions, nullifiers)
-  HashOf(block_number_gsrs_hash, block_number, gsrs_root)
-  HashOf(state_root_hash, txn_nullifiers_hash, block_number_gsrs_hash)
-  SetContains(transactions, source_txn)
-)
-
-// ========================================================
 // Inputs Grounded
 // ========================================================
 //
-// Proves each input object was live in some prior finalized
-// transaction referenced by the state root. For each input, we
-// show that some transaction in that root's transactions set
-// has the input in its live set.
+// The state root is a Merkleized dictionary
+//   { block_number, transactions, nullifiers, gsrs }
+// whose commitment is the canonical GSR. Predicates access its
+// fields via anchored-key syntax (e.g. `state_root.transactions`).
+//
+// InputsGrounded proves each input object was live in some prior
+// finalized transaction in `state_root.transactions`.
 //
 // Same loop-unrolling pattern as ReplayContents above: a recursive
 // OR over inputs, with explicit fast paths for small N (0/1/2/3) to
 // avoid the per-input dispatch cost of the general recursion. The
 // `Var` siblings of Single and Pair exist because the outer
 // InputsGrounded OR requires all branches to share the
-// `(inputs, state_root_hash)` signature; Pair/Triple chain through
+// `(inputs, state_root)` signature; Pair/Triple chain through
 // them to expose additional inputs as public args along the way.
 
-InputsGrounded(inputs, state_root_hash) = OR(
-  // Base case: empty inputs. state_root_hash is intentionally
+InputsGrounded(inputs, state_root) = OR(
+  // Base case: empty inputs. state_root is intentionally
   // unconstrained -- an empty-input tx needs no prior state.
   Equal(inputs, {})
-  InputsGroundedSingle(inputs, state_root_hash)
-  InputsGroundedPair(inputs, state_root_hash)
-  InputsGroundedTriple(inputs, state_root_hash)
-  InputsGroundedRecursive(inputs, state_root_hash)
+  InputsGroundedSingle(inputs, state_root)
+  InputsGroundedPair(inputs, state_root)
+  InputsGroundedTriple(inputs, state_root)
+  InputsGroundedRecursive(inputs, state_root)
 )
 
 // Single-input fast path: avoids the cost of a recursive
 // InputsGrounded call.
-InputsGroundedSingle(inputs, state_root_hash,
+InputsGroundedSingle(inputs, state_root,
     private: input, source_tx) = AND(
-  TxInStateRoot(state_root_hash, source_tx)
+  SetContains(state_root.transactions, source_tx)
   SetContains(source_tx.live, input)
   SetInsert(inputs, {}, input)
 )
@@ -362,10 +342,10 @@ InputsGroundedSingle(inputs, state_root_hash,
 // Same body as InputsGroundedSingle, but `input` is a public arg so a
 // caller (e.g. InputsGroundedPair) can reuse it in a subsequent SetInsert.
 // Not eligible for the InputsGrounded OR directly because the OR requires
-// all branches to share the (inputs, state_root_hash) signature.
-InputsGroundedSingleVar(inputs, state_root_hash, input,
+// all branches to share the (inputs, state_root) signature.
+InputsGroundedSingleVar(inputs, state_root, input,
     private: source_tx) = AND(
-  TxInStateRoot(state_root_hash, source_tx)
+  SetContains(state_root.transactions, source_tx)
   SetContains(source_tx.live, input)
   SetInsert(inputs, {}, input)
 )
@@ -374,10 +354,10 @@ InputsGroundedSingleVar(inputs, state_root_hash, input,
 // IG-dispatch + one IGR vs. the recursive chain for N=2.
 // IGSV builds the {first} singleton; the second input is verified inline
 // and inserted into the singleton to form `inputs`.
-InputsGroundedPair(inputs, state_root_hash,
+InputsGroundedPair(inputs, state_root,
     private: first_input, second_input, set_first, source_tx_second) = AND(
-  InputsGroundedSingleVar(set_first, state_root_hash, first_input)
-  TxInStateRoot(state_root_hash, source_tx_second)
+  InputsGroundedSingleVar(set_first, state_root, first_input)
+  SetContains(state_root.transactions, source_tx_second)
   SetContains(source_tx_second.live, second_input)
   SetInsert(inputs, set_first, second_input)
 )
@@ -385,23 +365,23 @@ InputsGroundedPair(inputs, state_root_hash,
 // Same body as InputsGroundedPair, but first_input and second_input are
 // public args so a caller (InputsGroundedTriple) can chain through them.
 // Not eligible for the InputsGrounded OR directly because the OR requires
-// all branches to share the (inputs, state_root_hash) signature.
-InputsGroundedPairVar(inputs, state_root_hash, first_input, second_input,
+// all branches to share the (inputs, state_root) signature.
+InputsGroundedPairVar(inputs, state_root, first_input, second_input,
     private: set_first, source_tx_second) = AND(
-  InputsGroundedSingleVar(set_first, state_root_hash, first_input)
-  TxInStateRoot(state_root_hash, source_tx_second)
+  InputsGroundedSingleVar(set_first, state_root, first_input)
+  SetContains(state_root.transactions, source_tx_second)
   SetContains(source_tx_second.live, second_input)
   SetInsert(inputs, set_first, second_input)
 )
 
 // Three-input fast path: grounds three inputs in 4 statements (IG + IGT +
-// IGPV + IGSV). Used directly for N=3, or as the bottom-out for N>=4 (after
-// IGR peels off the outer inputs).
-InputsGroundedTriple(inputs, state_root_hash,
+// IGPV + IGSV). Used directly for N=3, or as the bottom-out for N>=4
+// (after IGR peels off the outer inputs).
+InputsGroundedTriple(inputs, state_root,
     private: first_input, second_input, third_input, set_pair,
              source_tx_third) = AND(
-  InputsGroundedPairVar(set_pair, state_root_hash, first_input, second_input)
-  TxInStateRoot(state_root_hash, source_tx_third)
+  InputsGroundedPairVar(set_pair, state_root, first_input, second_input)
+  SetContains(state_root.transactions, source_tx_third)
   SetContains(source_tx_third.live, third_input)
   SetInsert(inputs, set_pair, third_input)
 )
@@ -409,12 +389,12 @@ InputsGroundedTriple(inputs, state_root_hash,
 // 4+ inputs: ground one input, then recurse for the rest. Bottoms out at
 // InputsGroundedTriple for N=4, or at a further IGR -> ... -> IGT chain
 // for larger N.
-InputsGroundedRecursive(inputs, state_root_hash,
+InputsGroundedRecursive(inputs, state_root,
     private: input, prev_inputs, source_tx) = AND(
-  TxInStateRoot(state_root_hash, source_tx)
+  SetContains(state_root.transactions, source_tx)
   SetContains(source_tx.live, input)
   SetInsert(inputs, prev_inputs, input)
-  InputsGrounded(prev_inputs, state_root_hash)
+  InputsGrounded(prev_inputs, state_root)
 )
 
 // ========================================================
@@ -425,7 +405,9 @@ InputsGroundedRecursive(inputs, state_root_hash,
 // certificate: it attests to the final state without revealing the
 // event sequence that produced it.
 
-// Exposes (state_root_hash, tx_final, nullifiers) publicly.
+// Exposes (state_root, tx_final, nullifiers) publicly. The verifier
+// sees `state_root` as a single hash -- the commitment of the state
+// root dictionary { block_number, transactions, nullifiers, gsrs }.
 // tx_final is the after_tx dictionary commitment, which binds the
 // live set, nullifiers, and final chain_start/chain_end together. The
 // live set and chain are private. The top-level walker is
@@ -439,9 +421,9 @@ InputsGroundedRecursive(inputs, state_root_hash,
 // values for those two fields (they pass through ReplayActions
 // verbatim into `tx_final`, since ReplayAction only updates the
 // `live` and `nullifiers` keys).
-TxFinalized(state_root_hash, tx_final, nullifiers,
+TxFinalized(state_root, tx_final, nullifiers,
     private: before_tx, chain_start, chain_final) = AND(
-  InputsGrounded(before_tx.live, state_root_hash)
+  InputsGrounded(before_tx.live, state_root)
   HashOf(chain_start, before_tx.live, 0)
   DictInsert(before_tx, {"nullifiers": {}, "chain_start": 0, "chain_end": 0}, "live", before_tx.live)
   DictContains(tx_final, "nullifiers", nullifiers)


### PR DESCRIPTION
Closes #100

Before we introduced cheap Merkle proofs for shallow Merkle trees, we reduced the number of Merkle proofs by implementing the state root as a hash of the transaction set, the nullifier set, and the past state roots array. This used `HashOf` statements and a custom predicate rather than `SetContains` and anchored keys to access the transaction set.

However, since we now have cheap Merkle proofs, we can return to the simpler approach, which uses fewer statements and eliminates a custom statement per input. This will also make it easier to extend the state root in future, e.g. by adding the created items set.

There is no change in the synchronizer or relayer, this is purely a change in how we expose the global state to txlib.