### PR TITLE
Identity based on initial object state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5976,7 +5976,7 @@ dependencies = [
 [[package]]
 name = "pod2"
 version = "0.1.0"
-source = "git+https://github.com/0xPARC/pod2?rev=52d96a5a0dfb3e43a3ec8a0c42b8f2b6d40baecc#52d96a5a0dfb3e43a3ec8a0c42b8f2b6d40baecc"
+source = "git+https://github.com/0xPARC/pod2?rev=2b61720cd7103d97d708ab8b15dbcc8a04880fcc#2b61720cd7103d97d708ab8b15dbcc8a04880fcc"
 dependencies = [
  "annotate-snippets",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,7 @@ members = [
 resolver = "2"
 
 [workspace.dependencies]
-# Branch next-2026-05-13
-pod2 = { git = "https://github.com/0xPARC/pod2", rev = "52d96a5a0dfb3e43a3ec8a0c42b8f2b6d40baecc", default-features = false, features = [
+pod2 = { git = "https://github.com/0xPARC/pod2", rev = "2b61720cd7103d97d708ab8b15dbcc8a04880fcc", default-features = false, features = [
     "backend_plonky2",
     "disk_cache",
     "zk",

--- a/plugins/craft-basics/manifest.toml
+++ b/plugins/craft-basics/manifest.toml
@@ -2,7 +2,7 @@
 name = "craft-basics"
 version = "0.1.0"
 # Rewritten by `cargo run -p pexe -- build plugins/craft-basics`.
-module_hash = "0c1b18862f9f9dac2576e8712df821abd828699e88bbe6b8bca84a0898a41516"
+module_hash = "b1209099905ee349660880077b4d1cb34f4296d2913716a0688b6f4b43112a30"
 
 [[classes]]
 name = "Log"

--- a/plugins/craft-basics/manifest.toml
+++ b/plugins/craft-basics/manifest.toml
@@ -2,7 +2,7 @@
 name = "craft-basics"
 version = "0.1.0"
 # Rewritten by `cargo run -p pexe -- build plugins/craft-basics`.
-module_hash = "b1209099905ee349660880077b4d1cb34f4296d2913716a0688b6f4b43112a30"
+module_hash = "cdb831c5a4f0087a6d3a93dee3583f94cda4a7fea90a163f90014356bfab9358"
 
 [[classes]]
 name = "Log"

--- a/plugins/craft-basics/manifest.toml
+++ b/plugins/craft-basics/manifest.toml
@@ -2,7 +2,7 @@
 name = "craft-basics"
 version = "0.1.0"
 # Rewritten by `cargo run -p pexe -- build plugins/craft-basics`.
-module_hash = "97ee84293bdec99d5dd41a1005e39a2cdefcead01ec6719dd8b9ce8c4d7c6c78"
+module_hash = "0c1b18862f9f9dac2576e8712df821abd828699e88bbe6b8bca84a0898a41516"
 
 [[classes]]
 name = "Log"

--- a/plugins/episode-1/manifest.toml
+++ b/plugins/episode-1/manifest.toml
@@ -2,7 +2,7 @@
 name = "episode-1"
 version = "0.1.0"
 # Rewritten by `cargo run -p pexe -- build plugins/episode-1`.
-module_hash = "b0c13279acea87c7222fe5829a82070b3aced7bcd1809471f4348e48b5c6b2af"
+module_hash = "90752a5fac6f39de79c273544169513be681f78b224fa565def49ec927a3b895"
 
 # ── raw resources ────────────────────────────────────────────────────────────
 

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -159,50 +159,53 @@ The emitted podlang embeds `target` as a hex `Raw(0x00…)` literal.
 The example in the test `test_sdk_1` produces the following podlang code:
 
 ```
-use module 0xb1a79d9f0953e49fdcf43697c3c61aa5b59b2b88f5a5dcde8b8c76942dfdd4f4 as tx
-use intro Vdf(count, input, output) from 0xb77a964de74c8569e6c6172692bb50147df9334fd9b572abc8d4d9c688a40e06
-use intro LtEqU256(lhs, rhs) from 0x2e79114ee823f4783ab5b6eb93b49abba87fb69b4d14de4cf1d78648ade73529
+use module 0x1127dce1866ccc4bb6a32782dec35754451ae33ac72e8daaa7e8454be8ac813d as tx
+use intro Vdf(count, input, output) from 0x92586a223c74ba4083d5c5d5b10f9c0a227b91fb2baa2272ffb99faca7adb993
+use intro LtEqU256(lhs, rhs) from 0xd80d0ac8d9d02dc8e9fa3344936a8c9594b915b10a88a4981ceecc462ed03724
 
 record FindLogOut = (_pad, log)
+record FindLogInitials = (_pad, log)
 record CraftWoodIn = (_pad, log)
 record CraftWoodOut = (_pad, wood)
 record CraftSticksIn = (_pad, wood)
 record CraftSticksOut = (_pad, stick_a, stick_b)
 record CraftSticksChain = (_pad, step_0, step_1)
+record CraftSticksInitials = (_pad, stick_a, stick_b)
 record CraftWoodPickIn = (_pad, wood, stick)
 record CraftWoodPickOut = (_pad, pick)
 record CraftWoodPickChain = (_pad, step_0, step_1)
+record CraftWoodPickInitials = (_pad, pick)
 record UseWoodPickIn = (_pad, wood_pick)
 record UseWoodPickOut = (_pad, wood_pick)
 record MineStoneWithWoodPickOut = (_pad, stone)
+record MineStoneWithWoodPickInitials = (_pad, stone)
 
 // Actions
 
-FindLog(out FindLogOut, chain0, chain, private: log0, work) = AND(
+FindLog(out FindLogOut, chain0, chain, private: log0, work, initials FindLogInitials) = AND(
   Vdf(3, log0, work)
-  DictUpdate(out.log, log0, "work", work)
-  tx::TxInsert(chain, chain0, out.log, @self_predicate(IsLog))
+  DictUpdate(initials.log, log0, "work", work)
+  tx::TxInsert(chain, chain0, initials.log, out.log, @self_predicate(IsLog))
 )
 
-CraftWood(in CraftWoodIn, out CraftWoodOut, chain0, chain, private: chain1, wood0, wood, key) = AND(
-  ArrayContains(out, CraftWoodOut::wood, wood)
-  DictUpdate(wood, wood0, "key", key)
-  LtEqU256(wood, Raw(0x0020000000000000000000000000000000000000000000000000000000000000))
+CraftWood(in CraftWoodIn, out CraftWoodOut, chain0, chain, private: chain1, wood0, wood1, key) = AND(
+  DictUpdate(wood1, wood0, "key", key)
+  LtEqU256(wood1, Raw(0x0020000000000000000000000000000000000000000000000000000000000000))
   tx::TxDelete(chain1, chain0, in.log, @self_predicate(IsLog))
-  tx::TxInsert(chain, chain1, wood, @self_predicate(IsWood))
+  tx::TxInsert(chain, chain1, wood1, out.wood, @self_predicate(IsWood))
 )
 
-CraftSticks(in CraftSticksIn, out CraftSticksOut, chain0, chain, private: chain_steps CraftSticksChain) = AND(
+CraftSticks(in CraftSticksIn, out CraftSticksOut, chain0, chain, private: chain_steps CraftSticksChain, initials CraftSticksInitials) = AND(
   tx::TxDelete(chain_steps.step_0, chain0, in.wood, @self_predicate(IsWood))
-  tx::TxInsert(chain_steps.step_1, chain_steps.step_0, out.stick_a, @self_predicate(IsStick))
-  tx::TxInsert(chain, chain_steps.step_1, out.stick_b, @self_predicate(IsStick))
+  tx::TxInsert(chain_steps.step_1, chain_steps.step_0, initials.stick_a, out.stick_a, @self_predicate(IsStick))
+  tx::TxInsert(chain, chain_steps.step_1, initials.stick_b, out.stick_b, @self_predicate(IsStick))
 )
 
-CraftWoodPick(in CraftWoodPickIn, out CraftWoodPickOut, chain0, chain, private: chain_steps CraftWoodPickChain) = AND(
-  DictContains(out.pick, "durability", 100)
+CraftWoodPick(in CraftWoodPickIn, out CraftWoodPickOut, chain0, chain, private: chain_steps CraftWoodPickChain, initials CraftWoodPickInitials) = AND(
+  DictContains(initials.pick, "durability", 100)
   tx::TxDelete(chain_steps.step_0, chain0, in.wood, @self_predicate(IsWood))
   tx::TxDelete(chain_steps.step_1, chain_steps.step_0, in.stick, @self_predicate(IsStick))
-  tx::TxInsert(chain, chain_steps.step_1, out.pick, @self_predicate(IsWoodPick))
+  tx::TxInsert(chain, chain_steps.step_1, initials.pick, out.pick, @self_predicate(IsWoodPick))
 )
 
 UseWoodPick(in UseWoodPickIn, out UseWoodPickOut, chain0, chain, private: wood_pick0, wood_pick1, wood_pick2, durability, key, work) = AND(
@@ -216,9 +219,9 @@ UseWoodPick(in UseWoodPickIn, out UseWoodPickOut, chain0, chain, private: wood_p
   tx::TxMutate(chain, chain0, out.wood_pick, wood_pick0, @self_predicate(IsWoodPick))
 )
 
-MineStoneWithWoodPick(out MineStoneWithWoodPickOut, chain0, chain, private: chain1, _UseWoodPick_in_0 UseWoodPickIn, _UseWoodPick_out_0 UseWoodPickOut) = AND(
+MineStoneWithWoodPick(out MineStoneWithWoodPickOut, chain0, chain, private: chain1, _UseWoodPick_in_0 UseWoodPickIn, _UseWoodPick_out_0 UseWoodPickOut, initials MineStoneWithWoodPickInitials) = AND(
   UseWoodPick(_UseWoodPick_in_0, _UseWoodPick_out_0, chain0, chain1)
-  tx::TxInsert(chain, chain1, out.stone, @self_predicate(IsStone))
+  tx::TxInsert(chain, chain1, initials.stone, out.stone, @self_predicate(IsStone))
 )
 
 // Bridges

--- a/sdk/src/fmt_podlang.rs
+++ b/sdk/src/fmt_podlang.rs
@@ -48,6 +48,17 @@ fn fmt_var_at(name: &str, ts: usize, max_ts: usize) -> String {
     }
 }
 
+/// Output Objects reserve one extra ts beyond the script's last
+/// DictUpdate to hold the implicit identity-stamping step (TxInsert's
+/// `DictInsert(new, initial, "identity", initial)` proves it). The
+/// script-final ts is the pre-identity `initial` wildcard the action
+/// predicate hands to TxInsert; the bumped ts collapses to
+/// `out.<name>` (the post-identity dict that lives in the tx). Mutate
+/// doesn't bump -- TxMutate preserves identity, doesn't stamp it.
+pub(crate) const fn output_max_ts(base_ts: usize, is_output: bool) -> usize {
+    if is_output { base_ts + 1 } else { base_ts }
+}
+
 /// Slot 0 placeholder in every records-form schema (`<Action>In`,
 /// `<Action>Out`, `<Action>Chain`). Real entries start at slot 1.
 /// Works around pod2 issue #513.
@@ -343,6 +354,14 @@ fn fmt_action(action: &ActionContext, loader: &Loader, w: &mut dyn fmt::Write) -
     let alias_names: std::collections::HashSet<String> =
         sub_calls.iter().filter_map(|c| c.alias.clone()).collect();
 
+    let max_ts_for = |var: &str| -> usize {
+        let is_output = meta
+            .object_refs
+            .iter()
+            .any(|o| o.varname == var && o.io == ObjectIO::Output);
+        output_max_ts(action.var_state[var].ts, is_output)
+    };
+
     // Private wildcards: every (var, ts) except sub-action aliases,
     // chain endpoints (public chain0/chain), packed chain intermediates
     // (anchored via the `chain_steps` record), and Object pre/post-form
@@ -353,7 +372,7 @@ fn fmt_action(action: &ActionContext, loader: &Loader, w: &mut dyn fmt::Write) -
         if alias_names.contains(var.as_str()) {
             continue;
         }
-        let max_ts = action.var_state[var].ts;
+        let max_ts = max_ts_for(var);
         for i in 0..=max_ts {
             let skip = if var == "chain" {
                 i == 0 || i == max_ts || chain_step_at(i, max_ts).is_some()
@@ -397,7 +416,7 @@ fn fmt_action(action: &ActionContext, loader: &Loader, w: &mut dyn fmt::Write) -
         .vars
         .iter()
         .map(|v| {
-            let max_ts = action.var_state[v].ts;
+            let max_ts = max_ts_for(v);
             let collapsed_in = meta.collapsed_at(v, 0, max_ts) == Some(Side::In);
             let collapsed_out = meta.collapsed_at(v, max_ts, max_ts) == Some(Side::Out);
             (
@@ -521,6 +540,11 @@ fn fmt_action(action: &ActionContext, loader: &Loader, w: &mut dyn fmt::Write) -
     // internally, so the guard predicate ref is passed as the last
     // arg to TxInsert / TxDelete / TxMutate (and pins both sides for
     // mutate, making the type-preservation check implicit).
+    // For Output, the script's final wildcard (`obj_str`) is the
+    // pre-identity `initial` arg; the bumped-ts rendering
+    // (`obj_with_id`, which collapses to `out.<name>`) is the
+    // post-identity `new` arg that lives in the tx and is bound to
+    // the output record.
     for o in &meta.object_refs {
         let chain = vars["chain"];
         let chain_next = chain.next();
@@ -531,10 +555,13 @@ fn fmt_action(action: &ActionContext, loader: &Loader, w: &mut dyn fmt::Write) -
                 w,
                 "  tx::TxDelete({chain_next}, {chain}, {obj_str}, @self_predicate(Is{class}))"
             )?,
-            ObjectIO::Output => writeln!(
-                w,
-                "  tx::TxInsert({chain_next}, {chain}, {obj_str}, @self_predicate(Is{class}))"
-            )?,
+            ObjectIO::Output => {
+                let obj_with_id = obj_str.next();
+                writeln!(
+                    w,
+                    "  tx::TxInsert({chain_next}, {chain}, {obj_str}, {obj_with_id}, @self_predicate(Is{class}))"
+                )?;
+            }
             ObjectIO::Mutate => {
                 let mut pre = vars[o.varname.as_str()];
                 pre.ts = 0;

--- a/sdk/src/fmt_podlang.rs
+++ b/sdk/src/fmt_podlang.rs
@@ -8,8 +8,8 @@
 //! to the action; the IsX OR is over those bridge predicates.
 
 use crate::{
-    ActionContext, ActionObjectRef, ClassMeta, Dependency, Inst, Intro, Loader, ObjectIO, Ref,
-    VarOrValue,
+    ActionContext, ActionMeta, ActionObjectRef, ClassMeta, Dependency, Inst, Intro, Loader,
+    ObjectIO, Ref, VarOrValue,
 };
 use std::collections::HashMap;
 use std::fmt;
@@ -49,12 +49,9 @@ fn fmt_var_at(name: &str, ts: usize, max_ts: usize) -> String {
 }
 
 /// Output Objects reserve one extra ts beyond the script's last
-/// DictUpdate to hold the implicit identity-stamping step (TxInsert's
-/// `DictInsert(new, initial, "identity", initial)` proves it). The
-/// script-final ts is the pre-identity `initial` wildcard the action
-/// predicate hands to TxInsert; the bumped ts collapses to
-/// `out.<name>` (the post-identity dict that lives in the tx). Mutate
-/// doesn't bump -- TxMutate preserves identity, doesn't stamp it.
+/// DictUpdate to account for the update performed when TxInsert adds
+/// the `identity` entry to the object. This is always the final update
+/// to the object's state before output.
 pub(crate) const fn output_max_ts(base_ts: usize, is_output: bool) -> usize {
     if is_output { base_ts + 1 } else { base_ts }
 }
@@ -97,13 +94,10 @@ pub(crate) fn chain_step_at(ts: usize, chain_max_ts: usize) -> Option<usize> {
 struct VarNameFmt<'a> {
     name: &'a str,
     ts: usize,
-    max_ts: usize,
-    /// Object Ref's pre-form collapses to `in.<name>`. False for
-    /// non-Object vars and Output-only Objects.
-    collapsed_in: bool,
-    /// Object Ref's post-form collapses to `out.<name>`. False for
-    /// non-Object vars and Input-only Objects.
-    collapsed_out: bool,
+    /// The owning action's metadata: the single source for this var's
+    /// max ts and which record namespace (if any) it collapses to at a
+    /// given ts. See `collapses_at`.
+    meta: &'a ActionMeta,
 }
 
 impl<'a> VarNameFmt<'a> {
@@ -118,32 +112,45 @@ impl<'a> VarNameFmt<'a> {
     }
 }
 
-impl<'a> fmt::Display for VarNameFmt<'a> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        // For a Mutate Object at ts=0=max (no updates), `in` wins.
-        if self.collapsed_in && self.ts == 0 {
-            return write!(f, "in.{}", self.name);
-        }
-        if self.collapsed_out && self.ts == self.max_ts {
-            return write!(f, "out.{}", self.name);
-        }
-        if self.name == "chain"
-            && let Some(slot) = chain_step_at(self.ts, self.max_ts)
-        {
-            return write!(f, "chain_steps.step_{}", slot - 1);
-        }
-        write!(f, "{}", fmt_var_at(self.name, self.ts, self.max_ts))
+impl<'a> VarNameFmt<'a> {
+    /// The record namespace this var pins at its current `ts`, or
+    /// `None` to render as a bare wildcard. Delegates to
+    /// `ActionMeta::collapsed_at`, which owns the in/out/initials
+    /// resolution (and its precedence).
+    fn collapses_at(&self) -> Option<Collapse> {
+        self.meta.collapsed_at(self.name, self.ts)
     }
 }
 
-/// One of the two record args in an action's signature
-/// `Action(in <Action>In, out <Action>Out, ...)`. Each Object inst
-/// contributes one entry to one (Input/Output) or both (Mutate) of
-/// these records.
+impl<'a> fmt::Display for VarNameFmt<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if let Some(ns) = self.collapses_at() {
+            return write!(f, "{}.{}", ns.arg_name(), self.name);
+        }
+        let max_ts = self.meta.max_ts(self.name);
+        if self.name == "chain"
+            && let Some(slot) = chain_step_at(self.ts, max_ts)
+        {
+            return write!(f, "chain_steps.step_{}", slot - 1);
+        }
+        write!(f, "{}", fmt_var_at(self.name, self.ts, max_ts))
+    }
+}
+
+/// Which public record an Object inst belongs to: `in <Action>In`
+/// and `out <Action>Out` each carry one entry per Object inst on that
+/// side (Mutate contributes to both).
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum Side {
     In,
     Out,
+}
+
+/// The record namespace a collapsed Object state dict belongs to.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum Collapse {
+    Side(Side),
+    Initials,
 }
 
 impl Side {
@@ -157,6 +164,27 @@ impl Side {
         match self {
             Side::In => "In",
             Side::Out => "Out",
+        }
+    }
+}
+
+impl From<Side> for Collapse {
+    fn from(side: Side) -> Self {
+        Collapse::Side(side)
+    }
+}
+
+impl Collapse {
+    pub(crate) fn arg_name(self) -> &'static str {
+        match self {
+            Collapse::Side(side) => side.arg_name(),
+            Collapse::Initials => "initials",
+        }
+    }
+    fn schema_suffix(self) -> &'static str {
+        match self {
+            Collapse::Side(side) => side.schema_suffix(),
+            Collapse::Initials => "Initials",
         }
     }
 }
@@ -193,9 +221,9 @@ pub(crate) fn dispatch_side(io: &ObjectIO) -> Side {
     }
 }
 
-/// Schema name for a (action, side) pair, e.g. `LogToWoodIn`.
-fn schema_name(action_name: &str, side: Side) -> String {
-    format!("{action_name}{}", side.schema_suffix())
+/// Schema name for a (action, namespace) pair, e.g. `LogToWoodIn`.
+fn schema_name(action_name: &str, ns: impl Into<Collapse>) -> String {
+    format!("{action_name}{}", ns.into().schema_suffix())
 }
 
 /// Emit `record <Action><Side> = (<entries>)` lines for any non-empty
@@ -238,6 +266,14 @@ fn fmt_record_decls(loader: &Loader, w: &mut dyn fmt::Write) -> fmt::Result {
                 "record {} = ({})",
                 chain_schema_name(&meta.name),
                 render(&steps),
+            )?;
+        }
+        if let Some(initials) = &meta.initials_entries {
+            writeln!(
+                w,
+                "record {} = ({})",
+                schema_name(&meta.name, Collapse::Initials),
+                render(initials),
             )?;
         }
     }
@@ -354,30 +390,23 @@ fn fmt_action(action: &ActionContext, loader: &Loader, w: &mut dyn fmt::Write) -
     let alias_names: std::collections::HashSet<String> =
         sub_calls.iter().filter_map(|c| c.alias.clone()).collect();
 
-    let max_ts_for = |var: &str| -> usize {
-        let is_output = meta
-            .object_refs
-            .iter()
-            .any(|o| o.varname == var && o.io == ObjectIO::Output);
-        output_max_ts(action.var_state[var].ts, is_output)
-    };
-
     // Private wildcards: every (var, ts) except sub-action aliases,
     // chain endpoints (public chain0/chain), packed chain intermediates
-    // (anchored via the `chain_steps` record), and Object pre/post-form
-    // ts on collapsed sides. Unpacked chain intermediates appear as
-    // scalar `chain1, chain2, ...` privates.
+    // (anchored via the `chain_steps` record), Object pre/post-form
+    // ts on collapsed sides, and Output Objects' script-final ts when
+    // packed into the `initials` record. Unpacked chain intermediates
+    // appear as scalar `chain1, chain2, ...` privates.
     let mut private_vars: Vec<String> = Vec::new();
     for var in &action.vars {
         if alias_names.contains(var.as_str()) {
             continue;
         }
-        let max_ts = max_ts_for(var);
+        let max_ts = meta.max_ts(var);
         for i in 0..=max_ts {
             let skip = if var == "chain" {
                 i == 0 || i == max_ts || chain_step_at(i, max_ts).is_some()
             } else {
-                meta.collapsed_at(var, i, max_ts).is_some()
+                meta.collapsed_at(var, i).is_some()
             };
             if skip {
                 continue;
@@ -398,6 +427,14 @@ fn fmt_action(action: &ActionContext, loader: &Loader, w: &mut dyn fmt::Write) -
     if chain_packed(meta.chain_max_ts) {
         private_vars.push(format!("chain_steps {}", chain_schema_name(&action.name)));
     }
+    // Append the initials record typed private when packed.
+    if meta.initials_entries.is_some() {
+        private_vars.push(format!(
+            "{} {}",
+            Collapse::Initials.arg_name(),
+            schema_name(&action.name, Collapse::Initials),
+        ));
+    }
     if !private_vars.is_empty() {
         write!(w, ", private: ")?;
         for (i, v) in private_vars.iter().enumerate() {
@@ -409,24 +446,20 @@ fn fmt_action(action: &ActionContext, loader: &Loader, w: &mut dyn fmt::Write) -
     }
     writeln!(w, ") = AND(")?;
 
-    // Per-var rendering state for body emission. Object vars carry
-    // the per-side collapse flags so `VarNameFmt` can pick
-    // `in.<name>` / `out.<name>` over the bare name when collapsed.
+    // Per-var rendering state for body emission. Each var holds a
+    // back-reference to `meta` so `VarNameFmt::collapses_at` can
+    // resolve whether it renders as `in.<name>` / `out.<name>` /
+    // `initials.<name>` at a given ts.
     let mut vars: HashMap<&str, VarNameFmt> = action
         .vars
         .iter()
         .map(|v| {
-            let max_ts = max_ts_for(v);
-            let collapsed_in = meta.collapsed_at(v, 0, max_ts) == Some(Side::In);
-            let collapsed_out = meta.collapsed_at(v, max_ts, max_ts) == Some(Side::Out);
             (
                 v.as_str(),
                 VarNameFmt {
                     name: v,
                     ts: 0,
-                    max_ts,
-                    collapsed_in,
-                    collapsed_out,
+                    meta,
                 },
             )
         })
@@ -540,11 +573,14 @@ fn fmt_action(action: &ActionContext, loader: &Loader, w: &mut dyn fmt::Write) -
     // internally, so the guard predicate ref is passed as the last
     // arg to TxInsert / TxDelete / TxMutate (and pins both sides for
     // mutate, making the type-preservation check implicit).
-    // For Output, the script's final wildcard (`obj_str`) is the
-    // pre-identity `initial` arg; the bumped-ts rendering
-    // (`obj_with_id`, which collapses to `out.<name>`) is the
-    // post-identity `new` arg that lives in the tx and is bound to
-    // the output record.
+    // For Output, TxInsert produces a final state with an "identity"
+    // entry, so it takes the object in two forms. `obj_str` (the
+    // script's final wildcard) is the pre-identity `initial` dict the
+    // script built; `obj_with_id` (the same wildcard one ts later, the
+    // extra ts that `output_max_ts` reserves) is the post-identity `new`
+    // dict TxInsert produces. The post-identity form is the object's
+    // output state: it is what the transaction inserts, and it collapses
+    // to `out.<name>` to bind the `<Action>Out` record entry.
     for o in &meta.object_refs {
         let chain = vars["chain"];
         let chain_next = chain.next();

--- a/sdk/src/fmt_podlang.rs
+++ b/sdk/src/fmt_podlang.rs
@@ -468,7 +468,7 @@ fn fmt_action(action: &ActionContext, loader: &Loader, w: &mut dyn fmt::Write) -
     // ---- ArrayContains clauses for each Object's pre/post-form on
     // sides that need a wildcard; collapsed sides drop the clause.
     for o in &meta.object_refs {
-        let max_ts = action.var_state[&o.varname].ts;
+        let max_ts = meta.max_ts(&o.varname);
         if meta
             .in_entry(&o.varname)
             .is_some_and(|(_, e)| e.needs_wildcard)

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -542,12 +542,10 @@ impl ActionHandle {
         // dispatch side's array (Mutate contributes to both). Slot 0
         // is `_pad`; real entries start at slot 1 (see PAD_ENTRY).
         //
-        // For Output objects the script's view is pre-identity, but
-        // TxInsert stamps `new.identity = commitment(initial)` and
-        // the predicate references the stamped form via the `out`
-        // record. We cache the stamped dict once here so the
-        // out_array entry, the array_contains anchor below, and the
-        // post-event obj_dict downstream all see the same value.
+        // For Outputs, cache the identity-stamped dict once here so the
+        // three consumers that need the post-identity form -- the
+        // out_array entry, the ArrayContains anchor below, and the
+        // downstream obj_dict -- all use the same value.
         let exe_rc = self.0.borrow().exe_ctx.clone().expect("exe phase");
         let meta = module.action_by_name(&action);
         // Output dicts: `stamped_outputs` (keyed by varname) backs
@@ -612,19 +610,16 @@ impl ActionHandle {
         let in_array = Array::new(in_dicts);
         let out_array = Array::new(out_dicts);
 
-        // Build the `<Action>Initials` record value (pre-identity
-        // Output dicts), if required. Slot 0 is `_pad`; subsequent
-        // slots are `raw_outputs` in declaration order, matching
-        // `meta.initials_entries`.
+        // Build the `<Action>Initials` record value (the pre-identity Output
+        // dicts) when the action has one. Slot 0 is the `_pad` (see PAD_ENTRY).
         let initials_array: Option<Array> = has_initials.then(|| {
             let mut values: Vec<Value> = vec![Value::from(0_i64)];
             values.extend(raw_outputs.iter().cloned().map(Value::from));
             Array::new(values)
         });
 
-        // Anchor an Output's pre-identity slot in the `<Action>Initials`
-        // record. Returns `None` for non-Output vars and for actions
-        // that don't have initials.
+        // Resolve an Output's pre-identity dict to its slot in the
+        // `<Action>Initials` record.
         let initials_anchor = |obj_name: &str| -> Option<OperationArg> {
             let slot = meta.initials_slot(obj_name)?;
             Some((initials_array.as_ref()?, slot as i64).into())
@@ -669,8 +664,7 @@ impl ActionHandle {
                             .as_ref()
                             .expect("Mutate records a pre-mutation dict")
                             .clone(),
-                        ObjectIO::Input => post_dict.clone(),
-                        ObjectIO::Output => post_dict.clone(),
+                        _ => post_dict.clone(),
                     };
                     if let Some((idx, e)) = meta.in_entry(&varname)
                         && e.needs_wildcard
@@ -783,9 +777,7 @@ impl ActionHandle {
                     // the raw dictionary.
                     let (obj_dict, st_tx_literal, handle) = match io {
                         ObjectIO::Output => {
-                            let (new_dict, st, h) =
-                                exe_ctx.tx_builder.insert(&mut exe_ctx.bld, &raw_obj_dict);
-                            (new_dict, st, h)
+                            exe_ctx.tx_builder.insert(&mut exe_ctx.bld, &raw_obj_dict)
                         }
                         ObjectIO::Input => {
                             let (st, h) =

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -20,7 +20,7 @@ use pod2::{
 };
 use pod2utils::{dict, macros::BuildContext, rand_raw_value};
 use rhai::{AST, CallFnOptions, Dynamic, Engine, EvalAltResult, EvalContext, Expression, Scope};
-use txlib::{EventHandle, GroundingEvidence, GroundingWitness, Tx, TxBuilder};
+use txlib::{EventHandle, GroundingEvidence, GroundingWitness, Tx, TxBuilder, with_identity};
 use vdfpod::{STANDARD_VDF_VD_HASH, VdfPod};
 
 mod error;
@@ -53,7 +53,7 @@ enum Intro {
     LtEqU256, // (lhs, rhs)
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ObjectIO {
     Input,
     Mutate,
@@ -514,8 +514,34 @@ impl ActionHandle {
         // Object insts. Each Object contributes one entry to its
         // dispatch side's array (Mutate contributes to both). Slot 0
         // is `_pad`; real entries start at slot 1 (see PAD_ENTRY).
+        //
+        // For Output objects the script's view is pre-identity, but
+        // TxInsert stamps `new.identity = commitment(initial)` and
+        // the predicate references the stamped form via the `out`
+        // record. We cache the stamped dict once here so the
+        // out_array entry, the array_contains anchor below, and the
+        // post-event obj_dict downstream all see the same value.
+        // Input/Mutate dicts pass through unchanged (identity is
+        // preserved from the prior tx).
         let exe_rc = self.0.borrow().exe_ctx.clone().expect("exe phase");
         let meta = module.action_by_name(&action);
+        let stamped_outputs: HashMap<String, Dictionary> = {
+            let ctx = self.0.borrow();
+            ctx.insts
+                .iter()
+                .filter_map(|inst| match inst {
+                    Inst::Object {
+                        io: ObjectIO::Output,
+                        obj,
+                        ..
+                    } => {
+                        let obj = obj.borrow();
+                        Some((obj.var_name().to_string(), with_identity(&obj.to_dict())))
+                    }
+                    _ => None,
+                })
+                .collect()
+        };
         let mut in_dicts: Vec<Value> = vec![Value::from(0_i64)];
         let mut out_dicts: Vec<Value> = vec![Value::from(0_i64)];
         {
@@ -525,13 +551,14 @@ impl ActionHandle {
                     io, obj, original, ..
                 } = inst
                 {
+                    let varname = obj.borrow().var_name().to_string();
                     let post_dict = obj.borrow().to_dict();
                     match io {
                         ObjectIO::Input => {
                             in_dicts.push(Value::from(post_dict));
                         }
                         ObjectIO::Output => {
-                            out_dicts.push(Value::from(post_dict));
+                            out_dicts.push(Value::from(stamped_outputs[&varname].clone()));
                         }
                         ObjectIO::Mutate => {
                             let pre_dict = original
@@ -548,11 +575,32 @@ impl ActionHandle {
         let in_array = Array::new(in_dicts);
         let out_array = Array::new(out_dicts);
 
+        // Mirror fmt_podlang's per-Output ts bump (see
+        // `fmt_podlang::output_max_ts`): the script-final ts on an
+        // Output object is the pre-identity intermediate, not
+        // `out.<name>`, so `anchor_or_literal` must not collapse it.
         let max_ts: HashMap<String, usize> = {
             let ctx = self.0.borrow();
+            let output_vars: HashSet<String> = ctx
+                .insts
+                .iter()
+                .filter_map(|inst| match inst {
+                    Inst::Object {
+                        io: ObjectIO::Output,
+                        obj,
+                        ..
+                    } => Some(obj.borrow().var_name().to_string()),
+                    _ => None,
+                })
+                .collect();
             ctx.var_state
                 .iter()
-                .map(|(k, v)| (k.clone(), v.ts))
+                .map(|(k, v)| {
+                    (
+                        k.clone(),
+                        fmt_podlang::output_max_ts(v.ts, output_vars.contains(k)),
+                    )
+                })
                 .collect()
         };
 
@@ -584,7 +632,10 @@ impl ActionHandle {
                 } = inst
                 {
                     let varname = obj.borrow().var_name().to_string();
-                    let post_dict = obj.borrow().to_dict();
+                    let post_dict = match io {
+                        ObjectIO::Output => stamped_outputs[&varname].clone(),
+                        _ => obj.borrow().to_dict(),
+                    };
                     let pre_dict = match io {
                         ObjectIO::Mutate => original
                             .as_ref()
@@ -698,15 +749,33 @@ impl ActionHandle {
                 } = inst
                 {
                     let varname = obj.borrow().var_name().to_string();
-                    let obj_dict = obj.borrow().to_dict();
-                    let (st_tx_literal, handle) = match io {
-                        ObjectIO::Output => exe_ctx.tx_builder.insert(&mut exe_ctx.bld, &obj_dict),
-                        ObjectIO::Input => exe_ctx.tx_builder.delete(&mut exe_ctx.bld, &obj_dict),
+                    let raw_obj_dict = obj.borrow().to_dict();
+                    // `obj_dict` is the post-identity dict for Output
+                    // (taken from `tx_builder.insert`'s return) so
+                    // out_array entries, `exe_ctx.outputs`, and the
+                    // pending event all reference the form that's in
+                    // the live set. Input/Mutate dicts already carry
+                    // identity from the prior tx.
+                    let (obj_dict, st_tx_literal, handle) = match io {
+                        ObjectIO::Output => {
+                            let (new_dict, st, h) =
+                                exe_ctx.tx_builder.insert(&mut exe_ctx.bld, &raw_obj_dict);
+                            (new_dict, st, h)
+                        }
+                        ObjectIO::Input => {
+                            let (st, h) =
+                                exe_ctx.tx_builder.delete(&mut exe_ctx.bld, &raw_obj_dict);
+                            (raw_obj_dict, st, h)
+                        }
                         ObjectIO::Mutate => {
                             let obj0 = original
                                 .as_ref()
                                 .expect("Mutate records a pre-mutation dict");
-                            exe_ctx.tx_builder.mutate(&mut exe_ctx.bld, &obj_dict, obj0)
+                            let (st, h) =
+                                exe_ctx
+                                    .tx_builder
+                                    .mutate(&mut exe_ctx.bld, &raw_obj_dict, obj0);
+                            (raw_obj_dict, st, h)
                         }
                     };
                     let post_ts = inst_chain_ts[i].expect("Object inst has parent_ts");
@@ -750,10 +819,12 @@ impl ActionHandle {
 
         // Wrap each pending Tx event with its anchors. Arg layout
         // (per txlib):
-        //   TxInsert(chain, prev_chain, new, type)
+        //   TxInsert(chain, prev_chain, initial, new, type)
         //   TxDelete(chain, prev_chain, old, type)
         //   TxMutate(chain, prev_chain, new, old, type)
-        // `type` is always literal (the @self_predicate ref).
+        // `type` is always literal (the @self_predicate ref);
+        // TxInsert's `initial` (slot 2) stays literal too to bind
+        // the predicate's pre-identity private wildcard.
         let mut events: Vec<EventData> = Vec::new();
         let mut event_sts: Vec<Statement> = Vec::new();
         {
@@ -782,7 +853,8 @@ impl ActionHandle {
                 let prev_chain_anchor = chain_step_anchor(pre_ts);
                 let replacements: Vec<Option<OperationArg>> = match io {
                     ObjectIO::Output => {
-                        vec![chain_anchor, prev_chain_anchor, new_anchor, None]
+                        // (chain, prev_chain, initial, new, type)
+                        vec![chain_anchor, prev_chain_anchor, None, new_anchor, None]
                     }
                     ObjectIO::Input => {
                         vec![chain_anchor, prev_chain_anchor, old_anchor, None]
@@ -1586,10 +1658,17 @@ fn compute_wildcard_needs(ctx: &ActionContext) -> (HashSet<String>, HashSet<Stri
         }
     }
     let mut current_ts: HashMap<String, usize> = object_io.keys().map(|v| (v.clone(), 0)).collect();
+    // Mirror fmt_podlang's per-Output ts bump (see
+    // `fmt_podlang::output_max_ts`): a whole-dict reference at the
+    // script-final ts on an Output stays an *intermediate*
+    // (pre-identity) ref, so we don't force the at_out wildcard.
     let max_ts: HashMap<String, usize> = ctx
         .var_state
         .iter()
-        .map(|(k, v)| (k.clone(), v.ts))
+        .map(|(k, v)| {
+            let is_output = matches!(object_io.get(k), Some(ObjectIO::Output));
+            (k.clone(), fmt_podlang::output_max_ts(v.ts, is_output))
+        })
         .collect();
     let mut needs_in: HashSet<String> = HashSet::new();
     let mut needs_out: HashSet<String> = HashSet::new();

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -408,6 +408,33 @@ impl ActionContext {
         state.ts += 1;
         Ok(())
     }
+    /// Per-var max ts, including the extra ts an Output reserves for
+    /// the identity-stamp bump (`fmt_podlang::output_max_ts`). This is
+    /// the single source for in/out/initials slot positions, consumed
+    /// by `compute_wildcard_needs`, `ActionMeta`, and `fmt_podlang`.
+    fn max_ts_per_var(&self) -> HashMap<String, usize> {
+        let output_vars: HashSet<String> = self
+            .insts
+            .iter()
+            .filter_map(|inst| match inst {
+                Inst::Object {
+                    io: ObjectIO::Output,
+                    obj,
+                    ..
+                } => Some(obj.borrow().var_name().to_string()),
+                _ => None,
+            })
+            .collect();
+        self.var_state
+            .iter()
+            .map(|(k, v)| {
+                (
+                    k.clone(),
+                    fmt_podlang::output_max_ts(v.ts, output_vars.contains(k)),
+                )
+            })
+            .collect()
+    }
     fn assert_unsafe(&self, unsafe_block: bool) -> RuntimeResult<()> {
         if self.unsafe_block != unsafe_block {
             if self.unsafe_block {
@@ -521,26 +548,36 @@ impl ActionHandle {
         // record. We cache the stamped dict once here so the
         // out_array entry, the array_contains anchor below, and the
         // post-event obj_dict downstream all see the same value.
-        // Input/Mutate dicts pass through unchanged (identity is
-        // preserved from the prior tx).
         let exe_rc = self.0.borrow().exe_ctx.clone().expect("exe phase");
         let meta = module.action_by_name(&action);
-        let stamped_outputs: HashMap<String, Dictionary> = {
+        // Output dicts: `stamped_outputs` (keyed by varname) backs
+        // `out_array` and the array_contains anchors; `raw_outputs`
+        // (declaration-ordered, matching `meta.initials_entries`) backs
+        // the `<Action>Initials` array. `raw_outputs` is only built
+        // when this action performs TxInserts and thus requires an
+        // `initials` record.
+        let has_initials = meta.initials_entries.is_some();
+        let (raw_outputs, stamped_outputs): (Vec<Dictionary>, HashMap<String, Dictionary>) = {
             let ctx = self.0.borrow();
-            ctx.insts
-                .iter()
-                .filter_map(|inst| match inst {
-                    Inst::Object {
-                        io: ObjectIO::Output,
-                        obj,
-                        ..
-                    } => {
-                        let obj = obj.borrow();
-                        Some((obj.var_name().to_string(), with_identity(&obj.to_dict())))
+            let mut raw: Vec<Dictionary> = Vec::new();
+            let mut stamped: HashMap<String, Dictionary> = HashMap::new();
+            for inst in &ctx.insts {
+                if let Inst::Object {
+                    io: ObjectIO::Output,
+                    obj,
+                    ..
+                } = inst
+                {
+                    let obj = obj.borrow();
+                    let varname = obj.var_name().to_string();
+                    let raw_dict = obj.to_dict();
+                    stamped.insert(varname, with_identity(&raw_dict));
+                    if has_initials {
+                        raw.push(raw_dict);
                     }
-                    _ => None,
-                })
-                .collect()
+                }
+            }
+            (raw, stamped)
         };
         let mut in_dicts: Vec<Value> = vec![Value::from(0_i64)];
         let mut out_dicts: Vec<Value> = vec![Value::from(0_i64)];
@@ -575,45 +612,36 @@ impl ActionHandle {
         let in_array = Array::new(in_dicts);
         let out_array = Array::new(out_dicts);
 
-        // Mirror fmt_podlang's per-Output ts bump (see
-        // `fmt_podlang::output_max_ts`): the script-final ts on an
-        // Output object is the pre-identity intermediate, not
-        // `out.<name>`, so `anchor_or_literal` must not collapse it.
-        let max_ts: HashMap<String, usize> = {
-            let ctx = self.0.borrow();
-            let output_vars: HashSet<String> = ctx
-                .insts
-                .iter()
-                .filter_map(|inst| match inst {
-                    Inst::Object {
-                        io: ObjectIO::Output,
-                        obj,
-                        ..
-                    } => Some(obj.borrow().var_name().to_string()),
-                    _ => None,
-                })
-                .collect();
-            ctx.var_state
-                .iter()
-                .map(|(k, v)| {
-                    (
-                        k.clone(),
-                        fmt_podlang::output_max_ts(v.ts, output_vars.contains(k)),
-                    )
-                })
-                .collect()
+        // Build the `<Action>Initials` record value (pre-identity
+        // Output dicts), if required. Slot 0 is `_pad`; subsequent
+        // slots are `raw_outputs` in declaration order, matching
+        // `meta.initials_entries`.
+        let initials_array: Option<Array> = has_initials.then(|| {
+            let mut values: Vec<Value> = vec![Value::from(0_i64)];
+            values.extend(raw_outputs.iter().cloned().map(Value::from));
+            Array::new(values)
+        });
+
+        // Anchor an Output's pre-identity slot in the `<Action>Initials`
+        // record. Returns `None` for non-Output vars and for actions
+        // that don't have initials.
+        let initials_anchor = |obj_name: &str| -> Option<OperationArg> {
+            let slot = meta.initials_slot(obj_name)?;
+            Some((initials_array.as_ref()?, slot as i64).into())
         };
 
         // Returns an anchored op-arg when the Object's side at this ts
         // is collapsed; else a literal op-arg for the dict.
         let anchor_or_literal = |obj_name: &str, dict: &Dictionary, ts: usize| -> OperationArg {
-            let mts = *max_ts.get(obj_name).unwrap_or(&0);
-            match meta.collapsed_at(obj_name, ts, mts) {
-                Some(fmt_podlang::Side::In) => {
+            match meta.collapsed_at(obj_name, ts) {
+                Some(fmt_podlang::Collapse::Side(fmt_podlang::Side::In)) => {
                     (&in_array, meta.in_entry(obj_name).unwrap().0 as i64).into()
                 }
-                Some(fmt_podlang::Side::Out) => {
+                Some(fmt_podlang::Collapse::Side(fmt_podlang::Side::Out)) => {
                     (&out_array, meta.out_entry(obj_name).unwrap().0 as i64).into()
+                }
+                Some(fmt_podlang::Collapse::Initials) => {
+                    initials_anchor(obj_name).expect("collapsed_at promised an initials slot")
                 }
                 None => OperationArg::Literal(Value::from(dict.clone())),
             }
@@ -750,12 +778,9 @@ impl ActionHandle {
                 {
                     let varname = obj.borrow().var_name().to_string();
                     let raw_obj_dict = obj.borrow().to_dict();
-                    // `obj_dict` is the post-identity dict for Output
-                    // (taken from `tx_builder.insert`'s return) so
-                    // out_array entries, `exe_ctx.outputs`, and the
-                    // pending event all reference the form that's in
-                    // the live set. Input/Mutate dicts already carry
-                    // identity from the prior tx.
+                    // tx_builder.insert returns a new dictionary with
+                    // an added identity entry, other cases stick with
+                    // the raw dictionary.
                     let (obj_dict, st_tx_literal, handle) = match io {
                         ObjectIO::Output => {
                             let (new_dict, st, h) =
@@ -817,14 +842,9 @@ impl ActionHandle {
             Some((chain_steps_array.as_ref()?, slot as i64).into())
         };
 
-        // Wrap each pending Tx event with its anchors. Arg layout
-        // (per txlib):
-        //   TxInsert(chain, prev_chain, initial, new, type)
-        //   TxDelete(chain, prev_chain, old, type)
-        //   TxMutate(chain, prev_chain, new, old, type)
-        // `type` is always literal (the @self_predicate ref);
-        // TxInsert's `initial` (slot 2) stays literal too to bind
-        // the predicate's pre-identity private wildcard.
+        // Each pending Tx event is first proved with literal args. We then use
+        // ReplaceValueWithEntry to replace those literal args with entries from
+        // the `chain_steps`, `in`, `out`, and `initials` records as appropriate.
         let mut events: Vec<EventData> = Vec::new();
         let mut event_sts: Vec<Statement> = Vec::new();
         {
@@ -853,8 +873,14 @@ impl ActionHandle {
                 let prev_chain_anchor = chain_step_anchor(pre_ts);
                 let replacements: Vec<Option<OperationArg>> = match io {
                     ObjectIO::Output => {
-                        // (chain, prev_chain, initial, new, type)
-                        vec![chain_anchor, prev_chain_anchor, None, new_anchor, None]
+                        let initial_anchor = initials_anchor(varname);
+                        vec![
+                            chain_anchor,
+                            prev_chain_anchor,
+                            initial_anchor,
+                            new_anchor,
+                            None,
+                        ]
                     }
                     ObjectIO::Input => {
                         vec![chain_anchor, prev_chain_anchor, old_anchor, None]
@@ -1509,10 +1535,20 @@ pub struct ActionMeta {
     total_outputs: Vec<ActionObjectRef>,
     pub(crate) in_entries: Vec<EntryShape>,
     pub(crate) out_entries: Vec<EntryShape>,
+    /// The Output varnames that get a slot in the `<Action>Initials`
+    /// record, in declaration order (the order of their slots). `None`
+    /// when there is no such record: an Intro that consumes an output's
+    /// pre-identity dict whole forces that dict to stay a literal
+    /// wildcard, since Intro args can't be anchored.
+    pub(crate) initials_entries: Option<Vec<String>>,
     /// `var_state["chain"].ts` for this action — i.e. the count of
     /// txlib events recorded by this action (Object insts + sub-action
     /// calls). Drives whether the chain is packed into `<Action>Chain`.
     pub(crate) chain_max_ts: usize,
+    /// Per-var max ts, with the Output identity-stamp bump applied. The
+    /// cached result of `ActionContext::max_ts_per_var`, so `collapsed_at`
+    /// need not recompute it or take it as an argument.
+    var_max_ts: HashMap<String, usize>,
 }
 
 impl ActionMeta {
@@ -1552,6 +1588,16 @@ impl ActionMeta {
             .map(|(p, e)| (p + 1, e))
     }
 
+    /// 1-based slot for `varname` in the `<Action>Initials` record
+    /// (slot 0 is `_pad`), if such a record exists for this action.
+    pub(crate) fn initials_slot(&self, varname: &str) -> Option<usize> {
+        self.initials_entries
+            .as_ref()?
+            .iter()
+            .position(|name| name == varname)
+            .map(|p| p + 1)
+    }
+
     pub(crate) fn out_entry(&self, varname: &str) -> Option<(usize, &EntryShape)> {
         self.out_entries
             .iter()
@@ -1560,29 +1606,38 @@ impl ActionMeta {
             .map(|(p, e)| (p + 1, e))
     }
 
-    /// Side the Object Ref pins at this ts, when the matching side is
-    /// collapsed. Callers render/anchor as `<side>.<entry>` on a
-    /// `Some(side)` answer; on `None` the Ref falls back to a scalar
-    /// wildcard (or whatever else).
-    pub(crate) fn collapsed_at(
-        &self,
-        varname: &str,
-        ts: usize,
-        max_ts: usize,
-    ) -> Option<fmt_podlang::Side> {
+    pub(crate) fn max_ts(&self, varname: &str) -> usize {
+        *self
+            .var_max_ts
+            .get(varname)
+            .expect("varname is a var of this action")
+    }
+
+    /// At a given ts, an object's state might be "collapsed" into a
+    /// record (in, out, or initials) rather than held in its own
+    /// wildcard. Returns which record, or None if it is not collapsed
+    /// at this ts.
+    pub(crate) fn collapsed_at(&self, varname: &str, ts: usize) -> Option<fmt_podlang::Collapse> {
+        let max_ts = self.max_ts(varname);
         if ts == 0
             && self
                 .in_entry(varname)
                 .is_some_and(|(_, e)| !e.needs_wildcard)
         {
-            return Some(fmt_podlang::Side::In);
+            return Some(fmt_podlang::Collapse::Side(fmt_podlang::Side::In));
         }
         if ts == max_ts
             && self
                 .out_entry(varname)
                 .is_some_and(|(_, e)| !e.needs_wildcard)
         {
-            return Some(fmt_podlang::Side::Out);
+            return Some(fmt_podlang::Collapse::Side(fmt_podlang::Side::Out));
+        }
+        // If we have an "initials" record for this var, and we are at
+        // the penultimate ts, then the var must be collapsed into
+        // initials, for passing to TxInsert.
+        if ts + 1 == max_ts && self.initials_slot(varname).is_some() {
+            return Some(fmt_podlang::Collapse::Initials);
         }
         None
     }
@@ -1595,6 +1650,7 @@ impl ActionMeta {
         let mut meta = Self {
             name: ctx.name.clone(),
             chain_max_ts: ctx.var_state.get("chain").map(|s| s.ts).unwrap_or(0),
+            var_max_ts: ctx.max_ts_per_var(),
             ..Self::default()
         };
         for inst in &ctx.insts {
@@ -1624,7 +1680,7 @@ impl ActionMeta {
                 _ => {}
             }
         }
-        let (needs_in, needs_out) = compute_wildcard_needs(ctx);
+        let (needs_in, needs_out, blocks_initials_pack) = compute_wildcard_needs(ctx);
         for r in &meta.object_refs {
             if r.io.consumes() {
                 meta.in_entries.push(EntryShape {
@@ -1639,18 +1695,34 @@ impl ActionMeta {
                 });
             }
         }
+        // Give the action an initials record iff it has Output objects and none
+        // is blocked from anchoring (blocks_initials_pack, from
+        // compute_wildcard_needs); otherwise leave it None.
+        let output_names: Vec<String> = meta
+            .object_refs
+            .iter()
+            .filter(|r| r.io == ObjectIO::Output)
+            .map(|r| r.varname.clone())
+            .collect();
+        let any_blocked = output_names
+            .iter()
+            .any(|name| blocks_initials_pack.contains(name));
+        meta.initials_entries = (!output_names.is_empty() && !any_blocked).then_some(output_names);
         Ok(meta)
     }
 }
 
-/// Walk an action's Insts and determine, for each direct Object,
-/// whether its `in` entry and/or `out` entry needs a wildcard. Returns
-/// (needs_in, needs_out) as sets of Object var names.
-///
-/// An Object's pre-form sits at ts=0 (Input/Mutate); its post-form sits
-/// at ts=max (Output/Mutate). Refs at intermediate ts already use
-/// their own wildcard and don't influence either decision.
-fn compute_wildcard_needs(ctx: &ActionContext) -> (HashSet<String>, HashSet<String>) {
+/// An Object's in/out/initials form normally collapses into the matching
+/// record and needs no wildcard of its own. A body reference can defeat
+/// that, keeping the form as an explicit wildcard instead; this walks the
+/// body and returns the Objects forced open on each side: `needs_in`,
+/// `needs_out`, and `blocks_initials_pack` (an Output's pre-identity form,
+/// reachable only by an Intro, so forcing it open also disables initials
+/// packing for the action). The per-reference rules are in the `check`
+/// closure below.
+fn compute_wildcard_needs(
+    ctx: &ActionContext,
+) -> (HashSet<String>, HashSet<String>, HashSet<String>) {
     let mut object_io: HashMap<String, ObjectIO> = HashMap::new();
     for inst in &ctx.insts {
         if let Inst::Object { io, obj, .. } = inst {
@@ -1658,20 +1730,10 @@ fn compute_wildcard_needs(ctx: &ActionContext) -> (HashSet<String>, HashSet<Stri
         }
     }
     let mut current_ts: HashMap<String, usize> = object_io.keys().map(|v| (v.clone(), 0)).collect();
-    // Mirror fmt_podlang's per-Output ts bump (see
-    // `fmt_podlang::output_max_ts`): a whole-dict reference at the
-    // script-final ts on an Output stays an *intermediate*
-    // (pre-identity) ref, so we don't force the at_out wildcard.
-    let max_ts: HashMap<String, usize> = ctx
-        .var_state
-        .iter()
-        .map(|(k, v)| {
-            let is_output = matches!(object_io.get(k), Some(ObjectIO::Output));
-            (k.clone(), fmt_podlang::output_max_ts(v.ts, is_output))
-        })
-        .collect();
+    let max_ts = ctx.max_ts_per_var();
     let mut needs_in: HashSet<String> = HashSet::new();
     let mut needs_out: HashSet<String> = HashSet::new();
+    let mut blocks_initials_pack: HashSet<String> = HashSet::new();
 
     // Force the wildcard on whichever side(s) the Object Ref pins.
     // Sub-field anchored refs (`var.key.is_some()`) always count
@@ -1684,7 +1746,8 @@ fn compute_wildcard_needs(ctx: &ActionContext) -> (HashSet<String>, HashSet<Stri
                  whole_dict_pins: bool,
                  cur: &HashMap<String, usize>,
                  needs_in: &mut HashSet<String>,
-                 needs_out: &mut HashSet<String>| {
+                 needs_out: &mut HashSet<String>,
+                 blocks_initials_pack: &mut HashSet<String>| {
         let arg = arg.borrow();
         let VarOrValue::Var(var) = &*arg else {
             return;
@@ -1699,11 +1762,16 @@ fn compute_wildcard_needs(ctx: &ActionContext) -> (HashSet<String>, HashSet<Stri
         let mts = *max_ts.get(&var.name).unwrap_or(&0);
         let at_in = matches!(io, ObjectIO::Input | ObjectIO::Mutate) && ts == 0;
         let at_out = matches!(io, ObjectIO::Output | ObjectIO::Mutate) && ts == mts;
+        let at_initials =
+            matches!(io, ObjectIO::Output) && var.key.is_none() && whole_dict_pins && ts + 1 == mts;
         if at_in {
             needs_in.insert(var.name.clone());
         }
         if at_out {
             needs_out.insert(var.name.clone());
+        }
+        if at_initials {
+            blocks_initials_pack.insert(var.name.clone());
         }
     };
 
@@ -1711,30 +1779,58 @@ fn compute_wildcard_needs(ctx: &ActionContext) -> (HashSet<String>, HashSet<Stri
         match inst {
             Inst::Object { .. } | Inst::SubAction { .. } => {}
             Inst::Update { obj, value, .. } => {
-                check(value, false, &current_ts, &mut needs_in, &mut needs_out);
+                check(
+                    value,
+                    false,
+                    &current_ts,
+                    &mut needs_in,
+                    &mut needs_out,
+                    &mut blocks_initials_pack,
+                );
                 if let Some(ts) = current_ts.get_mut(obj) {
                     *ts += 1;
                 }
             }
             Inst::Set { kvs, .. } => {
                 for (_k, v) in kvs {
-                    check(v, false, &current_ts, &mut needs_in, &mut needs_out);
+                    check(
+                        v,
+                        false,
+                        &current_ts,
+                        &mut needs_in,
+                        &mut needs_out,
+                        &mut blocks_initials_pack,
+                    );
                 }
             }
             Inst::Statement { args, .. } => {
                 for arg in args {
-                    check(arg, false, &current_ts, &mut needs_in, &mut needs_out);
+                    check(
+                        arg,
+                        false,
+                        &current_ts,
+                        &mut needs_in,
+                        &mut needs_out,
+                        &mut blocks_initials_pack,
+                    );
                 }
             }
             Inst::Intro { args, .. } => {
                 for arg in args {
-                    check(arg, true, &current_ts, &mut needs_in, &mut needs_out);
+                    check(
+                        arg,
+                        true,
+                        &current_ts,
+                        &mut needs_in,
+                        &mut needs_out,
+                        &mut blocks_initials_pack,
+                    );
                 }
             }
         }
     }
 
-    (needs_in, needs_out)
+    (needs_in, needs_out, blocks_initials_pack)
 }
 
 /// Collected metadata that declares a Class

--- a/sdk/src/tests.rs
+++ b/sdk/src/tests.rs
@@ -246,7 +246,7 @@ fn test_sdk_2() {
         [plugin]
         name = "test"
         version = "0.1.0"
-        module_hash = "4b73f3a8fa7f2bed3032bedfacd11c9909af751067b7bc4cdb5a92b7389a6168"
+        module_hash = "61700dde89cd070d1d5e6b3a02a0d66cfc329280130708d393c3a9cd0a2acbc9"
 
         [[classes]]
         name = "Log"
@@ -316,8 +316,8 @@ fn test_records_form_just_output() {
 
 // Actions
 
-JustOutput(out JustOutputOut, chain0, chain) = AND(
-  tx::TxInsert(chain, chain0, out.x, @self_predicate(IsFoo))
+JustOutput(out JustOutputOut, chain0, chain, private: x0) = AND(
+  tx::TxInsert(chain, chain0, x0, out.x, @self_predicate(IsFoo))
 )
 
 // Bridges
@@ -367,10 +367,10 @@ record LogToWoodOut = (_pad, wood)
 
 // Actions
 
-LogToWood(in LogToWoodIn, out LogToWoodOut, chain0, chain, private: chain1, wood0, key) = AND(
-  DictUpdate(out.wood, wood0, "key", key)
+LogToWood(in LogToWoodIn, out LogToWoodOut, chain0, chain, private: chain1, wood0, wood1, key) = AND(
+  DictUpdate(wood1, wood0, "key", key)
   tx::TxDelete(chain1, chain0, in.log, @self_predicate(IsLog))
-  tx::TxInsert(chain, chain1, out.wood, @self_predicate(IsWood))
+  tx::TxInsert(chain, chain1, wood1, out.wood, @self_predicate(IsWood))
 )
 
 // Bridges
@@ -433,9 +433,9 @@ fn test_records_form_subaction() {
     // Parent action signature + sub-action call body. `bar`'s
     // out-side collapses (no sub-field reads, no Intro use) so the
     // wildcard is dropped and body refs render as `out.bar`.
-    let expected_parent = r#"MineBar(out MineBarOut, chain0, chain, private: chain1, _UseFoo_in_0 UseFooIn, _UseFoo_out_0 UseFooOut) = AND(
+    let expected_parent = r#"MineBar(out MineBarOut, chain0, chain, private: chain1, bar0, _UseFoo_in_0 UseFooIn, _UseFoo_out_0 UseFooOut) = AND(
   UseFoo(_UseFoo_in_0, _UseFoo_out_0, chain0, chain1)
-  tx::TxInsert(chain, chain1, out.bar, @self_predicate(IsBar))
+  tx::TxInsert(chain, chain1, bar0, out.bar, @self_predicate(IsBar))
 )
 "#;
     assert!(

--- a/sdk/src/tests.rs
+++ b/sdk/src/tests.rs
@@ -246,7 +246,7 @@ fn test_sdk_2() {
         [plugin]
         name = "test"
         version = "0.1.0"
-        module_hash = "61700dde89cd070d1d5e6b3a02a0d66cfc329280130708d393c3a9cd0a2acbc9"
+        module_hash = "8d3754249fb1122eb5baf2127a63856ea7d67e70df9d1258cd67b1dd335d8500"
 
         [[classes]]
         name = "Log"
@@ -313,11 +313,12 @@ fn test_records_form_just_output() {
         .unwrap();
 
     let expected = r#"record JustOutputOut = (_pad, x)
+record JustOutputInitials = (_pad, x)
 
 // Actions
 
-JustOutput(out JustOutputOut, chain0, chain, private: x0) = AND(
-  tx::TxInsert(chain, chain0, x0, out.x, @self_predicate(IsFoo))
+JustOutput(out JustOutputOut, chain0, chain, private: initials JustOutputInitials) = AND(
+  tx::TxInsert(chain, chain0, initials.x, out.x, @self_predicate(IsFoo))
 )
 
 // Bridges
@@ -364,13 +365,14 @@ fn test_records_form_input_output_update() {
 
     let expected = r#"record LogToWoodIn = (_pad, log)
 record LogToWoodOut = (_pad, wood)
+record LogToWoodInitials = (_pad, wood)
 
 // Actions
 
-LogToWood(in LogToWoodIn, out LogToWoodOut, chain0, chain, private: chain1, wood0, wood1, key) = AND(
-  DictUpdate(wood1, wood0, "key", key)
+LogToWood(in LogToWoodIn, out LogToWoodOut, chain0, chain, private: chain1, wood0, key, initials LogToWoodInitials) = AND(
+  DictUpdate(initials.wood, wood0, "key", key)
   tx::TxDelete(chain1, chain0, in.log, @self_predicate(IsLog))
-  tx::TxInsert(chain, chain1, wood1, out.wood, @self_predicate(IsWood))
+  tx::TxInsert(chain, chain1, initials.wood, out.wood, @self_predicate(IsWood))
 )
 
 // Bridges
@@ -433,9 +435,9 @@ fn test_records_form_subaction() {
     // Parent action signature + sub-action call body. `bar`'s
     // out-side collapses (no sub-field reads, no Intro use) so the
     // wildcard is dropped and body refs render as `out.bar`.
-    let expected_parent = r#"MineBar(out MineBarOut, chain0, chain, private: chain1, bar0, _UseFoo_in_0 UseFooIn, _UseFoo_out_0 UseFooOut) = AND(
+    let expected_parent = r#"MineBar(out MineBarOut, chain0, chain, private: chain1, _UseFoo_in_0 UseFooIn, _UseFoo_out_0 UseFooOut, initials MineBarInitials) = AND(
   UseFoo(_UseFoo_in_0, _UseFoo_out_0, chain0, chain1)
-  tx::TxInsert(chain, chain1, bar0, out.bar, @self_predicate(IsBar))
+  tx::TxInsert(chain, chain1, initials.bar, out.bar, @self_predicate(IsBar))
 )
 "#;
     assert!(

--- a/txlib/src/lib.rs
+++ b/txlib/src/lib.rs
@@ -275,6 +275,24 @@ pub fn new_obj() -> Dictionary {
     Dictionary::new(map)
 }
 
+/// Field name TxInsert's DictInsert clause stamps onto every newly
+/// inserted object. Must stay in sync with `txlib.podlang`'s TxInsert
+/// body and TxMutate's `Equal(old.identity, new.identity)` clause.
+pub const IDENTITY_FIELD: &str = "identity";
+
+/// Stamp `identity = commitment(initial)` into the dict and return the
+/// materialized object. TxInsert's DictInsert clause proves the same
+/// relationship; callers that need the post-identity dict outside of
+/// `TxBuilder::insert` (e.g. tests, builders that pre-compute the
+/// finalized object) should go through this helper to stay consistent.
+pub fn with_identity(initial: &Dictionary) -> Dictionary {
+    let identity = Value::from(initial.commitment());
+    let mut new = initial.clone();
+    new.insert(&StrKey::from(IDENTITY_FIELD), &identity)
+        .unwrap();
+    new
+}
+
 // ============================================================================
 // Event tree (for replay construction in finalize)
 // ============================================================================
@@ -282,6 +300,11 @@ pub fn new_obj() -> Dictionary {
 pub(crate) enum ChainEvent {
     Insert {
         new: Dictionary,
+        /// Pre-identity dict from which `new` was derived via
+        /// `with_identity`. Threaded into replay so TxInsert's `initial`
+        /// public arg (the dict the action constructed) can be bound at
+        /// replay time.
+        initial: Dictionary,
         chain_after: Hash,
         /// The TxInsert statement emitted at record time. Replay
         /// references this directly instead of re-proving the chain
@@ -390,7 +413,7 @@ pub struct TxBuilder {
 // ============================================================================
 
 /// Fields to skip in compact display (noise for debugging).
-const DISPLAY_SKIP_FIELDS: &[&str] = &["type", "key"];
+const DISPLAY_SKIP_FIELDS: &[&str] = &["type", "key", IDENTITY_FIELD];
 
 /// Format a Dictionary as a compact summary: commitment + interesting fields.
 fn obj_summary(obj: &Dictionary) -> String {
@@ -620,25 +643,38 @@ impl TxBuilder {
         }
     }
 
-    /// Record an insertion. Emits TxInsert, updates live set.
-    /// Must be called inside an open action scope. Returns the
-    /// TxInsert statement (for composition into the action's
-    /// predicate) and a handle used to attach guard evidence via
-    /// `set_guard`.
-    pub fn insert(&mut self, ctx: &mut BuildContext, new: &Dictionary) -> (Statement, EventHandle) {
+    /// Record an insertion. Emits TxInsert, updates live set. Must be
+    /// called inside an open action scope.
+    ///
+    /// `initial` is the pre-identity object state; the builder stamps
+    /// `identity = commitment(initial)` via [`with_identity`] and the
+    /// returned `Dictionary` is the post-identity `new` (the dict that
+    /// lives in the tx). Subsequent mutate/delete must reference the
+    /// returned dict, not `initial`.
+    pub fn insert(
+        &mut self,
+        ctx: &mut BuildContext,
+        initial: &Dictionary,
+    ) -> (Dictionary, Statement, EventHandle) {
         assert!(
             !self.action_stack.is_empty(),
             "insert must be called inside an action scope",
         );
+        let new = with_identity(initial);
+
         let prev = self.chain;
         let event_hash = hash_values(&[Value::from(EMPTY_VALUE), Value::from(new.clone())]);
         self.chain = hash_values(&[Value::from(prev), Value::from(event_hash)]);
         self.live.insert(&Value::from(new.clone())).unwrap();
 
-        let new_type = object_type(new);
+        let new_type = object_type(&new);
         let st_dc = ctx
             .builder
             .priv_op(op!(DictContains(new, "type", new_type.clone())))
+            .unwrap();
+        let st_di = ctx
+            .builder
+            .priv_op(op!(DictInsert(new, initial, IDENTITY_FIELD, initial)))
             .unwrap();
         let st_h1 = ctx
             .builder
@@ -652,20 +688,21 @@ impl TxBuilder {
             .apply_custom_pred(
                 false,
                 "TxInsert",
-                map!({"chain" => self.chain, "prev_chain" => prev, "new" => new.clone(), "type" => new_type}),
-                vec![st_dc, st_h1, st_h2],
+                map!({"chain" => self.chain, "prev_chain" => prev, "initial" => initial.clone(), "new" => new.clone(), "type" => new_type}),
+                vec![st_dc, st_di, st_h1, st_h2],
             )
             .unwrap();
         record(&mut self.stats, "TxInsert");
 
         self.push_event(ChainEvent::Insert {
             new: new.clone(),
+            initial: initial.clone(),
             chain_after: self.chain,
             tx_stmt: st.clone(),
             guard_evidence: None,
         });
         let handle = self.handle_for_last_event();
-        (st, handle)
+        (new, st, handle)
     }
 
     /// Record a mutation. Emits TxMutate, updates live set and nullifiers.
@@ -693,6 +730,18 @@ impl TxBuilder {
         let new_type = object_type(new);
         let old_type = object_type(old);
         assert_eq!(new_type, old_type, "mutate must preserve object type");
+        let new_identity = new
+            .get(&StrKey::from(IDENTITY_FIELD))
+            .expect("new dict lookup")
+            .expect("mutate target missing identity field (must come from TxBuilder::insert)");
+        let old_identity = old
+            .get(&StrKey::from(IDENTITY_FIELD))
+            .expect("old dict lookup")
+            .expect("mutate source missing identity field (must come from TxBuilder::insert)");
+        assert_eq!(
+            new_identity, old_identity,
+            "mutate must preserve object identity"
+        );
         let st_dc_new = ctx
             .builder
             .priv_op(op!(DictContains(new, "type", new_type.clone())))
@@ -700,6 +749,10 @@ impl TxBuilder {
         let st_dc_old = ctx
             .builder
             .priv_op(op!(DictContains(old, "type", new_type.clone())))
+            .unwrap();
+        let st_eq_identity = ctx
+            .builder
+            .priv_op(op!(Equal((old, IDENTITY_FIELD), (new, IDENTITY_FIELD))))
             .unwrap();
         let st_h1 = ctx
             .builder
@@ -714,7 +767,7 @@ impl TxBuilder {
                 false,
                 "TxMutate",
                 map!({"chain" => self.chain, "prev_chain" => prev, "new" => new.clone(), "old" => old.clone(), "type" => new_type}),
-                vec![st_dc_new, st_dc_old, st_h1, st_h2],
+                vec![st_dc_new, st_dc_old, st_eq_identity, st_h1, st_h2],
             )
             .unwrap();
         record(&mut self.stats, "TxMutate");
@@ -1346,7 +1399,7 @@ mod tests {
             modules: modules.clone(),
         };
 
-        let pick = make_object(
+        let pick_initial = make_object(
             is_wood_pick.clone(),
             &[("durability", Value::from(100_i64))],
         );
@@ -1354,7 +1407,7 @@ mod tests {
         let mut tx1 = TxBuilder::new(&mut ctx, &[], state.grounding_witness(&[]));
 
         let scope = tx1.begin_action();
-        let (st_insert, h) = tx1.insert(&mut ctx, &pick);
+        let (pick, st_insert, h) = tx1.insert(&mut ctx, &pick_initial);
         let op_dur = ctx
             .builder
             .priv_op(op!(DictContains(pick, "durability", 100_i64)))
@@ -1389,7 +1442,7 @@ mod tests {
         pick_new
             .update(&StrKey::from("durability"), &Value::from(99_i64))
             .unwrap();
-        let stone = make_object(is_stone.clone(), &[]);
+        let stone_initial = make_object(is_stone.clone(), &[]);
 
         let witness = state.grounding_witness(std::slice::from_ref(&tx0));
         let evidence = GroundingEvidence::new(&tx0.ctx, &pick).unwrap();
@@ -1434,7 +1487,7 @@ mod tests {
         };
 
         // Direct: insert stone
-        let (st_stone_insert, h) = tx2.insert(&mut ctx, &stone);
+        let (_stone, st_stone_insert, h) = tx2.insert(&mut ctx, &stone_initial);
         let st_mine = ctx
             .apply_custom_pred_simple(false, "MineStone", vec![st_use_wp, st_stone_insert])
             .unwrap();
@@ -1486,12 +1539,12 @@ mod tests {
             modules: modules.clone(),
         };
 
-        let log = make_object(is_log.clone(), &[]);
+        let log_initial = make_object(is_log.clone(), &[]);
 
         let mut tx1 = TxBuilder::new(&mut ctx, &[], state.grounding_witness(&[]));
 
         let scope = tx1.begin_action();
-        let (st_insert, h) = tx1.insert(&mut ctx, &log);
+        let (log, st_insert, h) = tx1.insert(&mut ctx, &log_initial);
         let st_find = ctx
             .apply_custom_pred_simple(false, "FindLog", vec![st_insert])
             .unwrap();
@@ -1517,7 +1570,7 @@ mod tests {
             modules: modules.clone(),
         };
 
-        let wood = make_object(is_wood.clone(), &[]);
+        let wood_initial = make_object(is_wood.clone(), &[]);
 
         let witness = state.grounding_witness(std::slice::from_ref(&tx1_out));
         let evidence = GroundingEvidence::new(&tx1_out.ctx, &log).unwrap();
@@ -1542,7 +1595,7 @@ mod tests {
         };
 
         // Direct: insert wood
-        let (st_ins, h) = tx2.insert(&mut ctx, &wood);
+        let (wood, st_ins, h) = tx2.insert(&mut ctx, &wood_initial);
         let st_craft_wood = ctx
             .apply_custom_pred_simple(false, "CraftWood", vec![st_del_log, st_ins])
             .unwrap();
@@ -1569,8 +1622,8 @@ mod tests {
         let builder = MultiPodBuilder::new(&params, &vd_set);
         let mut ctx = BuildContext { builder, modules };
 
-        let stick_a = make_object(is_stick.clone(), &[]);
-        let stick_b = make_object(is_stick, &[]);
+        let stick_a_initial = make_object(is_stick.clone(), &[]);
+        let stick_b_initial = make_object(is_stick, &[]);
 
         let witness = state.grounding_witness(std::slice::from_ref(&tx2_out));
         let evidence = GroundingEvidence::new(&tx2_out.ctx, &wood).unwrap();
@@ -1595,13 +1648,40 @@ mod tests {
         };
 
         // Direct: insert stick_a
-        let (st_ins_a, h_a) = tx3.insert(&mut ctx, &stick_a);
+        let (stick_a, st_ins_a, h_a) = tx3.insert(&mut ctx, &stick_a_initial);
 
         // Direct: insert stick_b
-        let (st_ins_b, h_b) = tx3.insert(&mut ctx, &stick_b);
+        let (stick_b, st_ins_b, h_b) = tx3.insert(&mut ctx, &stick_b_initial);
 
+        // Pack stick_a / stick_b's pre-identity initials into an
+        // `initials` dict so CraftSticks stays within the 8-wildcard
+        // limit; rebind each TxInsert's slot 2 (initial) onto the
+        // matching anchored key. TxInsert's arg layout is (chain,
+        // prev_chain, initial, new, type).
+        let initials = dict!({
+            "stick_a" => stick_a_initial.clone(),
+            "stick_b" => stick_b_initial.clone()
+        });
+        let st_ins_a_anchored = ctx
+            .builder
+            .priv_op(Operation::replace_value_with_entry(
+                vec![None, None, Some((&initials, "stick_a")), None, None],
+                st_ins_a,
+            ))
+            .unwrap();
+        let st_ins_b_anchored = ctx
+            .builder
+            .priv_op(Operation::replace_value_with_entry(
+                vec![None, None, Some((&initials, "stick_b")), None, None],
+                st_ins_b,
+            ))
+            .unwrap();
         let st_craft_sticks = ctx
-            .apply_custom_pred_simple(false, "CraftSticks", vec![st_del_wood, st_ins_a, st_ins_b])
+            .apply_custom_pred_simple(
+                false,
+                "CraftSticks",
+                vec![st_del_wood, st_ins_a_anchored, st_ins_b_anchored],
+            )
             .unwrap();
 
         // stick_a: IsStick branch 2 = CraftSticks(obj, other, chain_start, chain_end)

--- a/txlib/src/lib.rs
+++ b/txlib/src/lib.rs
@@ -648,9 +648,9 @@ impl TxBuilder {
     ///
     /// `initial` is the pre-identity object state; the builder stamps
     /// `identity = commitment(initial)` via [`with_identity`] and the
-    /// returned `Dictionary` is the post-identity `new` (the dict that
-    /// lives in the tx). Subsequent mutate/delete must reference the
-    /// returned dict, not `initial`.
+    /// returned `Dictionary` is the post-identity `new` that the tx
+    /// records. Subsequent mutate/delete must reference the returned
+    /// dict, not `initial`.
     pub fn insert(
         &mut self,
         ctx: &mut BuildContext,

--- a/txlib/src/predicates/crafting_test.podlang
+++ b/txlib/src/predicates/crafting_test.podlang
@@ -27,32 +27,40 @@ DeleteStick(stick, chain_start, chain_end) = AND(
 // ========================================================
 
 // FindLog: creates a log from nothing (simplified: no VDF).
-FindLog(log, chain_start, chain_end) = AND(
-  tx::TxInsert(chain_end, chain_start, log, @self_predicate(IsLog))
+// `log` is the post-identity dict that lives in the tx; `log0` is
+// the pre-identity dict the action constructed, exposed as TxInsert's
+// public `initial` arg so identity = commitment(log0) is verifiable
+// against script-level DictUpdate/DictInsert chains.
+FindLog(log, chain_start, chain_end, private: log0) = AND(
+  tx::TxInsert(chain_end, chain_start, log0, log, @self_predicate(IsLog))
 )
 
 // CraftWood: consumes a log, produces wood (simplified: no LtEqU256).
 CraftWood(wood, chain_start, chain_end,
-    private: h0, log) = AND(
+    private: h0, log, wood0) = AND(
   DeleteLog(log, chain_start, h0)
-  tx::TxInsert(chain_end, h0, wood, @self_predicate(IsWood))
+  tx::TxInsert(chain_end, h0, wood0, wood, @self_predicate(IsWood))
 )
 
-// CraftSticks: consumes wood, produces two sticks.
+// CraftSticks: consumes wood, produces two sticks. The two stick
+// initials are packed into a single private `initials` dict
+// (`initials.stick_a`, `initials.stick_b`) so the predicate stays
+// within the 8-wildcard limit -- same trick as ReplayContentsStep*
+// packs `new`/`new_live`/`initial` into an `ins` dict.
 CraftSticks(stick_a, stick_b, chain_start, chain_end,
-    private: h0, h1, wood) = AND(
+    private: h0, h1, wood, initials) = AND(
   DeleteWood(wood, chain_start, h0)
-  tx::TxInsert(h1, h0, stick_a, @self_predicate(IsStick))
-  tx::TxInsert(chain_end, h1, stick_b, @self_predicate(IsStick))
+  tx::TxInsert(h1, h0, initials.stick_a, stick_a, @self_predicate(IsStick))
+  tx::TxInsert(chain_end, h1, initials.stick_b, stick_b, @self_predicate(IsStick))
 )
 
 // CraftWoodPick: consumes wood + stick, produces wood pick.
 CraftWoodPick(wood_pick, chain_start, chain_end,
-    private: h0, h1, wood, stick) = AND(
+    private: h0, h1, wood, stick, wood_pick0) = AND(
   DeleteWood(wood, chain_start, h0)
   DeleteStick(stick, h0, h1)
   DictContains(wood_pick, "durability", 100)
-  tx::TxInsert(chain_end, h1, wood_pick, @self_predicate(IsWoodPick))
+  tx::TxInsert(chain_end, h1, wood_pick0, wood_pick, @self_predicate(IsWoodPick))
 )
 
 // UseWoodPick: mutates a wood pick, decrementing durability.
@@ -67,15 +75,15 @@ UseWoodPick(wood_pick, chain_start, chain_end,
 
 // MineStone: uses a wood pick to mine stone.
 MineStone(stone, chain_start, chain_end,
-    private: h0, pick) = AND(
+    private: h0, pick, stone0) = AND(
   UseWoodPick(pick, chain_start, h0)
-  tx::TxInsert(chain_end, h0, stone, @self_predicate(IsStone))
+  tx::TxInsert(chain_end, h0, stone0, stone, @self_predicate(IsStone))
 )
 
 // SpawnWoodPick: test-only action that creates a wood pick from nothing.
-SpawnWoodPick(wood_pick, chain_start, chain_end) = AND(
+SpawnWoodPick(wood_pick, chain_start, chain_end, private: wood_pick0) = AND(
   DictContains(wood_pick, "durability", 100)
-  tx::TxInsert(chain_end, chain_start, wood_pick, @self_predicate(IsWoodPick))
+  tx::TxInsert(chain_end, chain_start, wood_pick0, wood_pick, @self_predicate(IsWoodPick))
 )
 
 // ========================================================

--- a/txlib/src/predicates/crafting_test.podlang
+++ b/txlib/src/predicates/crafting_test.podlang
@@ -27,7 +27,7 @@ DeleteStick(stick, chain_start, chain_end) = AND(
 // ========================================================
 
 // FindLog: creates a log from nothing (simplified: no VDF).
-// `log` is the post-identity dict that lives in the tx; `log0` is
+// `log` is the post-identity dict the tx records; `log0` is
 // the pre-identity dict the action constructed, exposed as TxInsert's
 // public `initial` arg so identity = commitment(log0) is verifiable
 // against script-level DictUpdate/DictInsert chains.

--- a/txlib/src/predicates/txlib.podlang
+++ b/txlib/src/predicates/txlib.podlang
@@ -49,7 +49,7 @@
 // `new.identity = commitment(initial)`: `initial` is the
 // pre-identity object dict the action constructed (script-driven
 // DictUpdates land on `initial`), and `new` is the materialized
-// post-identity dict that lives in the tx's `live` set. Exposing
+// post-identity dict the tx records in its `live` set. Exposing
 // `initial` as a public arg lets the calling action predicate
 // share its body wildcard with both the script's DictUpdate chain
 // and TxInsert's identity-derivation clause.

--- a/txlib/src/predicates/txlib.podlang
+++ b/txlib/src/predicates/txlib.podlang
@@ -45,19 +45,30 @@
 
 // Insert: chain = H(prev, H(0, new)). The `type` arg pins the
 // inserted object's type field so ReplayInsert can dispatch the
-// guard without re-extracting it.
-TxInsert(chain, prev_chain, new, type, private: event_hash) = AND(
+// guard without re-extracting it. The DictInsert clause stamps
+// `new.identity = commitment(initial)`: `initial` is the
+// pre-identity object dict the action constructed (script-driven
+// DictUpdates land on `initial`), and `new` is the materialized
+// post-identity dict that lives in the tx's `live` set. Exposing
+// `initial` as a public arg lets the calling action predicate
+// share its body wildcard with both the script's DictUpdate chain
+// and TxInsert's identity-derivation clause.
+TxInsert(chain, prev_chain, initial, new, type, private: event_hash) = AND(
   DictContains(new, "type", type)
+  DictInsert(new, initial, "identity", initial)
   HashOf(event_hash, 0, new)
   HashOf(chain, prev_chain, event_hash)
 )
 
 // Mutate: chain = H(prev, H(old, new)). The shared `type` arg pins
 // both old and new to the same type, enforcing type preservation
-// implicitly (no separate Equal needed).
+// implicitly (no separate Equal needed). The Equal clause pins
+// old.identity == new.identity so the stable per-instance identifier
+// set by TxInsert survives every mutation.
 TxMutate(chain, prev_chain, new, old, type, private: event_hash) = AND(
   DictContains(new, "type", type)
   DictContains(old, "type", type)
+  Equal(old.identity, new.identity)
   HashOf(event_hash, old, new)
   HashOf(chain, prev_chain, event_hash)
 )
@@ -126,7 +137,7 @@ ReplayContents(before_tx, after_tx, before_chain, after_chain) = OR(
 // wrapping per-event predicate.
 ReplayContentsStepInsert(before_tx, after_tx, before_chain, after_chain,
     private: mid_tx, mid_chain, ins, guard) = AND(
-  TxInsert(mid_chain, before_chain, ins.new, guard)
+  TxInsert(mid_chain, before_chain, ins.initial, ins.new, guard)
   SetInsert(ins.new_live, before_tx.live, ins.new)
   DictUpdate(mid_tx, before_tx, "live", ins.new_live)
   guard(ins.new, before_tx.chain_start, before_tx.chain_end)
@@ -227,8 +238,8 @@ ReplayActionsStep(before_tx, after_tx, before_chain, after_chain,
 // inside a `ReplayAction`-materialized `inner_tx`. Skipping that
 // materialization is what saves the three intermediate statements.
 ReplayActionInsert(before_tx, after_tx, before_chain, after_chain,
-    private: new, new_live, guard) = AND(
-  TxInsert(after_chain, before_chain, new, guard)
+    private: new, new_live, guard, initial) = AND(
+  TxInsert(after_chain, before_chain, initial, new, guard)
   SetInsert(new_live, before_tx.live, new)
   DictUpdate(after_tx, before_tx, "live", new_live)
   guard(new, before_chain, after_chain)
@@ -243,8 +254,8 @@ ReplayActionInsert(before_tx, after_tx, before_chain, after_chain,
 // HashOf equations lets the prover reuse the record-time statement
 // that it already built for the application's action predicate.
 ReplayInsert(before_tx, after_tx, before_chain, after_chain,
-    private: new, new_live, guard) = AND(
-  TxInsert(after_chain, before_chain, new, guard)
+    private: new, new_live, guard, initial) = AND(
+  TxInsert(after_chain, before_chain, initial, new, guard)
   SetInsert(new_live, before_tx.live, new)
   DictUpdate(after_tx, before_tx, "live", new_live)
   guard(new, before_tx.chain_start, before_tx.chain_end)

--- a/txlib/src/replay.rs
+++ b/txlib/src/replay.rs
@@ -279,6 +279,7 @@ impl<'a> Replayer<'a> {
         let (st_step, tag, final_chain, final_live, final_nulls) = match first {
             ChainEvent::Insert {
                 new,
+                initial,
                 chain_after,
                 tx_stmt,
                 guard_evidence,
@@ -292,6 +293,7 @@ impl<'a> Replayer<'a> {
                 let (st_rest, final_chain, final_live, final_nulls) =
                     self.build_replay_contents(rest, *chain_after, frame.with_live(&new_live));
                 let st = self.build_replay_step_insert(
+                    initial,
                     new,
                     frame,
                     &new_live,
@@ -539,6 +541,8 @@ impl<'a> Replayer<'a> {
         tx_stmt: Statement,
         guard_evidence: Statement,
     ) -> (Statement, Set) {
+        // ReplayInsert's `initial` private wildcard is bound by the
+        // TxInsert sub-statement we pass in; no standalone op needed.
         let btx = frame.to_tx_dict();
         let mut new_live = frame.live.clone();
         new_live.insert(&Value::from(new.clone())).unwrap();
@@ -576,14 +580,17 @@ impl<'a> Replayer<'a> {
 
     /// Build a `ReplayContentsStepInsert` statement: the inlined body
     /// of `ReplayInsert` plus the recursive `ReplayContents` tail. The
-    /// `new` object and the resulting `new_live` set are packed into a
-    /// tiny `ins` dict so they share a single wildcard slot (keeps the
-    /// predicate at 8 wildcards). Body sub-statements anchor to
-    /// `ins.new` / `ins.new_live` instead of using bare wildcards.
+    /// `new` object, the resulting `new_live` set, and the
+    /// pre-identity `initial` are packed into a tiny `ins` dict so
+    /// they share a single wildcard slot (keeps the predicate at 8
+    /// wildcards). Body sub-statements anchor to `ins.new` /
+    /// `ins.new_live` / `ins.initial` instead of using bare wildcards.
     /// `new_live` is `live + {new}`, supplied by the caller (which already
     /// needs it for the recursive tail).
+    #[allow(clippy::too_many_arguments)]
     fn build_replay_step_insert(
         &mut self,
+        initial: &Dictionary,
         new: &Dictionary,
         frame: ReplayFrame<'_>,
         new_live: &Set,
@@ -595,15 +602,23 @@ impl<'a> Replayer<'a> {
         let atx = tx_with(&btx, "live", Value::from(new_live.clone()));
         let ins = dict!({
             "new" => new.clone(),
-            "new_live" => new_live.clone()
+            "new_live" => new_live.clone(),
+            "initial" => initial.clone()
         });
 
-        // Re-anchor TxInsert's `new` slot (slot 2) from literal to ins.new.
+        // Re-anchor TxInsert's `initial` slot (slot 2) and `new`
+        // slot (slot 3) from literals to `ins.initial` / `ins.new`.
         let tx_stmt_wrapped = self
             .ctx
             .builder
             .priv_op(Operation::replace_value_with_entry(
-                vec![None, None, Some((&ins, "new")), None],
+                vec![
+                    None,
+                    None,
+                    Some((&ins, "initial")),
+                    Some((&ins, "new")),
+                    None,
+                ],
                 tx_stmt,
             ))
             .unwrap();


### PR DESCRIPTION
This PR adds an `identity` entry to all newly-created objects. The identity is the hash of the object's initial state (excluding the `identity` entry itself).

`TxMutate` enforces that the identity does not change during mutation.

`TxInsert` now takes an extra argument, `initial`, which is the initial state of the object prior to the `identity` entry being inserted. Actions have a new `initials` private argument, which contains the initial states of any objects they create (this is not present in actions which do not perform any `TxInsert`s). The created objects which appear in the `out` record will include the `identity` entry.