### PR TITLE
add dev remote

### DIFF
--- a/justfile
+++ b/justfile
@@ -39,6 +39,19 @@ dobjd:
 dev: ensure-plugins ensure-mcp
     mprocs --config mprocs.yaml
 
+# Like `just dev`, but without spawning the local synchronizer + relayer —
+# point dobjd at the hosted public endpoints instead. Faster spin-up when
+# you don't need to fork the chain locally and don't want a local Postgres.
+# Uses the standard 7717 default (same as `just dev`).
+dev-remote: ensure-remote-settings ensure-plugins ensure-mcp
+    mprocs --config mprocs.remote.yaml
+
+# Idempotently point ~/.dobj/settings.json at the hosted synchronizer + relayer
+ensure-remote-settings:
+    @mkdir -p ~/.dobj
+    @printf '{"synchronizerApiUrl":"http://18.217.144.33:3000","relayerApiUrl":"http://18.217.144.33:3200"}\n' > ~/.dobj/settings.json
+    @echo "~/.dobj/settings.json → hosted sync + relayer"
+
 # Install plugins into ~/.dobj/actions/ if none are present. Runs as part of
 # `just dev` so a fresh clone (or a `just reset`-ed dev env) boots cleanly.
 ensure-plugins:

--- a/mprocs.remote.yaml
+++ b/mprocs.remote.yaml
@@ -1,0 +1,7 @@
+procs:
+  dobjd:
+    shell: just dobjd
+  web:
+    shell: just web
+  desktop:
+    shell: just desktop-shell


### PR DESCRIPTION
Add a dev remote command that makes it easy to use the local build against the deployed synchronizer & relayer