### PR TITLE
Global created set

### DIFF
--- a/common/src/payload.rs
+++ b/common/src/payload.rs
@@ -33,6 +33,31 @@ pub fn read_elems<const N: usize>(bytes: &mut impl Read) -> Result<[F; N]> {
     Ok(elems)
 }
 
+/// A list of hashes, length-prefixed by a single `u8` count: at most 255
+/// entries.
+fn write_hashes(buffer: &mut Vec<u8>, hashes: &[Hash]) {
+    assert!(hashes.len() <= 255);
+    buffer
+        .write_all(&(hashes.len() as u8).to_le_bytes())
+        .expect("vec write");
+    for hash in hashes {
+        write_elems(buffer, &hash.0);
+    }
+}
+
+fn read_hashes(bytes: &mut &[u8]) -> Result<Vec<Hash>> {
+    let len = {
+        let mut buffer = [0; 1];
+        bytes.read_exact(&mut buffer)?;
+        u8::from_le_bytes(buffer)
+    };
+    let mut hashes = Vec::with_capacity(len as usize);
+    for _ in 0..len {
+        hashes.push(Hash(read_elems(bytes)?));
+    }
+    Ok(hashes)
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[allow(clippy::large_enum_variant)]
 pub struct Payload {
@@ -41,6 +66,13 @@ pub struct Payload {
     pub tx_final: Hash,
     pub state_root_hash: Hash,
     pub nullifiers: Vec<Hash>,
+    /// Commitments of the objects this tx leaves live. The synchronizer
+    /// inserts each into its global created set, rejecting any that already
+    /// exists (the creation-uniqueness check, like a nullifier double-spend).
+    /// The list is also reconstructed into the `live` set that the public
+    /// TxFinalized statement commits to, so the proof only verifies against
+    /// these exact commitments -- the list cannot be forged.
+    pub live: Vec<Hash>,
 }
 
 const PAYLOAD_MAGIC: u16 = 0xd10b;
@@ -54,13 +86,8 @@ impl Payload {
         self.proof.write_bytes(&mut buffer);
         write_elems(&mut buffer, &self.tx_final.0);
         write_elems(&mut buffer, &self.state_root_hash.0);
-        assert!(self.nullifiers.len() <= 255);
-        buffer
-            .write_all(&(self.nullifiers.len() as u8).to_le_bytes())
-            .expect("vec write");
-        for nullifier in &self.nullifiers {
-            write_elems(&mut buffer, &nullifier.0);
-        }
+        write_hashes(&mut buffer, &self.nullifiers);
+        write_hashes(&mut buffer, &self.live);
         buffer
     }
 
@@ -79,20 +106,14 @@ impl Payload {
         bytes = &bytes[len..];
         let tx_final = Hash(read_elems(&mut bytes)?);
         let state_root_hash = Hash(read_elems(&mut bytes)?);
-        let nullifiers_len = {
-            let mut buffer = [0; 1];
-            bytes.read_exact(&mut buffer)?;
-            u8::from_le_bytes(buffer)
-        };
-        let mut nullifiers = Vec::with_capacity(nullifiers_len as usize);
-        for _ in 0..nullifiers_len {
-            nullifiers.push(Hash(read_elems(&mut bytes)?));
-        }
+        let nullifiers = read_hashes(&mut bytes)?;
+        let live = read_hashes(&mut bytes)?;
         Ok(Self {
             proof,
             tx_final,
             state_root_hash,
             nullifiers,
+            live,
         })
     }
 }
@@ -194,7 +215,7 @@ mod tests {
         let vds_root = vd_set.root();
 
         let input = r#"
-        TxnFinalized(state_root_hash, tx_final, nullifiers) = AND(
+        TxnFinalized(state_root_hash, tx_final, nullifiers, live) = AND(
             Equal(0, 0)
         )
         "#;
@@ -216,6 +237,13 @@ mod tests {
             let nullifiers_set = Value::from(Set::new(HashSet::from_iter(
                 nullifiers.iter().map(|h| Value::from(*h)),
             )));
+            let live = vec![
+                Hash(Value::from(10i64).raw().0),
+                Hash(Value::from(11i64).raw().0),
+            ];
+            let live_set = Value::from(Set::new(HashSet::from_iter(
+                live.iter().map(|h| Value::from(*h)),
+            )));
             let state_root = Value::from("dummy_state_root");
             let st0 = builder.priv_op(Operation::eq(0, 0)).unwrap();
             let st_txn_finalized = builder
@@ -225,6 +253,7 @@ mod tests {
                         (0, state_root.clone()),
                         (1, tx_final.clone()),
                         (2, nullifiers_set.clone()),
+                        (3, live_set.clone()),
                     ],
                     Operation::custom(pred.clone(), [st0]),
                 )
@@ -245,6 +274,7 @@ mod tests {
                 tx_final: Hash(tx_final.raw().0),
                 state_root_hash: Hash(state_root.raw().0),
                 nullifiers: nullifiers.clone(),
+                live: live.clone(),
             }
         };
 
@@ -258,12 +288,16 @@ mod tests {
         let nullifiers_set = Value::from(Set::new(HashSet::from_iter(
             payload.nullifiers.iter().map(|h| Value::from(*h)),
         )));
+        let live_set = Value::from(Set::new(HashSet::from_iter(
+            payload.live.iter().map(|h| Value::from(*h)),
+        )));
         let st = Statement::Custom(
             pred,
             vec![
                 Value::from(payload.state_root_hash).into(),
                 Value::from(payload.tx_final).into(),
                 nullifiers_set.into(),
+                live_set.into(),
             ],
         );
         println!("st: {st:?}");

--- a/common/src/proof.rs
+++ b/common/src/proof.rs
@@ -14,6 +14,15 @@ use pod2::{
     },
 };
 
+fn hashes_to_set(hashes: &[Hash]) -> Set {
+    Set::new(
+        hashes
+            .iter()
+            .map(|h| Value::from(*h))
+            .collect::<HashSet<_>>(),
+    )
+}
+
 /// Decodes and validates a raw blob payload.
 ///
 /// Returns `Ok(Some(payload))` when the blob contains a valid, cryptographically verified
@@ -28,7 +37,7 @@ pub trait BlobParser: Send + Sync {
 // MockBlobParser
 // ---------------------------------------------------------------------------
 
-/// Mock parser: accepts JSON `{ "tx_final": "0x...", "nullifiers": [...], "state_root_hash": "0x..." }`
+/// Mock parser: accepts JSON `{ "tx_final": "0x...", "nullifiers": [...], "live": [...], "state_root_hash": "0x..." }`
 /// Hash bytes serialized as lowercase hex strings.
 /// Returns a `Payload` with a dummy empty `PayloadProof` since no real proof
 /// is needed for mock testing.
@@ -40,6 +49,7 @@ pub struct MockBlobParser;
 struct MockProofJson {
     tx_final: String,
     nullifiers: Vec<String>,
+    live: Vec<String>,
     state_root_hash: String,
 }
 
@@ -57,12 +67,18 @@ impl BlobParser for MockBlobParser {
             .iter()
             .map(|s| decode_hash_hex(s))
             .collect::<Result<Vec<_>>>()?;
+        let live = json
+            .live
+            .iter()
+            .map(|s| decode_hash_hex(s))
+            .collect::<Result<Vec<_>>>()?;
         let state_root_hash = decode_hash_hex(&json.state_root_hash)?;
         Ok(Some(Payload {
             proof: PayloadProof::empty_for_test(),
             tx_final,
             state_root_hash,
             nullifiers,
+            live,
         }))
     }
 }
@@ -136,24 +152,16 @@ impl BlobParser for ProofParser {
             Err(_) => return Ok(None),
         };
 
-        // 2. Reconstruct the nullifiers Set and build the expected Statement::Custom.
-        //    txlib's TxFinalized(state_root_hash, tx_final, nullifiers):
-        //      - state_root_hash: payload.state_root_hash
-        //      - tx_final:        Value::from(tx dict commitment) = Value::from(payload.tx_final)
-        //      - nullifiers:      Set reconstructed from payload.nullifiers
-        let nullifiers_set = Set::new(
-            payload
-                .nullifiers
-                .iter()
-                .map(|h| Value::from(*h))
-                .collect::<HashSet<_>>(),
-        );
+        // 2. Rebuild the public statement the proof was made against. The
+        //    nullifier and live sets travel as plain hash lists, so the set
+        //    commitments have to be reconstructed before they can be matched.
         let statement = Statement::Custom(
             self.txn_finalized_pred.clone(),
             vec![
                 Value::from(payload.state_root_hash).into(),
                 Value::from(payload.tx_final).into(),
-                Value::from(nullifiers_set).into(),
+                Value::from(hashes_to_set(&payload.nullifiers)).into(),
+                Value::from(hashes_to_set(&payload.live)).into(),
             ],
         );
 
@@ -191,7 +199,7 @@ mod tests {
         let sr_hex = format!("0x{}", hash_to_hex(&state_root));
 
         let json = format!(
-            r#"{{"tx_final":"{}","nullifiers":["{}"],"state_root_hash":"{}"}}"#,
+            r#"{{"tx_final":"{}","nullifiers":["{}"],"live":[],"state_root_hash":"{}"}}"#,
             tx_hex, null_hex, sr_hex
         );
 
@@ -219,7 +227,7 @@ mod tests {
         let tx_hex = hash_to_hex(&tx_final); // no "0x" prefix
 
         let json = format!(
-            r#"{{"tx_final":"{}","nullifiers":[],"state_root_hash":"{}"}}"#,
+            r#"{{"tx_final":"{}","nullifiers":[],"live":[],"state_root_hash":"{}"}}"#,
             tx_hex, tx_hex
         );
 

--- a/common/src/test_state.rs
+++ b/common/src/test_state.rs
@@ -8,11 +8,15 @@ use pod2::{
     },
 };
 
-/// Reusable committed-state helper for proof-heavy tests across crates.
+/// Reusable committed-state helper for proof-heavy tests across crates. Holds
+/// a grow-only global created-object set (an array, plus a reverse index for
+/// proofs), a nullifier set, and a GSR history array, and hands out the Merkle
+/// proofs grounding needs.
 #[derive(Clone, Debug)]
 pub struct TestState {
     pub block_number: i64,
-    transactions: Set,
+    created: Array,
+    created_index: HashMap<Hash, i64>,
     nullifiers: Set,
     gsrs: Array,
 }
@@ -27,91 +31,57 @@ impl TestState {
     pub fn empty(block_number: i64) -> Self {
         Self {
             block_number,
-            transactions: Set::new(HashSet::<Value>::new()),
+            created: Array::new(Vec::<Value>::new()),
+            created_index: HashMap::new(),
             nullifiers: Set::new(HashSet::<Value>::new()),
             gsrs: Array::new(Vec::<Value>::new()),
         }
     }
 
-    pub fn from_txs<T, FHash, FNullifiers>(
-        block_number: i64,
-        txs: &[T],
-        prior_state_root_hashes: &[Hash],
-        tx_hash: FHash,
-        nullifier_hashes: FNullifiers,
-    ) -> Self
-    where
-        FHash: Fn(&T) -> Hash,
-        FNullifiers: Fn(&T) -> Vec<Hash>,
-    {
-        let transactions = Set::new(
-            txs.iter()
-                .map(|tx| Value::from(tx_hash(tx)))
-                .collect::<HashSet<_>>(),
-        );
-        let nullifiers = Set::new(
-            txs.iter()
-                .flat_map(nullifier_hashes)
-                .map(Value::from)
-                .collect::<HashSet<_>>(),
-        );
-        let gsrs = Array::new(
-            prior_state_root_hashes
-                .iter()
-                .copied()
-                .map(Value::from)
-                .collect(),
-        );
-        Self {
-            block_number,
-            transactions,
-            nullifiers,
-            gsrs,
-        }
-    }
-
+    /// `(created_root, nullifiers_root, gsrs_root)`.
     pub fn roots(&self) -> (Hash, Hash, Hash) {
         (
-            self.transactions.commitment(),
+            self.created.commitment(),
             self.nullifiers.commitment(),
             self.gsrs.commitment(),
         )
     }
 
-    pub fn build_grounding_witness<T, W, FHash>(
+    /// Build a grounding witness proving each input object commitment is a
+    /// member of the global created set. `build` assembles the crate's witness
+    /// type from `(block_number, created_root, nullifiers_root, gsrs_root,
+    /// per-object (index, proof) keyed by commitment)`.
+    pub fn build_grounding_witness<W>(
         &self,
-        source_txs: &[T],
-        tx_hash: FHash,
-        build: impl FnOnce(i64, Hash, Hash, Hash, HashMap<Hash, MerkleProof>) -> W,
-    ) -> W
-    where
-        FHash: Fn(&T) -> Hash,
-    {
-        let source_tx_proofs = source_txs
+        input_commitments: &[Hash],
+        build: impl FnOnce(i64, Hash, Hash, Hash, HashMap<Hash, (i64, MerkleProof)>) -> W,
+    ) -> W {
+        let created_proofs = input_commitments
             .iter()
-            .map(|tx| {
-                let tx_hash = tx_hash(tx);
-                let proof = self
-                    .transactions
-                    .prove(&Value::from(tx_hash))
-                    .expect("source tx should be provable from test state");
-                (tx_hash, proof)
-            })
+            .map(|commitment| (*commitment, self.created_membership_proof(*commitment)))
             .collect::<HashMap<_, _>>();
-        let (transactions_root, nullifiers_root, gsrs_root) = self.roots();
+        let (created_root, nullifiers_root, gsrs_root) = self.roots();
         build(
             self.block_number,
-            transactions_root,
+            created_root,
             nullifiers_root,
             gsrs_root,
-            source_tx_proofs,
+            created_proofs,
         )
     }
 
-    pub fn tx_membership_proof(&self, tx_hash: Hash) -> MerkleProof {
-        self.transactions
-            .prove(&Value::from(tx_hash))
-            .expect("tx should be provable from test state")
+    /// `(array index, membership proof)` for one object commitment in the
+    /// created set.
+    pub fn created_membership_proof(&self, commitment: Hash) -> (i64, MerkleProof) {
+        let index = *self
+            .created_index
+            .get(&commitment)
+            .expect("object should be present in test state created set");
+        let (_value, proof) = self
+            .created
+            .prove(index as usize)
+            .expect("object should be provable from test state");
+        (index, proof)
     }
 
     pub fn prior_state_root_membership(&self, prior_state_root_hash: Hash) -> (usize, MerkleProof) {
@@ -126,10 +96,19 @@ impl TestState {
         panic!("prior state root missing from grounding state");
     }
 
-    pub fn apply_tx(&mut self, tx_hash: Hash, nullifier_hashes: impl IntoIterator<Item = Hash>) {
-        self.transactions
-            .insert(&Value::from(tx_hash))
-            .expect("tx hash should insert into test state");
+    pub fn apply_tx(
+        &mut self,
+        created_commitments: impl IntoIterator<Item = Hash>,
+        nullifier_hashes: impl IntoIterator<Item = Hash>,
+    ) {
+        for commitment in created_commitments {
+            // 1-indexed: slot 0 stays empty so nothing grounds at index 0.
+            let index = self.created_index.len() as i64 + 1;
+            self.created
+                .insert(index as usize, Value::from(commitment))
+                .expect("created object should insert into test state");
+            self.created_index.insert(commitment, index);
+        }
         for nullifier in nullifier_hashes {
             self.nullifiers
                 .insert(&Value::from(nullifier))

--- a/driver/src/clients/synchronizer_client.rs
+++ b/driver/src/clients/synchronizer_client.rs
@@ -9,7 +9,7 @@ use serde::de::DeserializeOwned;
 use txlib::{GroundingWitness, StateRoot};
 use wire_types::synchronizer::{
     GroundingWitnessRequest, GroundingWitnessResponse, MembershipRequest, MembershipResponse,
-    StateHeadResponse, TxStatusResponse,
+    StateHeadResponse,
 };
 
 use common::{decode_hash_hex, encode_hash_hex};
@@ -35,7 +35,8 @@ pub struct SynchronizerHead {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SynchronizerMembership {
-    pub grounded_txs: HashSet<Hash>,
+    /// Object commitments present in the canonical global created set.
+    pub created_objects: HashSet<Hash>,
     pub on_chain_nullifiers: HashSet<Hash>,
 }
 
@@ -44,18 +45,23 @@ pub trait SynchronizerClient: Send + Sync {
     fn fetch_grounding_witness(
         &self,
         sync_api_url: &str,
-        source_tx_hashes: &[Hash],
+        object_commitments: &[Hash],
     ) -> Result<GroundingWitness>;
     fn fetch_membership_with_nullifiers(
         &self,
         sync_api_url: &str,
-        tx_hashes: &[Hash],
+        object_commitments: &[Hash],
         nullifiers: &[Hash],
     ) -> Result<SynchronizerMembership>;
+    /// Wait until a transaction has landed: every object commitment it produces
+    /// is in the canonical created set and every nullifier it emits is in the
+    /// canonical nullifier set. Returns the resulting head once the whole union
+    /// is present, or errors on timeout.
     fn wait_for_tx(
         &self,
         sync_api_url: &str,
-        tx_final: Hash,
+        created_commitments: &[Hash],
+        nullifiers: &[Hash],
         timeout_secs: u64,
         poll_interval_ms: u64,
     ) -> Result<SynchronizerHead>;
@@ -84,14 +90,14 @@ impl SynchronizerClient for HttpSynchronizerClient {
     fn fetch_grounding_witness(
         &self,
         sync_api_url: &str,
-        source_tx_hashes: &[Hash],
+        object_commitments: &[Hash],
     ) -> Result<GroundingWitness> {
         let endpoint = format!(
             "{}/v1/txlib/grounding-witness",
             sync_api_url.trim_end_matches('/')
         );
         let request = GroundingWitnessRequest {
-            source_tx_hashes: source_tx_hashes.iter().map(encode_hash_hex).collect(),
+            object_commitments: object_commitments.iter().map(encode_hash_hex).collect(),
         };
         let client = reqwest::blocking::Client::new();
         let payload: GroundingWitnessResponse = send_json_request(
@@ -102,7 +108,7 @@ impl SynchronizerClient for HttpSynchronizerClient {
 
         let state_root = StateRoot::new(
             payload.block_number,
-            parse_hash_hex(&payload.transactions_root)?,
+            parse_hash_hex(&payload.created_root)?,
             parse_hash_hex(&payload.nullifiers_root)?,
             parse_hash_hex(&payload.gsrs_root)?,
         );
@@ -116,53 +122,56 @@ impl SynchronizerClient for HttpSynchronizerClient {
             ));
         }
 
-        let source_tx_proofs = collect_source_tx_proofs(
-            source_tx_hashes,
-            payload
-                .source_tx_proofs
-                .into_iter()
-                .map(|entry| (entry.tx_hash, entry.present, entry.proof)),
+        let created_proofs = collect_created_proofs(
+            object_commitments,
+            payload.created_proofs.into_iter().map(|entry| {
+                (
+                    entry.commitment,
+                    entry.present,
+                    entry.index.zip(entry.proof),
+                )
+            }),
         )?;
 
-        Ok(GroundingWitness::new(state_root, source_tx_proofs))
+        Ok(GroundingWitness::new(state_root, created_proofs))
     }
 
     fn fetch_membership_with_nullifiers(
         &self,
         sync_api_url: &str,
-        tx_hashes: &[Hash],
+        object_commitments: &[Hash],
         nullifiers: &[Hash],
     ) -> Result<SynchronizerMembership> {
         let endpoint = format!("{}/v1/state/membership", sync_api_url.trim_end_matches('/'));
         let client = reqwest::blocking::Client::new();
 
-        let mut grounded_txs: HashSet<Hash> = HashSet::new();
+        let mut created_objects: HashSet<Hash> = HashSet::new();
         let mut on_chain_nullifiers: HashSet<Hash> = HashSet::new();
 
-        // Empty inputs → no network call. The membership endpoint accepts
-        // a request with both lists empty, but it's a wasted round trip.
-        if tx_hashes.is_empty() && nullifiers.is_empty() {
+        // Empty inputs need no network call: the membership endpoint accepts a
+        // request with both lists empty, but it is a wasted round trip.
+        if object_commitments.is_empty() && nullifiers.is_empty() {
             return Ok(SynchronizerMembership {
-                grounded_txs,
+                created_objects,
                 on_chain_nullifiers,
             });
         }
 
-        // The synchronizer rejects bodies where `tx_hashes.len() +
+        // The synchronizer rejects bodies where `object_commitments.len() +
         // nullifiers.len() > MEMBERSHIP_BATCH_LIMIT` with 400. Pack each
-        // batch tightly: take as many tx_hashes as possible (up to the
-        // limit), then fill the remainder with nullifiers. Continue until
+        // batch tightly: take as many object commitments as possible (up to
+        // the limit), then fill the remainder with nullifiers. Continue until
         // both lists are drained. Sequential because reqwest::blocking
         // and synchronizer responses are fast.
-        let mut tx_cursor = 0usize;
+        let mut obj_cursor = 0usize;
         let mut null_cursor = 0usize;
-        while tx_cursor < tx_hashes.len() || null_cursor < nullifiers.len() {
-            let tx_take = (tx_hashes.len() - tx_cursor).min(MEMBERSHIP_BATCH_LIMIT);
-            let remaining_capacity = MEMBERSHIP_BATCH_LIMIT - tx_take;
+        while obj_cursor < object_commitments.len() || null_cursor < nullifiers.len() {
+            let obj_take = (object_commitments.len() - obj_cursor).min(MEMBERSHIP_BATCH_LIMIT);
+            let remaining_capacity = MEMBERSHIP_BATCH_LIMIT - obj_take;
             let null_take = (nullifiers.len() - null_cursor).min(remaining_capacity);
 
             let request = MembershipRequest {
-                tx_hashes: tx_hashes[tx_cursor..tx_cursor + tx_take]
+                object_commitments: object_commitments[obj_cursor..obj_cursor + obj_take]
                     .iter()
                     .map(encode_hash_hex)
                     .collect(),
@@ -178,9 +187,9 @@ impl SynchronizerClient for HttpSynchronizerClient {
                 "synchronizer membership response",
             )?;
 
-            for entry in payload.tx_results {
+            for entry in payload.created_results {
                 if entry.present {
-                    grounded_txs.insert(parse_hash_hex(&entry.tx_hash)?);
+                    created_objects.insert(parse_hash_hex(&entry.commitment)?);
                 }
             }
             for entry in payload.nullifier_results {
@@ -189,12 +198,12 @@ impl SynchronizerClient for HttpSynchronizerClient {
                 }
             }
 
-            tx_cursor += tx_take;
+            obj_cursor += obj_take;
             null_cursor += null_take;
         }
 
         Ok(SynchronizerMembership {
-            grounded_txs,
+            created_objects,
             on_chain_nullifiers,
         })
     }
@@ -202,7 +211,8 @@ impl SynchronizerClient for HttpSynchronizerClient {
     fn wait_for_tx(
         &self,
         sync_api_url: &str,
-        tx_final: Hash,
+        created_commitments: &[Hash],
+        nullifiers: &[Hash],
         timeout_secs: u64,
         poll_interval_ms: u64,
     ) -> Result<SynchronizerHead> {
@@ -210,14 +220,23 @@ impl SynchronizerClient for HttpSynchronizerClient {
         let poll_interval = Duration::from_millis(poll_interval_ms);
         let start = Instant::now();
         loop {
-            let status = fetch_synchronizer_tx_status(sync_api_url, &tx_final)?;
-            if status.present {
+            let membership = self.fetch_membership_with_nullifiers(
+                sync_api_url,
+                created_commitments,
+                nullifiers,
+            )?;
+            let landed = created_commitments
+                .iter()
+                .all(|c| membership.created_objects.contains(c))
+                && nullifiers
+                    .iter()
+                    .all(|n| membership.on_chain_nullifiers.contains(n));
+            if landed {
                 return self.fetch_head(sync_api_url);
             }
             if start.elapsed() >= timeout {
                 return Err(anyhow!(
-                    "synchronizer did not index relayed tx {} within {}s",
-                    encode_hash_hex(&tx_final),
+                    "synchronizer did not observe the transaction within {}s",
                     timeout_secs
                 ));
             }
@@ -251,53 +270,62 @@ fn send_json_request<T: DeserializeOwned>(
         .map_err(|err| anyhow!("failed to decode {decode_context}: {err}"))
 }
 
-fn collect_source_tx_proofs<P>(
-    requested_source_tx_hashes: &[Hash],
-    entries: impl IntoIterator<Item = (String, bool, P)>,
+/// Validate and index the per-object created-set proofs returned by the
+/// synchronizer against the commitments we requested. Rejects unexpected,
+/// conflicting, omitted, or not-yet-present entries.
+fn collect_created_proofs<P>(
+    requested_commitments: &[Hash],
+    entries: impl IntoIterator<Item = (String, bool, Option<P>)>,
 ) -> Result<HashMap<Hash, P>> {
-    let expected_hashes = requested_source_tx_hashes
+    let expected_hashes = requested_commitments
         .iter()
         .copied()
         .collect::<HashSet<_>>();
     let mut response_presence = HashMap::new();
-    let mut source_tx_proofs = HashMap::new();
+    let mut created_proofs = HashMap::new();
 
-    for (tx_hash_raw, present, proof) in entries {
-        let tx_hash = parse_hash_hex(&tx_hash_raw)?;
-        if !expected_hashes.contains(&tx_hash) {
+    for (commitment_raw, present, proof) in entries {
+        let commitment = parse_hash_hex(&commitment_raw)?;
+        if !expected_hashes.contains(&commitment) {
             return Err(anyhow!(
-                "synchronizer grounding witness response contained unexpected source tx proof: {}",
-                encode_hash_hex(&tx_hash)
+                "synchronizer grounding witness response contained unexpected object proof: {}",
+                encode_hash_hex(&commitment)
             ));
         }
 
-        if let Some(previous_present) = response_presence.insert(tx_hash, present)
+        if let Some(previous_present) = response_presence.insert(commitment, present)
             && previous_present != present
         {
             return Err(anyhow!(
-                "synchronizer grounding witness response contained conflicting entries for source tx {}",
-                encode_hash_hex(&tx_hash)
+                "synchronizer grounding witness response contained conflicting entries for object {}",
+                encode_hash_hex(&commitment)
             ));
         }
 
         if present {
-            source_tx_proofs.insert(tx_hash, proof);
+            let proof = proof.ok_or_else(|| {
+                anyhow!(
+                    "synchronizer reported object {} present but omitted its array proof",
+                    encode_hash_hex(&commitment)
+                )
+            })?;
+            created_proofs.insert(commitment, proof);
         }
     }
 
-    let omitted = render_requested_hashes(requested_source_tx_hashes, |tx_hash| {
-        !response_presence.contains_key(tx_hash)
+    let omitted = render_requested_hashes(requested_commitments, |commitment| {
+        !response_presence.contains_key(commitment)
     });
     if !omitted.is_empty() {
         return Err(anyhow!(
-            "synchronizer grounding witness response omitted requested source tx proofs: {}",
+            "synchronizer grounding witness response omitted requested object proofs: {}",
             omitted.join(", ")
         ));
     }
 
-    let unavailable = render_requested_hashes(requested_source_tx_hashes, |tx_hash| {
+    let unavailable = render_requested_hashes(requested_commitments, |commitment| {
         response_presence
-            .get(tx_hash)
+            .get(commitment)
             .is_some_and(|present| !*present)
     });
     if !unavailable.is_empty() {
@@ -307,35 +335,21 @@ fn collect_source_tx_proofs<P>(
         ));
     }
 
-    Ok(source_tx_proofs)
+    Ok(created_proofs)
 }
 
 fn render_requested_hashes(
-    requested_source_tx_hashes: &[Hash],
+    requested_commitments: &[Hash],
     include: impl Fn(&Hash) -> bool,
 ) -> Vec<String> {
     let mut seen = HashSet::new();
     let mut rendered = Vec::new();
-    for tx_hash in requested_source_tx_hashes {
-        if seen.insert(*tx_hash) && include(tx_hash) {
-            rendered.push(encode_hash_hex(tx_hash));
+    for commitment in requested_commitments {
+        if seen.insert(*commitment) && include(commitment) {
+            rendered.push(encode_hash_hex(commitment));
         }
     }
     rendered
-}
-
-fn fetch_synchronizer_tx_status(sync_api_url: &str, tx_hash: &Hash) -> Result<TxStatusResponse> {
-    let endpoint = format!(
-        "{}/v1/state/tx/{}",
-        sync_api_url.trim_end_matches('/'),
-        encode_hash_hex(tx_hash)
-    );
-    let client = reqwest::blocking::Client::new();
-    send_json_request(
-        client.get(&endpoint),
-        &endpoint,
-        "synchronizer tx status response",
-    )
 }
 
 #[cfg(test)]
@@ -347,11 +361,11 @@ mod tests {
     }
 
     #[test]
-    fn collect_source_tx_proofs_rejects_omitted_requested_hash() {
+    fn collect_created_proofs_rejects_omitted_requested_hash() {
         let requested = [test_hash(1), test_hash(2)];
-        let proofs = vec![(encode_hash_hex(&requested[0]), true, "proof-1")];
+        let proofs = vec![(encode_hash_hex(&requested[0]), true, Some("proof-1"))];
 
-        let err = collect_source_tx_proofs(&requested, proofs).expect_err("should fail");
+        let err = collect_created_proofs(&requested, proofs).expect_err("should fail");
 
         assert!(
             err.to_string().contains(&encode_hash_hex(&requested[1])),
@@ -360,12 +374,12 @@ mod tests {
     }
 
     #[test]
-    fn collect_source_tx_proofs_rejects_unexpected_hash() {
+    fn collect_created_proofs_rejects_unexpected_hash() {
         let requested = [test_hash(1)];
         let unexpected = test_hash(9);
-        let proofs = vec![(encode_hash_hex(&unexpected), true, "proof-9")];
+        let proofs = vec![(encode_hash_hex(&unexpected), true, Some("proof-9"))];
 
-        let err = collect_source_tx_proofs(&requested, proofs).expect_err("should fail");
+        let err = collect_created_proofs(&requested, proofs).expect_err("should fail");
 
         assert!(
             err.to_string().contains(&encode_hash_hex(&unexpected)),
@@ -374,14 +388,14 @@ mod tests {
     }
 
     #[test]
-    fn collect_source_tx_proofs_rejects_conflicting_duplicate_status() {
+    fn collect_created_proofs_rejects_conflicting_duplicate_status() {
         let requested = [test_hash(1)];
         let proofs = vec![
-            (encode_hash_hex(&requested[0]), true, "proof-1a"),
-            (encode_hash_hex(&requested[0]), false, "proof-1b"),
+            (encode_hash_hex(&requested[0]), true, Some("proof-1a")),
+            (encode_hash_hex(&requested[0]), false, None),
         ];
 
-        let err = collect_source_tx_proofs(&requested, proofs).expect_err("should fail");
+        let err = collect_created_proofs(&requested, proofs).expect_err("should fail");
 
         assert!(
             err.to_string().contains("conflicting entries"),
@@ -390,14 +404,14 @@ mod tests {
     }
 
     #[test]
-    fn collect_source_tx_proofs_allows_duplicate_requested_hashes() {
+    fn collect_created_proofs_allows_duplicate_requested_hashes() {
         let requested = [test_hash(1), test_hash(1), test_hash(2)];
         let proofs = vec![
-            (encode_hash_hex(&requested[0]), true, "proof-1"),
-            (encode_hash_hex(&requested[2]), true, "proof-2"),
+            (encode_hash_hex(&requested[0]), true, Some("proof-1")),
+            (encode_hash_hex(&requested[2]), true, Some("proof-2")),
         ];
 
-        let result = collect_source_tx_proofs(&requested, proofs).expect("should succeed");
+        let result = collect_created_proofs(&requested, proofs).expect("should succeed");
 
         assert_eq!(result.len(), 2);
         assert_eq!(result.get(&requested[0]), Some(&"proof-1"));

--- a/driver/src/driver.rs
+++ b/driver/src/driver.rs
@@ -161,9 +161,9 @@ impl Driver {
     pub fn sync_inventory(&self, query: Option<&ObjectQuery>) -> Result<Vec<ObjectSummary>> {
         let mut entries = load_object_files(&self.paths)?;
         let settings = self.load_settings()?;
-        let source_tx_hashes = entries
+        let object_commitments = entries
             .iter()
-            .map(|entry| entry.record.evidence.tx_final)
+            .map(|entry| entry.record.obj.commitment())
             .collect::<HashSet<_>>();
         let all_nullifiers = entries
             .iter()
@@ -172,14 +172,14 @@ impl Driver {
 
         let membership = self.deps.synchronizer.fetch_membership_with_nullifiers(
             &settings.synchronizer_api_url,
-            &source_tx_hashes.iter().copied().collect::<Vec<_>>(),
+            &object_commitments.iter().copied().collect::<Vec<_>>(),
             &all_nullifiers.iter().copied().collect::<Vec<_>>(),
         )?;
 
         reconcile_objects(
             &self.paths,
             &mut entries,
-            &membership.grounded_txs,
+            &membership.created_objects,
             &membership.on_chain_nullifiers,
         )?;
 
@@ -189,7 +189,7 @@ impl Driver {
             if entry.record.status != ObjectStatus::Pending {
                 continue;
             }
-            let tx_final = encode_hash_hex(&entry.record.evidence.tx_final);
+            let tx_final = encode_hash_hex(&entry.record.tx_final);
             let current_hash = self
                 .deps
                 .relayer
@@ -410,11 +410,11 @@ impl Driver {
         }
 
         // 4. Grounding decides status. A nullifier already on-chain means the
-        //    object has been spent — reject it. Otherwise Live if the source
-        //    tx is canonical, else Unknown. Tolerate an unreachable
-        //    synchronizer by importing as Unknown.
+        //    object has been spent — reject it. Otherwise Live if the object's
+        //    commitment is in the canonical created set, else Unknown. Tolerate
+        //    an unreachable synchronizer by importing as Unknown.
         let settings = self.load_settings()?;
-        let source_tx = record.evidence.tx_final;
+        let commitment = record.obj.commitment();
         let nullifier = object_nullifier_hash(&record.obj).map_err(|err| {
             DriverError::InvalidInput(format!(
                 "could not derive nullifier from imported object: {err}"
@@ -422,7 +422,7 @@ impl Driver {
         })?;
         let status = match self.deps.synchronizer.fetch_membership_with_nullifiers(
             &settings.synchronizer_api_url,
-            &[source_tx],
+            &[commitment],
             &[nullifier],
         ) {
             Ok(membership) => {
@@ -431,7 +431,7 @@ impl Driver {
                         "imported object has already been spent on-chain".to_string(),
                     )
                     .into());
-                } else if membership.grounded_txs.contains(&source_tx) {
+                } else if membership.created_objects.contains(&commitment) {
                     ObjectStatus::Live
                 } else {
                     ObjectStatus::Unknown
@@ -475,14 +475,14 @@ impl Driver {
         reporter.on_step(ExecutionPhase::GenerateProof, "Verifying inputs", &no_ctx);
         let entries = load_object_files(&self.paths)?;
         let resolved_inputs = resolve_inputs(&entries, &input, &action)?;
-        let source_tx_hashes = resolved_inputs
+        let input_commitments = resolved_inputs
             .iter()
-            .map(|entry| entry.record.evidence.tx_final)
+            .map(|entry| entry.record.obj.commitment())
             .collect::<Vec<_>>();
         let grounding_witness = self
             .deps
             .synchronizer
-            .fetch_grounding_witness(&settings.synchronizer_api_url, &source_tx_hashes)?;
+            .fetch_grounding_witness(&settings.synchronizer_api_url, &input_commitments)?;
         let old_root_hash = grounding_witness.state_root.hash();
         let old_root = encode_hash_hex(&old_root_hash);
 
@@ -508,7 +508,15 @@ impl Driver {
             .deps
             .payload_builder
             .build_payload(&old_root_hash, &spendable_outputs)?;
-        let expected_tx_final = spendable_outputs.tx.dict().commitment();
+        // A tx has landed once the union of its effects is canonical: every
+        // produced object commitment in the created set and every nullifier in
+        // the nullifier set. Collect both for the confirmation poll below.
+        let output_commitments: Vec<Hash> = spendable_outputs
+            .objs
+            .iter()
+            .map(|spendable| spendable.obj.commitment())
+            .collect();
+        let nullifiers = spendable_outputs.tx.nullifier_hashes()?;
 
         reporter.on_step(ExecutionPhase::Commit, "Creating files", &commit_ctx);
         let saved = save_results(&self.paths, &action, &resolved_inputs, &spendable_outputs)?;
@@ -601,7 +609,8 @@ impl Driver {
         );
         let sync_head = match self.deps.synchronizer.wait_for_tx(
             &settings.synchronizer_api_url,
-            expected_tx_final,
+            &output_commitments,
+            &nullifiers,
             SYNCHRONIZER_POLL_TIMEOUT_SECS,
             SYNCHRONIZER_POLL_INTERVAL_MS,
         ) {

--- a/driver/src/execute.rs
+++ b/driver/src/execute.rs
@@ -23,7 +23,7 @@ use wire_types::{ActionSummary, ObjectStatus};
 pub(crate) fn reconcile_objects(
     paths: &DriverPaths,
     objects: &mut [ObjectFileEntry],
-    grounded_txs: &HashSet<Hash>,
+    created_objects: &HashSet<Hash>,
     on_chain_nullifiers: &HashSet<Hash>,
 ) -> Result<()> {
     let mut errors: Vec<String> = Vec::new();
@@ -78,14 +78,14 @@ pub(crate) fn reconcile_objects(
         entry.record = restored_record;
     }
 
-    // Third pass: mark non-nullified objects as Live when their source tx
-    // is in the canonical grounded set.
+    // Third pass: mark non-nullified objects as Live when their commitment
+    // is present in the canonical global created set.
     for entry in objects.iter_mut() {
         if entry.record.is_nullified() || entry.record.status == ObjectStatus::Live {
             continue;
         }
-        let source_tx_hash = entry.record.evidence.tx_final;
-        if !grounded_txs.contains(&source_tx_hash) {
+        let commitment = entry.record.obj.commitment();
+        if !created_objects.contains(&commitment) {
             continue;
         }
         let live_record = StoredObjectRecord {
@@ -230,6 +230,7 @@ pub(crate) fn save_results(
         ));
     }
 
+    let tx_final = spendable_outputs.tx.dict().commitment();
     let mut output_files = Vec::new();
     for (index, output) in action.total_outputs.iter().enumerate() {
         let spendable = spendable_outputs.obj(index);
@@ -247,7 +248,7 @@ pub(crate) fn save_results(
             status: ObjectStatus::Unknown,
             tx_hash: None,
             obj: spendable.obj,
-            evidence: spendable.evidence,
+            tx_final,
         };
         write_object_file(paths, &live_record, &file_name)?;
     }
@@ -290,17 +291,14 @@ pub(crate) fn build_relayer_payload(
         .map_err(|err| anyhow!("failed to shrink/compress tx proof: {err}"))?;
 
     let tx_final = action_output.tx.dict().commitment();
-    let nullifiers = action_output
-        .tx
-        .nullifiers
-        .iter()
-        .map(|entry| Ok(Hash(entry?.raw().0)))
-        .collect::<Result<Vec<_>>>()?;
+    let nullifiers = action_output.tx.nullifier_hashes()?;
+    let live = action_output.tx.live_commitments()?;
     let payload = Payload {
         proof: PayloadProof::Plonky2(Box::new(compressed)),
         tx_final,
         state_root_hash: *old_state_root_hash,
         nullifiers,
+        live,
     };
 
     Ok(payload.to_bytes())

--- a/driver/src/object_record.rs
+++ b/driver/src/object_record.rs
@@ -1,8 +1,7 @@
-use pod2::middleware::containers::Dictionary;
+use pod2::middleware::{Hash, containers::Dictionary};
 use sdk::SpendableObject;
 use serde::{Deserialize, Serialize};
 use std::{fs, path::Path};
-use txlib::GroundingEvidence;
 
 use wire_types::{ObjectStatus, QualifiedName};
 
@@ -21,9 +20,10 @@ pub struct ObjectRecord {
     pub tx_hash: Option<String>,
     /// Object payload dictionary
     pub obj: Dictionary,
-    /// Per-object grounding evidence: source tx commitment + Merkle
-    /// proofs anchoring the object inside that source tx's live set.
-    pub evidence: GroundingEvidence,
+    /// Commitment of the transaction that produced this object. Used only to
+    /// correlate with the relayer, resolving the current Ethereum tx hash
+    /// across fee-bump replacements.
+    pub tx_final: Hash,
 }
 
 impl ObjectRecord {
@@ -34,7 +34,6 @@ impl ObjectRecord {
     pub(crate) fn spendable(&self) -> SpendableObject {
         SpendableObject {
             obj: self.obj.clone(),
-            evidence: self.evidence.clone(),
         }
     }
 

--- a/driver/src/object_store.rs
+++ b/driver/src/object_store.rs
@@ -220,6 +220,7 @@ mod tests {
                 vec![],
             )
             .unwrap();
+        let tx_final = outputs.tx.dict().commitment();
         let spendable = outputs.obj(0);
         ObjectRecord {
             content_hash: format!("{:#}", spendable.obj.commitment()),
@@ -227,7 +228,7 @@ mod tests {
             status: ObjectStatus::Live,
             tx_hash: None,
             obj: spendable.obj,
-            evidence: spendable.evidence,
+            tx_final,
         }
     }
 

--- a/driver/src/tests.rs
+++ b/driver/src/tests.rs
@@ -54,28 +54,16 @@ fn tx_hash(tx: &txlib::Tx) -> Hash {
     tx.dict().commitment()
 }
 
-fn tx_nullifiers(tx: &txlib::Tx) -> Vec<Hash> {
-    tx.nullifiers
-        .iter()
-        .map(|nullifier| {
-            let nullifier = nullifier.expect("tx nullifier should decode");
-            Hash(nullifier.raw().0)
-        })
-        .collect()
-}
-
 fn apply_tx(state: &mut TestState, tx: &txlib::Tx) {
-    state.apply_tx(tx_hash(tx), tx_nullifiers(tx));
+    state.apply_tx(
+        tx.live_commitments().unwrap(),
+        tx.nullifier_hashes().unwrap(),
+    );
 }
 
 fn state_root(state: &TestState) -> StateRoot {
-    let (transactions_root, nullifiers_root, gsrs_root) = state.roots();
-    StateRoot::new(
-        state.block_number,
-        transactions_root,
-        nullifiers_root,
-        gsrs_root,
-    )
+    let (created_root, nullifiers_root, gsrs_root) = state.roots();
+    StateRoot::new(state.block_number, created_root, nullifiers_root, gsrs_root)
 }
 
 fn craft_basics(name: &str) -> QualifiedName {
@@ -97,7 +85,7 @@ fn make_input_record(file_name: &str) -> (ObjectFileEntry, DriverDeps) {
         status: ObjectStatus::Live,
         tx_hash: None,
         obj: spendable.obj,
-        evidence: spendable.evidence,
+        tx_final: tx_hash(&source_tx),
     };
     let mut state = TestState::default();
     apply_tx(&mut state, &source_tx);
@@ -149,30 +137,30 @@ impl SynchronizerClient for MockSynchronizer {
     fn fetch_grounding_witness(
         &self,
         _sync_api_url: &str,
-        source_tx_hashes: &[Hash],
+        object_commitments: &[Hash],
     ) -> Result<GroundingWitness> {
-        let source_tx_proofs = source_tx_hashes
+        let created_proofs = object_commitments
             .iter()
             .copied()
-            .map(|tx_hash| (tx_hash, self.state.tx_membership_proof(tx_hash)))
+            .map(|commitment| (commitment, self.state.created_membership_proof(commitment)))
             .collect::<HashMap<_, _>>();
         Ok(GroundingWitness::new(
             state_root(&self.state),
-            source_tx_proofs,
+            created_proofs,
         ))
     }
 
     fn fetch_membership_with_nullifiers(
         &self,
         _sync_api_url: &str,
-        _tx_hashes: &[Hash],
+        _object_commitments: &[Hash],
         _nullifiers: &[Hash],
     ) -> Result<SynchronizerMembership> {
         if self.fail_membership {
             return Err(anyhow!("synchronizer unreachable"));
         }
         Ok(SynchronizerMembership {
-            grounded_txs: self.membership_grounded.clone(),
+            created_objects: self.membership_grounded.clone(),
             on_chain_nullifiers: self.membership_nullifiers.clone(),
         })
     }
@@ -180,7 +168,8 @@ impl SynchronizerClient for MockSynchronizer {
     fn wait_for_tx(
         &self,
         _sync_api_url: &str,
-        _tx_final: Hash,
+        _created_commitments: &[Hash],
+        _nullifiers: &[Hash],
         _timeout_secs: u64,
         _poll_interval_ms: u64,
     ) -> Result<SynchronizerHead> {
@@ -404,6 +393,7 @@ fn make_importable_log() -> (String, Hash, Hash) {
         .unwrap();
     let spendable = outputs.obj(0);
     let content_hash = format!("{:#}", spendable.obj.commitment());
+    let commitment = spendable.obj.commitment();
     let nullifier = txlib::object_nullifier_hash(&spendable.obj).unwrap();
     let record = ObjectRecord {
         content_hash,
@@ -411,11 +401,10 @@ fn make_importable_log() -> (String, Hash, Hash) {
         status: ObjectStatus::Live,
         tx_hash: None,
         obj: spendable.obj,
-        evidence: spendable.evidence,
+        tx_final: outputs.tx.dict().commitment(),
     };
-    let source_tx = record.evidence.tx_final;
     let json = serde_json::to_string(&record).unwrap();
-    (json, source_tx, nullifier)
+    (json, commitment, nullifier)
 }
 
 fn import_driver(

--- a/pexe/src/fixtures.rs
+++ b/pexe/src/fixtures.rs
@@ -9,12 +9,10 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use anyhow::{Result, anyhow};
-use pod2::middleware::{
-    EMPTY_HASH, EMPTY_VALUE, Hash, StrKey, Value, containers::Set, hash_values,
-};
-use pod2utils::{dict, rand_raw_value, set};
+use pod2::middleware::{EMPTY_HASH, EMPTY_VALUE, Hash, StrKey, Value, containers::Array};
+use pod2utils::{dict, rand_raw_value};
 use sdk::{SdkModule, SpendableObject};
-use txlib::{GroundingEvidence, GroundingWitness, StateRoot, with_identity};
+use txlib::{GroundingWitness, StateRoot, with_identity};
 
 use crate::inspect::derive_class_signature;
 
@@ -99,63 +97,45 @@ pub struct SyntheticState {
     pub spendable: Vec<SpendableObject>,
 }
 
-/// Build a state in which each `obj` is Live, by fabricating one
-/// "source tx" per object that inserts it into its own (single-element)
-/// live set, gathering those source-tx ctxs into a `transactions` set,
-/// and packaging the resulting Merkle proofs into a `GroundingWitness`.
-///
-/// For each input, a [`GroundingEvidence`] is constructed against its
-/// source tx so the SDK's [`txlib::TxBuilder`] can verify the live-set
-/// membership chain.
+/// Build a state in which each `obj` is Live, by inserting every object
+/// into a single global created set (an array, indexed by position) and
+/// packaging per-object `(index, membership proof)` into a `GroundingWitness`.
 pub fn build_synthetic_state(
     objs: &[pod2::middleware::containers::Dictionary],
 ) -> Result<SyntheticState> {
-    let mut transactions: Set = set!();
-    let mut source_ctxs: Vec<pod2::middleware::containers::Dictionary> =
-        Vec::with_capacity(objs.len());
-
+    let mut created: Array = Array::new(Vec::new());
+    let mut indices: HashMap<Hash, i64> = HashMap::with_capacity(objs.len());
     for obj in objs {
-        let live: Set = set!(obj.clone());
-        let nullifiers: Set = set!();
-        // Source-tx ctx only needs to carry "live" for the SDK's
-        // grounding checks; the chain_start/chain_end fields are
-        // included for shape consistency with real txs but their
-        // contents aren't checked at grounding time.
-        let chain_seed = hash_values(&[Value::from(live.commitment()), Value::from(EMPTY_VALUE)]);
-        let ctx = dict!({
-            "live" => Value::from(live.clone()),
-            "nullifiers" => Value::from(nullifiers.clone()),
-            "chain_start" => Value::from(chain_seed),
-            "chain_end" => Value::from(chain_seed),
-        });
-        transactions
-            .insert(&Value::from(ctx.clone()))
-            .map_err(|err| anyhow!("recording synthetic source tx: {err}"))?;
-        source_ctxs.push(ctx);
+        let commitment = obj.commitment();
+        if indices.contains_key(&commitment) {
+            continue;
+        }
+        // 1-indexed: slot 0 stays empty so nothing grounds at index 0.
+        let index = indices.len() as i64 + 1;
+        created
+            .insert(index as usize, Value::from(obj.clone()))
+            .map_err(|err| anyhow!("recording synthetic created object: {err}"))?;
+        indices.insert(commitment, index);
     }
 
-    let state_root = StateRoot::new(1, transactions.commitment(), EMPTY_HASH, EMPTY_HASH);
+    let state_root = StateRoot::new(1, created.commitment(), EMPTY_HASH, EMPTY_HASH);
 
-    let mut source_tx_proofs: HashMap<Hash, _> = HashMap::with_capacity(source_ctxs.len());
-    for ctx in &source_ctxs {
-        let commitment = ctx.commitment();
-        let proof = transactions
-            .prove(&Value::from(commitment))
-            .map_err(|err| anyhow!("proving synthetic source-tx membership: {err}"))?;
-        source_tx_proofs.insert(commitment, proof);
+    let mut created_proofs: HashMap<Hash, _> = HashMap::with_capacity(objs.len());
+    for obj in objs {
+        let commitment = obj.commitment();
+        let index = indices[&commitment];
+        let (_value, proof) = created
+            .prove(index as usize)
+            .map_err(|err| anyhow!("proving synthetic created-set membership: {err}"))?;
+        created_proofs.insert(commitment, (index, proof));
     }
 
-    let grounding_witness = Arc::new(GroundingWitness::new(state_root, source_tx_proofs));
+    let grounding_witness = Arc::new(GroundingWitness::new(state_root, created_proofs));
 
-    let mut spendable: Vec<SpendableObject> = Vec::with_capacity(objs.len());
-    for (obj, ctx) in objs.iter().zip(source_ctxs.iter()) {
-        let evidence = GroundingEvidence::new(ctx, obj)
-            .map_err(|err| anyhow!("building grounding evidence: {err}"))?;
-        spendable.push(SpendableObject {
-            obj: obj.clone(),
-            evidence,
-        });
-    }
+    let spendable: Vec<SpendableObject> = objs
+        .iter()
+        .map(|obj| SpendableObject { obj: obj.clone() })
+        .collect();
 
     Ok(SyntheticState {
         grounding_witness,

--- a/plugins/craft-basics/manifest.toml
+++ b/plugins/craft-basics/manifest.toml
@@ -2,7 +2,7 @@
 name = "craft-basics"
 version = "0.1.0"
 # Rewritten by `cargo run -p pexe -- build plugins/craft-basics`.
-module_hash = "cdb831c5a4f0087a6d3a93dee3583f94cda4a7fea90a163f90014356bfab9358"
+module_hash = "6b9c665f8f6cc0741ba86b710e371068dd335b6e38dcef177facb5df76d6bbb2"
 
 [[classes]]
 name = "Log"

--- a/plugins/episode-1/manifest.toml
+++ b/plugins/episode-1/manifest.toml
@@ -2,7 +2,7 @@
 name = "episode-1"
 version = "0.1.0"
 # Rewritten by `cargo run -p pexe -- build plugins/episode-1`.
-module_hash = "90752a5fac6f39de79c273544169513be681f78b224fa565def49ec927a3b895"
+module_hash = "9a2021bfb68f8a83190fa78fdf3495293bc4b96caa8fc13823a6f5d98fe581d9"
 
 # ── raw resources ────────────────────────────────────────────────────────────
 

--- a/relayer/src/api.rs
+++ b/relayer/src/api.rs
@@ -298,6 +298,7 @@ mod tests {
                     tx_final: EMPTY_HASH,
                     state_root_hash: EMPTY_HASH,
                     nullifiers: vec![],
+                    live: vec![],
                 })),
                 ParseMode::None => Ok(None),
                 ParseMode::Err => Err(anyhow::anyhow!("invalid proof")),

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -20,7 +20,7 @@ use pod2::{
 };
 use pod2utils::{dict, macros::BuildContext, rand_raw_value};
 use rhai::{AST, CallFnOptions, Dynamic, Engine, EvalAltResult, EvalContext, Expression, Scope};
-use txlib::{EventHandle, GroundingEvidence, GroundingWitness, Tx, TxBuilder, with_identity};
+use txlib::{EventHandle, GroundingWitness, Tx, TxBuilder, with_identity};
 use vdfpod::{STANDARD_VDF_VD_HASH, VdfPod};
 
 mod error;
@@ -2098,21 +2098,15 @@ impl SdkModule {
 #[derive(Debug, Clone)]
 pub struct SpendableObject {
     pub obj: Dictionary,
-    pub evidence: GroundingEvidence,
-}
-
-impl SpendableObject {
-    pub fn tx_input(&self) -> (Dictionary, GroundingEvidence) {
-        (self.obj.clone(), self.evidence.clone())
-    }
 }
 
 pub struct SpendableObjects {
     /// Single tx-level pod that proves `TxFinalized` and is published
     /// via the relayer.
     pub tx_pod: MainPod,
-    /// Each produced output object with its own per-object grounding
-    /// evidence (no per-object pod).
+    /// Each produced output object. Grounding when an object is later
+    /// spent is proven against the synchronizer's live set, so outputs
+    /// carry no per-object proof.
     pub objs: Vec<SpendableObject>,
     /// In-flight `Tx` value held by the producer; carries the literal
     /// live/nullifiers/ctx for the SDK's own bookkeeping. Not part of
@@ -2210,11 +2204,7 @@ impl Executor {
     fn new_builder(&self) -> MultiPodBuilder {
         MultiPodBuilder::new(&self.params, &self.vd_set)
     }
-    fn new_tx_builder(
-        &self,
-        ctx: &mut BuildContext,
-        inputs: &[(Dictionary, GroundingEvidence)],
-    ) -> TxBuilder {
+    fn new_tx_builder(&self, ctx: &mut BuildContext, inputs: &[Dictionary]) -> TxBuilder {
         TxBuilder::new(ctx, inputs, self.grounding_witness.clone())
     }
     /// Execute an action that consumes some input objects and produces some output objects
@@ -2232,11 +2222,11 @@ impl Executor {
 
         let total = &self.module.action_by_name(action).total_inputs;
 
-        let mut tx_inputs = Vec::with_capacity(inputs.len());
+        let mut tx_inputs: Vec<Dictionary> = Vec::with_capacity(inputs.len());
         let mut rhai_input_objs: Vec<Dictionary> = Vec::with_capacity(inputs.len());
         for (input, _ref) in zip_eq(inputs, total.iter()) {
-            let SpendableObject { obj, evidence } = input;
-            tx_inputs.push((obj.clone(), evidence));
+            let SpendableObject { obj } = input;
+            tx_inputs.push(obj.clone());
             rhai_input_objs.push(obj);
         }
         // Reverse so rhai pops in declaration order (last-declared on top).
@@ -2275,38 +2265,14 @@ impl Executor {
         // The action body's `st_action` and any sub-action `st_sub`
         // statements are not revealed: they would force a wrapping pod
         // to mask them from the relayer / synchronizer's `ProofParser`,
-        // which expects a single public statement. Per-output IsX pods
-        // (which used to consume `st_action` via `prove_is_x_pod`) were
-        // removed when outputs switched to `GroundingEvidence`.
+        // which expects a single public statement.
         log::info!("proving tx_pod for action {}", action);
         let tx_pod = prove(bld.builder, &*self.prover);
         tx_pod.pod.verify().unwrap();
 
-        // tx_final, live_root, and the "live" Merkle path are invariant
-        // across outputs; compute once and share.
-        let tx_final = tx.ctx.commitment();
-        let live_root = tx.live.commitment();
-        let (_, live_in_tx_proof) = tx
-            .ctx
-            .prove(&StrKey::from("live"))
-            .expect("finalized tx has a live key");
         let objs: Vec<SpendableObject> = outputs
             .into_iter()
-            .map(|obj| {
-                let obj_in_live_proof = tx
-                    .live
-                    .prove(&Value::from(obj.clone()))
-                    .expect("output is live in finalized tx");
-                SpendableObject {
-                    obj,
-                    evidence: GroundingEvidence {
-                        tx_final,
-                        live_root,
-                        live_in_tx_proof: live_in_tx_proof.clone(),
-                        obj_in_live_proof,
-                    },
-                }
-            })
+            .map(|obj| SpendableObject { obj })
             .collect();
 
         Ok(SpendableObjects { tx_pod, objs, tx })
@@ -2330,11 +2296,11 @@ impl Executor {
 
         let total = &self.module.action_by_name(action).total_inputs;
 
-        let mut tx_inputs = Vec::with_capacity(inputs.len());
+        let mut tx_inputs: Vec<Dictionary> = Vec::with_capacity(inputs.len());
         let mut rhai_input_objs: Vec<Dictionary> = Vec::with_capacity(inputs.len());
         for (input, _ref) in zip_eq(inputs, total.iter()) {
-            let SpendableObject { obj, evidence } = input;
-            tx_inputs.push((obj.clone(), evidence));
+            let SpendableObject { obj } = input;
+            tx_inputs.push(obj.clone());
             rhai_input_objs.push(obj);
         }
         rhai_input_objs.reverse();

--- a/sdk/src/tests.rs
+++ b/sdk/src/tests.rs
@@ -3,32 +3,20 @@ use super::*;
 use common::test_state::TestState;
 use txlib::StateRoot;
 
-fn tx_hash(tx: &Tx) -> Hash {
-    tx.dict().commitment()
-}
-
-fn tx_nullifiers(tx: &Tx) -> Vec<Hash> {
-    tx.nullifiers
-        .iter()
-        .map(|nullifier| {
-            let nullifier = nullifier.expect("tx nullifier should decode");
-            Hash(nullifier.raw().0)
-        })
-        .collect()
-}
-
 fn apply_tx(state: &mut TestState, tx: &Tx) {
-    state.apply_tx(tx_hash(tx), tx_nullifiers(tx));
+    state.apply_tx(
+        tx.live_commitments().unwrap(),
+        tx.nullifier_hashes().unwrap(),
+    );
 }
 
-fn grounding_witness(state: &TestState, inputs: &[Tx]) -> Arc<GroundingWitness> {
+fn grounding_witness(state: &TestState, input_commitments: &[Hash]) -> Arc<GroundingWitness> {
     state.build_grounding_witness(
-        inputs,
-        tx_hash,
-        |block_number, transactions_root, nullifiers_root, gsrs_root, source_tx_proofs| {
+        input_commitments,
+        |block_number, created_root, nullifiers_root, gsrs_root, created_proofs| {
             Arc::new(GroundingWitness::new(
-                StateRoot::new(block_number, transactions_root, nullifiers_root, gsrs_root),
-                source_tx_proofs,
+                StateRoot::new(block_number, created_root, nullifiers_root, gsrs_root),
+                created_proofs,
             ))
         },
     )
@@ -186,14 +174,14 @@ fn test_sdk_1() {
     apply_tx(&mut state, &log_a_tx);
 
     println!("exe CraftWood");
-    let executor = module.executor(true, grounding_witness(&state, &[log_a_tx]));
+    let executor = module.executor(true, grounding_witness(&state, &[log_a.obj.commitment()]));
     let res = executor.action("CraftWood", vec![log_a]).unwrap();
     let wood_a_tx = res.tx.clone();
     let [wood_a] = res.objs();
     apply_tx(&mut state, &wood_a_tx);
 
     println!("exe CraftSticks");
-    let executor = module.executor(true, grounding_witness(&state, &[wood_a_tx]));
+    let executor = module.executor(true, grounding_witness(&state, &[wood_a.obj.commitment()]));
     let res = executor.action("CraftSticks", vec![wood_a]).unwrap();
     let sticks_tx = res.tx.clone();
     let [stick_a, _stick_b] = res.objs();
@@ -207,14 +195,17 @@ fn test_sdk_1() {
     apply_tx(&mut state, &log_b_tx);
 
     println!("exe CraftWood");
-    let executor = module.executor(true, grounding_witness(&state, &[log_b_tx]));
+    let executor = module.executor(true, grounding_witness(&state, &[log_b.obj.commitment()]));
     let res = executor.action("CraftWood", vec![log_b]).unwrap();
     let wood_b_tx = res.tx.clone();
     let [wood_b] = res.objs();
     apply_tx(&mut state, &wood_b_tx);
 
     println!("exe CraftWoodPick");
-    let executor = module.executor(true, grounding_witness(&state, &[wood_b_tx, sticks_tx]));
+    let executor = module.executor(
+        true,
+        grounding_witness(&state, &[wood_b.obj.commitment(), stick_a.obj.commitment()]),
+    );
     let res = executor
         .action("CraftWoodPick", vec![wood_b, stick_a])
         .unwrap();
@@ -223,14 +214,20 @@ fn test_sdk_1() {
     apply_tx(&mut state, &wood_pick_tx);
 
     println!("exe UseWoodPick");
-    let executor = module.executor(true, grounding_witness(&state, &[wood_pick_tx]));
+    let executor = module.executor(
+        true,
+        grounding_witness(&state, &[wood_pick.obj.commitment()]),
+    );
     let res = executor.action("UseWoodPick", vec![wood_pick]).unwrap();
     let wood_pick_tx = res.tx.clone();
     let [wood_pick] = res.objs();
     apply_tx(&mut state, &wood_pick_tx);
 
     println!("exe MineStoneWithWoodPick");
-    let executor = module.executor(true, grounding_witness(&state, &[wood_pick_tx]));
+    let executor = module.executor(
+        true,
+        grounding_witness(&state, &[wood_pick.obj.commitment()]),
+    );
     let res = executor
         .action("MineStoneWithWoodPick", vec![wood_pick])
         .unwrap();
@@ -246,7 +243,7 @@ fn test_sdk_2() {
         [plugin]
         name = "test"
         version = "0.1.0"
-        module_hash = "8d3754249fb1122eb5baf2127a63856ea7d67e70df9d1258cd67b1dd335d8500"
+        module_hash = "d5588dc1b89c1246900b6f1ed86a41e0a8b7059f7c514dc9ac21e4efef69c762"
 
         [[classes]]
         name = "Log"

--- a/synchronizer/src/api.rs
+++ b/synchronizer/src/api.rs
@@ -2,7 +2,7 @@ use std::{net::SocketAddr, sync::Arc};
 
 use anyhow::Result;
 use axum::{
-    extract::{Path, State},
+    extract::State,
     http::StatusCode,
     routing::{get, post},
     Json, Router,
@@ -13,8 +13,8 @@ use tracing::info;
 use wire_types::synchronizer::{
     GroundingWitnessRequest, GroundingWitnessResponse, HealthResponse, MembershipRequest,
     MembershipResponse, NullifierContainsEntry, NullifierContainsRequest,
-    NullifierContainsResponse, SourceTxProofResponse, StateHeadResponse, SyncProgressResponse,
-    TxContainsEntry, TxContainsRequest, TxContainsResponse, TxStatusResponse,
+    NullifierContainsResponse, ObjectContainsEntry, ObjectContainsRequest, ObjectContainsResponse,
+    ObjectProofResponse, StateHeadResponse, SyncProgressResponse,
 };
 
 use crate::{
@@ -44,8 +44,8 @@ struct HeadSnapshot {
     current_gsr: Option<String>,
     /// Execution block number committed inside the current state root, if any.
     current_block_number: Option<i64>,
-    /// Number of accepted transactions in canonical state.
-    tx_count: usize,
+    /// Number of objects in the canonical global created set.
+    created_count: usize,
     /// Number of spent nullifiers in canonical state.
     nullifier_count: usize,
     /// Number of GSR entries in canonical history.
@@ -55,33 +55,33 @@ struct HeadSnapshot {
 #[derive(Debug, Clone)]
 /// Membership result anchored to one caller-provided root set.
 struct MembershipSnapshot {
-    /// Per-request transaction membership bits under `roots.transactions`.
-    tx_present: Vec<bool>,
+    /// Per-request created-object membership bits under `roots.created`.
+    created_present: Vec<bool>,
     /// Per-request nullifier membership bits under `roots.nullifiers`.
     nullifier_present: Vec<bool>,
 }
 
 #[derive(Debug, Clone)]
-/// Membership proof for a source transaction against the current transactions set root.
-struct TxMembershipProof {
-    /// Source transaction hash the client asked about.
-    tx_hash: Hash,
-    /// Whether the transaction is present in the committed transactions set.
+/// Membership proof for an object against the current created-set root.
+struct ObjectMembershipProof {
+    /// Object commitment the client asked about.
+    commitment: Hash,
+    /// Whether the object is present in the committed created set.
     present: bool,
-    /// Merkle proof against the current transactions set root.
-    proof: MerkleProof,
+    /// `(array index, ArrayContains proof)` when present, else `None`.
+    witness: Option<(i64, MerkleProof)>,
 }
 
 #[derive(Debug, Clone)]
 /// Proof-bearing result used by txlib to ground action execution.
 struct GroundingWitnessSnapshot {
-    /// Per-source transaction membership proofs under the provided roots.
-    source_tx_proofs: Vec<TxMembershipProof>,
+    /// Per-input-object created-set membership proofs under the provided roots.
+    object_proofs: Vec<ObjectMembershipProof>,
 }
 
 struct MembershipContext {
     head: HeadSnapshot,
-    tx_hashes: Vec<Hash>,
+    object_commitments: Vec<Hash>,
     nullifiers: Vec<Hash>,
     membership: MembershipSnapshot,
 }
@@ -97,12 +97,14 @@ pub async fn run_api_server(
         .route("/sync-progress", get(get_sync_progress))
         .route("/v1/state/head", get(get_state_head))
         .route("/v1/state/membership", post(post_state_membership))
-        .route("/v1/state/tx/contains", post(post_state_tx_contains))
+        .route(
+            "/v1/state/object/contains",
+            post(post_state_object_contains),
+        )
         .route(
             "/v1/state/nullifier/contains",
             post(post_state_nullifier_contains),
         )
-        .route("/v1/state/tx/{tx_hash}", get(get_state_tx))
         .route("/v1/txlib/grounding-witness", post(post_grounding_witness))
         .layer(tower_http::cors::CorsLayer::permissive())
         .with_state(AppState { app_db, sync_db });
@@ -142,28 +144,28 @@ async fn get_state_head(
         last_processed_block_number: head.last_processed_block_number,
         current_gsr: head.current_gsr,
         current_block_number: head.current_block_number,
-        tx_count: head.tx_count,
+        created_count: head.created_count,
         nullifier_count: head.nullifier_count,
         gsr_count: head.gsr_count,
     }))
 }
 
-async fn post_state_tx_contains(
+async fn post_state_object_contains(
     State(app_state): State<AppState>,
-    Json(body): Json<TxContainsRequest>,
-) -> Result<Json<TxContainsResponse>, (StatusCode, String)> {
+    Json(body): Json<ObjectContainsRequest>,
+) -> Result<Json<ObjectContainsResponse>, (StatusCode, String)> {
     let no_nullifiers: &[String] = &[];
     let MembershipContext {
         head,
-        tx_hashes,
+        object_commitments,
         membership,
         ..
-    } = load_membership_context(&app_state, &body.tx_hashes, no_nullifiers).await?;
+    } = load_membership_context(&app_state, &body.object_commitments, no_nullifiers).await?;
 
-    Ok(Json(TxContainsResponse {
+    Ok(Json(ObjectContainsResponse {
         last_processed_slot: head.last_processed_slot,
         current_gsr: head.current_gsr,
-        results: tx_contains_entries(tx_hashes, membership.tx_present),
+        results: object_contains_entries(object_commitments, membership.created_present),
     }))
 }
 
@@ -192,38 +194,16 @@ async fn post_state_membership(
 ) -> Result<Json<MembershipResponse>, (StatusCode, String)> {
     let MembershipContext {
         head,
-        tx_hashes,
+        object_commitments,
         nullifiers,
         membership,
-    } = load_membership_context(&app_state, &body.tx_hashes, &body.nullifiers).await?;
+    } = load_membership_context(&app_state, &body.object_commitments, &body.nullifiers).await?;
 
     Ok(Json(MembershipResponse {
         last_processed_slot: head.last_processed_slot,
         current_gsr: head.current_gsr,
-        tx_results: tx_contains_entries(tx_hashes, membership.tx_present),
+        created_results: object_contains_entries(object_commitments, membership.created_present),
         nullifier_results: nullifier_contains_entries(nullifiers, membership.nullifier_present),
-    }))
-}
-
-async fn get_state_tx(
-    State(app_state): State<AppState>,
-    Path(tx_hash): Path<String>,
-) -> Result<Json<TxStatusResponse>, (StatusCode, String)> {
-    let snapshot = load_current_snapshot(&app_state).await?;
-    let hash = parse_hash_hex(&tx_hash)?;
-    let membership = membership_snapshot(
-        &app_state.app_db,
-        &snapshot.head.roots,
-        std::slice::from_ref(&hash),
-        &[],
-    )
-    .map_err(internal_error)?;
-    let head = build_head_snapshot(&snapshot);
-    Ok(Json(TxStatusResponse {
-        tx_hash: encode_hash_hex(&hash),
-        present: membership.tx_present[0],
-        last_processed_slot: head.last_processed_slot,
-        current_gsr: head.current_gsr,
     }))
 }
 
@@ -231,14 +211,14 @@ async fn post_grounding_witness(
     State(app_state): State<AppState>,
     Json(body): Json<GroundingWitnessRequest>,
 ) -> Result<Json<GroundingWitnessResponse>, (StatusCode, String)> {
-    ensure_hash_query_limit("sourceTxHashes", body.source_tx_hashes.len())?;
+    ensure_hash_query_limit("objectCommitments", body.object_commitments.len())?;
     let snapshot = load_current_snapshot(&app_state).await?;
-    let source_tx_hashes = body
-        .source_tx_hashes
+    let object_commitments = body
+        .object_commitments
         .iter()
         .map(|raw| parse_hash_hex(raw))
         .collect::<Result<Vec<_>, _>>()?;
-    let witness = grounding_witness(&app_state.app_db, &snapshot.head.roots, &source_tx_hashes)
+    let witness = grounding_witness(&app_state.app_db, &snapshot.head.roots, &object_commitments)
         .map_err(internal_error)?;
     let head = snapshot.head;
     let state_root = head.current_state_root().ok_or_else(|| {
@@ -255,16 +235,23 @@ async fn post_grounding_witness(
     Ok(Json(GroundingWitnessResponse {
         state_root_hash: encode_hash_hex(&state_root_hash),
         block_number: state_root.block_number,
-        transactions_root: encode_hash_hex(&state_root.transactions_root),
+        created_root: encode_hash_hex(&state_root.created_root),
         nullifiers_root: encode_hash_hex(&state_root.nullifiers_root),
         gsrs_root: encode_hash_hex(&state_root.gsrs_root),
-        source_tx_proofs: witness
-            .source_tx_proofs
+        created_proofs: witness
+            .object_proofs
             .into_iter()
-            .map(|entry| SourceTxProofResponse {
-                tx_hash: encode_hash_hex(&entry.tx_hash),
-                present: entry.present,
-                proof: entry.proof,
+            .map(|entry| {
+                let (index, proof) = match entry.witness {
+                    Some((index, proof)) => (Some(index), Some(proof)),
+                    None => (None, None),
+                };
+                ObjectProofResponse {
+                    commitment: encode_hash_hex(&entry.commitment),
+                    present: entry.present,
+                    index,
+                    proof,
+                }
             })
             .collect(),
     }))
@@ -281,7 +268,7 @@ fn build_head_snapshot(snapshot: &CurrentSnapshot) -> HeadSnapshot {
             .as_ref()
             .map(encode_hash_hex),
         current_block_number: snapshot.head.metadata.current_block_number.map(i64::from),
-        tx_count: snapshot.head.metadata.tx_count as usize,
+        created_count: snapshot.head.metadata.created_count as usize,
         nullifier_count: snapshot.head.metadata.nullifier_count as usize,
         gsr_count: snapshot.head.metadata.gsr_count as usize,
     }
@@ -290,11 +277,11 @@ fn build_head_snapshot(snapshot: &CurrentSnapshot) -> HeadSnapshot {
 fn membership_snapshot(
     app_db: &AppDb,
     roots: &CanonicalRoots,
-    tx_hashes: &[Hash],
+    object_commitments: &[Hash],
     nullifiers: &[Hash],
 ) -> anyhow::Result<MembershipSnapshot> {
     Ok(MembershipSnapshot {
-        tx_present: app_db.tx_exists_batch(roots, tx_hashes)?,
+        created_present: app_db.created_exists_batch(roots, object_commitments)?,
         nullifier_present: app_db.nullifier_exists_batch(roots, nullifiers)?,
     })
 }
@@ -302,42 +289,42 @@ fn membership_snapshot(
 fn grounding_witness(
     app_db: &AppDb,
     roots: &CanonicalRoots,
-    source_tx_hashes: &[Hash],
+    object_commitments: &[Hash],
 ) -> anyhow::Result<GroundingWitnessSnapshot> {
-    let source_tx_proofs = source_tx_hashes
+    let object_proofs = object_commitments
         .iter()
-        .map(|tx_hash| {
-            let (present, proof) = app_db.prove_tx(roots, *tx_hash)?;
-            Ok(TxMembershipProof {
-                tx_hash: *tx_hash,
+        .map(|commitment| {
+            let (present, witness) = app_db.prove_created(roots, *commitment)?;
+            Ok(ObjectMembershipProof {
+                commitment: *commitment,
                 present,
-                proof,
+                witness,
             })
         })
         .collect::<anyhow::Result<Vec<_>>>()?;
-    Ok(GroundingWitnessSnapshot { source_tx_proofs })
+    Ok(GroundingWitnessSnapshot { object_proofs })
 }
 
 async fn load_membership_context(
     app_state: &AppState,
-    tx_hashes: &[String],
+    object_commitments: &[String],
     nullifiers: &[String],
 ) -> Result<MembershipContext, (StatusCode, String)> {
-    ensure_membership_query_limit(tx_hashes.len(), nullifiers.len())?;
+    ensure_membership_query_limit(object_commitments.len(), nullifiers.len())?;
     let snapshot = load_current_snapshot(app_state).await?;
-    let tx_hashes = parse_hashes(tx_hashes)?;
+    let object_commitments = parse_hashes(object_commitments)?;
     let nullifiers = parse_hashes(nullifiers)?;
     let membership = membership_snapshot(
         &app_state.app_db,
         &snapshot.head.roots,
-        &tx_hashes,
+        &object_commitments,
         &nullifiers,
     )
     .map_err(internal_error)?;
 
     Ok(MembershipContext {
         head: build_head_snapshot(&snapshot),
-        tx_hashes,
+        object_commitments,
         nullifiers,
         membership,
     })
@@ -393,12 +380,15 @@ fn ensure_membership_query_limit(
     Ok(())
 }
 
-fn tx_contains_entries(tx_hashes: Vec<Hash>, tx_present: Vec<bool>) -> Vec<TxContainsEntry> {
-    tx_hashes
+fn object_contains_entries(
+    object_commitments: Vec<Hash>,
+    created_present: Vec<bool>,
+) -> Vec<ObjectContainsEntry> {
+    object_commitments
         .into_iter()
-        .zip(tx_present)
-        .map(|(hash, present)| TxContainsEntry {
-            tx_hash: encode_hash_hex(&hash),
+        .zip(created_present)
+        .map(|(hash, present)| ObjectContainsEntry {
+            commitment: encode_hash_hex(&hash),
             present,
         })
         .collect()

--- a/synchronizer/src/app_db.rs
+++ b/synchronizer/src/app_db.rs
@@ -27,6 +27,13 @@ fn value_key(raw: RawValue) -> Vec<u8> {
     k
 }
 
+fn created_index_key(commitment: Hash) -> Vec<u8> {
+    let mut k = Vec::with_capacity(35);
+    k.extend_from_slice(b"ci/");
+    k.extend_from_slice(&hash_to_db_bytes(commitment));
+    k
+}
+
 #[derive(Clone)]
 pub struct AppDb {
     db: Arc<TransactionDB>,
@@ -51,8 +58,8 @@ impl AppDb {
         })
     }
 
-    pub fn open_transactions(&self, root: Hash) -> Result<Set> {
-        Ok(Set::from_db(root, self.db_box())?)
+    pub fn open_created(&self, root: Hash) -> Result<Array> {
+        Ok(Array::from_db(root, self.db_box())?)
     }
 
     pub fn open_nullifiers(&self, root: Hash) -> Result<Set> {
@@ -63,22 +70,64 @@ impl AppDb {
         Ok(Array::from_db(root, self.db_box())?)
     }
 
-    pub fn prove_tx(&self, roots: &CanonicalRoots, tx_hash: Hash) -> Result<(bool, MerkleProof)> {
-        let txs = self.open_transactions(roots.transactions)?;
-        let value = Value::from(tx_hash);
-        match txs.prove(&value) {
-            Ok(proof) => Ok((true, proof)),
-            Err(_) => Ok((false, txs.prove_nonexistence(&value)?)),
+    /// Record an object commitment's position in the created `Array`.
+    ///
+    /// The cache is a plain `commitment -> index` map: not Merkleized, not part
+    /// of any committed root. It is only ever read as a hint -- every membership
+    /// or proof query cross-checks the index against the `Array` at the queried
+    /// root, so a stale entry (e.g. one left behind by an abandoned reorg branch)
+    /// resolves to "absent" rather than a wrong answer.
+    pub fn created_index_put(&self, commitment: Hash, index: i64) -> Result<()> {
+        self.db
+            .put(created_index_key(commitment), index.to_le_bytes())
+            .map_err(|err| anyhow!("rocksdb created-index put failed: {err}"))
+    }
+
+    pub fn created_index_get(&self, commitment: Hash) -> Result<Option<i64>> {
+        match self.db.get(created_index_key(commitment))? {
+            None => Ok(None),
+            Some(bytes) => {
+                let limbs: [u8; 8] = bytes
+                    .as_slice()
+                    .try_into()
+                    .map_err(|_| anyhow!("invalid created-index entry length"))?;
+                Ok(Some(i64::from_le_bytes(limbs)))
+            }
         }
     }
 
-    pub fn tx_exists_batch(&self, roots: &CanonicalRoots, tx_hashes: &[Hash]) -> Result<Vec<bool>> {
-        let txs = self.open_transactions(roots.transactions)?;
-        tx_hashes
+    /// `(index, membership proof)` for one object commitment against the created
+    /// `Array` at `roots.created`, or `(false, None)` when it is not present
+    /// there. The cache supplies the candidate index; proving it against the
+    /// array is what authenticates membership (and rejects stale cache hits).
+    pub fn prove_created(
+        &self,
+        roots: &CanonicalRoots,
+        obj_commitment: Hash,
+    ) -> Result<(bool, Option<(i64, MerkleProof)>)> {
+        let Some(index) = self.created_index_get(obj_commitment)? else {
+            return Ok((false, None));
+        };
+        let created = self.open_created(roots.created)?;
+        match created.prove(index as usize) {
+            Ok((value, proof)) if value == Value::from(obj_commitment) => {
+                Ok((true, Some((index, proof))))
+            }
+            _ => Ok((false, None)),
+        }
+    }
+
+    pub fn created_exists_batch(
+        &self,
+        roots: &CanonicalRoots,
+        obj_commitments: &[Hash],
+    ) -> Result<Vec<bool>> {
+        let created = self.open_created(roots.created)?;
+        obj_commitments
             .iter()
-            .map(|hash| {
-                txs.contains(&Value::from(*hash))
-                    .map_err(|err| anyhow!("{err}"))
+            .map(|commitment| match self.created_index_get(*commitment)? {
+                None => Ok(false),
+                Some(index) => Ok(created.get(index as usize)? == Some(Value::from(*commitment))),
             })
             .collect()
     }
@@ -207,22 +256,42 @@ mod tests {
     }
 
     #[test]
-    fn test_persistent_tx_membership() {
+    fn test_persistent_created_membership() {
         let (app_db, _dir) = open_test_db();
-        let mut txs = app_db.open_transactions(EMPTY_HASH).unwrap();
-        let tx_hash = test_hash(9);
-        txs.insert(&Value::from(tx_hash)).unwrap();
+        let mut created = app_db.open_created(EMPTY_HASH).unwrap();
+        let obj_commitment = test_hash(9);
+        // The created set is 1-indexed (slot 0 is reserved empty).
+        created.insert(1, Value::from(obj_commitment)).unwrap();
+        app_db.created_index_put(obj_commitment, 1).unwrap();
 
         let roots = CanonicalRoots {
-            transactions: txs.commitment(),
+            created: created.commitment(),
             ..CanonicalRoots::empty()
         };
 
         assert_eq!(
-            app_db.tx_exists_batch(&roots, &[tx_hash]).unwrap(),
+            app_db
+                .created_exists_batch(&roots, &[obj_commitment])
+                .unwrap(),
             vec![true]
         );
-        let (present, _proof) = app_db.prove_tx(&roots, tx_hash).unwrap();
+        let (present, witness) = app_db.prove_created(&roots, obj_commitment).unwrap();
         assert!(present);
+        assert_eq!(witness.map(|(index, _proof)| index), Some(1));
+
+        // A commitment never recorded in the cache is absent, and a cache hit
+        // that the array root does not actually contain resolves to absent too.
+        let absent = test_hash(7);
+        assert_eq!(
+            app_db.created_exists_batch(&roots, &[absent]).unwrap(),
+            vec![false]
+        );
+        let empty_roots = CanonicalRoots::empty();
+        assert_eq!(
+            app_db
+                .created_exists_batch(&empty_roots, &[obj_commitment])
+                .unwrap(),
+            vec![false]
+        );
     }
 }

--- a/synchronizer/src/head.rs
+++ b/synchronizer/src/head.rs
@@ -4,8 +4,8 @@ use txlib::StateRoot;
 /// The Merkle roots that reopen the canonical persistent containers.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct CanonicalRoots {
-    /// Root of the persistent transactions set.
-    pub transactions: Hash,
+    /// Root of the persistent global created-object set (a pod2 `Array`).
+    pub created: Hash,
     /// Root of the persistent spent-nullifiers set.
     pub nullifiers: Hash,
     /// Root of the prior-GSR array committed inside `txlib::StateRoot`.
@@ -23,7 +23,7 @@ impl Default for CanonicalRoots {
 impl CanonicalRoots {
     pub fn empty() -> Self {
         Self {
-            transactions: EMPTY_HASH,
+            created: EMPTY_HASH,
             nullifiers: EMPTY_HASH,
             state_root_gsrs: EMPTY_HASH,
             gsr_history: EMPTY_HASH,
@@ -38,8 +38,10 @@ pub struct HeadMetadata {
     pub current_gsr: Option<Hash>,
     /// Execution block number associated with `current_gsr`.
     pub current_block_number: Option<u32>,
-    /// Number of accepted transactions in the canonical state.
-    pub tx_count: u64,
+    /// Number of objects in the canonical global created set. The array is
+    /// 1-indexed (slot 0 stays empty), so the next array slot is
+    /// `created_count + 1`.
+    pub created_count: u64,
     /// Number of spent nullifiers in the canonical state.
     pub nullifier_count: u64,
     /// Number of GSR entries in the persistent history array.
@@ -57,7 +59,7 @@ impl HeadMetadata {
         Self {
             current_gsr: None,
             current_block_number: None,
-            tx_count: 0,
+            created_count: 0,
             nullifier_count: 0,
             gsr_count: 0,
         }
@@ -94,7 +96,7 @@ impl CanonicalHead {
         self.metadata.current_block_number.map(|block_number| {
             StateRoot::new(
                 block_number as i64,
-                self.roots.transactions,
+                self.roots.created,
                 self.roots.nullifiers,
                 self.roots.state_root_gsrs,
             )

--- a/synchronizer/src/state_machine.rs
+++ b/synchronizer/src/state_machine.rs
@@ -21,12 +21,13 @@ pub const MAX_GSR_AGE_BLOCKS: i64 = 300;
 /// Ephemeral mutable view used while deriving one slot.
 ///
 /// This view opens the persistent POD2 containers used during slot derivation so validation can
-/// query and mutate transactions, nullifiers, and GSR history for one slot.
+/// query and mutate the created-object set, nullifiers, and GSR history for one slot.
 struct WorkingState {
     /// Mutable non-root metadata accumulated while deriving the slot.
     metadata: HeadMetadata,
-    /// Persistent transactions set opened from `head.roots.transactions`.
-    transactions: Set,
+    /// Persistent global created-object set (a pod2 `Array`) opened from
+    /// `head.roots.created`.
+    created: Array,
     /// Persistent nullifiers set opened from `head.roots.nullifiers`.
     nullifiers: Set,
     /// Persistent full GSR history array opened from `head.roots.gsr_history`.
@@ -66,12 +67,16 @@ impl StateMachine {
     /// 1. Parse and verify the blob as a `TxFinalized` payload via `proof_parser`
     /// 2. Check that `payload.state_root_hash` exists in the recent canonical GSR cache
     /// 3. Enforce the maximum grounding age window (`MAX_GSR_AGE_BLOCKS`)
-    /// 4. Reject duplicate `tx_final` values already present in the in-progress transactions set
+    /// 4. Reject duplicate created-object commitments both within the payload and against the
+    ///    in-progress created set: a tx that creates an object that already exists fails the same
+    ///    way a nullifier double-spend does. This is also what gives no-input (mining) txs their
+    ///    replay protection.
     /// 5. Reject duplicate nullifiers both within the payload and against the in-progress
     ///    nullifiers set, which starts from canonical state and includes earlier accepted blobs
     ///
     /// If all checks pass, the method mutates the slot-local `WorkingState` by:
-    /// - inserting `tx_final` into the persistent in-progress transactions set handle
+    /// - appending each created-object commitment to the persistent in-progress created array
+    ///   and recording its index in the reverse-index cache
     /// - inserting each nullifier into the persistent in-progress nullifiers set handle
     /// - incrementing the corresponding counts in `state.metadata`
     ///
@@ -123,10 +128,24 @@ impl StateMachine {
             return Ok(());
         }
 
-        let tx_value = Value::from(payload.tx_final);
-        if state.transactions.contains(&tx_value)? {
-            warn!(slot, block_number, "Duplicate tx_final; rejecting");
-            return Ok(());
+        // Pre-check created objects and nullifiers before mutating anything, so a
+        // single collision rejects the whole blob with no partial application.
+        let mut payload_created = HashSet::with_capacity(payload.live.len());
+        for obj in &payload.live {
+            if !payload_created.insert(*obj) {
+                warn!(
+                    slot,
+                    block_number, "Duplicate created object within payload; rejecting"
+                );
+                return Ok(());
+            }
+            if self.is_created(state, *obj)? {
+                warn!(
+                    slot,
+                    block_number, "Created object already exists (creation collision); rejecting"
+                );
+                return Ok(());
+            }
         }
 
         let mut payload_nullifiers = HashSet::with_capacity(payload.nullifiers.len());
@@ -144,8 +163,18 @@ impl StateMachine {
             }
         }
 
-        state.transactions.insert(&tx_value)?;
-        state.metadata.tx_count += 1;
+        for obj in &payload.live {
+            // The array is 1-indexed: slot 0 is left empty so no real object is
+            // ever grounded at `ArrayContains(created, 0, ..)`. Index 0's
+            // RawValue is [0,0,0,0], the all-zeros shape that collides with
+            // `None` / `IndexKey(0)` in pod2's StatementArg encoding -- the same
+            // hazard StateRoot's `_pad` slot avoids. `created_count` stays the
+            // true object count; the array slot is `created_count + 1`.
+            let index = state.metadata.created_count as usize + 1;
+            state.created.insert(index, Value::from(*obj))?;
+            self.app_db.created_index_put(*obj, index as i64)?;
+            state.metadata.created_count += 1;
+        }
         for nullifier in &payload.nullifiers {
             state.nullifiers.insert(&Value::from(*nullifier))?;
             state.metadata.nullifier_count += 1;
@@ -154,23 +183,34 @@ impl StateMachine {
         info!(
             slot,
             block_number,
-            transaction_count = state.metadata.tx_count,
+            created_count = state.metadata.created_count,
             nullifier_count = state.metadata.nullifier_count,
             "Validated blob state update in slot derivation"
         );
         Ok(())
     }
 
+    /// Whether `commitment` is already in the in-progress created set. The cache
+    /// gives a candidate index; the in-progress array is the authority, so a
+    /// stale cache hit (pointing at an index this array does not hold, or holds
+    /// a different commitment at) correctly reads as "not created".
+    fn is_created(&self, state: &WorkingState, commitment: Hash) -> Result<bool> {
+        match self.app_db.created_index_get(commitment)? {
+            None => Ok(false),
+            Some(index) => Ok(state.created.get(index as usize)? == Some(Value::from(commitment))),
+        }
+    }
+
     /// Derive the next canonical head for one execution slot from a caller-provided base head.
     ///
     /// This method is the slot-level orchestration layer around `process_blob`.
     /// It:
-    /// - reopens the persistent transactions, nullifiers, and GSR-history containers from
+    /// - reopens the persistent created-object, nullifiers, and GSR-history containers from
     ///   `base_head.roots`
     /// - seeds the per-slot `WorkingState` with the caller-provided recent-GSR window
     /// - feeds every decoded blob payload through `process_blob`, accumulating accepted updates
     ///   in the in-progress container handles
-    /// - computes the next GSR from the updated transactions/nullifiers roots and the prior
+    /// - computes the next GSR from the updated created/nullifiers roots and the prior
     ///   GSR-history root committed into the resulting `StateRoot`
     /// - appends that new GSR to the full history array and returns the resulting `CanonicalHead`
     ///
@@ -178,7 +218,7 @@ impl StateMachine {
     /// returns, RocksDB may already contain Merkle nodes for the derived containers, but the
     /// head does not become canonical until the caller persists it in Postgres.
     ///
-    /// Empty or fully rejected slots still produce a new head with the same transactions and
+    /// Empty or fully rejected slots still produce a new head with the same created and
     /// nullifiers roots as `base_head`, but with a newly derived `current_gsr` and an appended
     /// GSR-history entry for the slot's execution block.
     pub fn derive_slot_head(
@@ -191,9 +231,7 @@ impl StateMachine {
     ) -> Result<CanonicalHead> {
         let mut working = WorkingState {
             metadata: base_head.metadata,
-            transactions: self
-                .app_db
-                .open_transactions(base_head.roots.transactions)?,
+            created: self.app_db.open_created(base_head.roots.created)?,
             nullifiers: self.app_db.open_nullifiers(base_head.roots.nullifiers)?,
             gsr_history: self.app_db.open_gsr_history(base_head.roots.gsr_history)?,
             recent_gsrs: recent_gsrs.into_iter().collect(),
@@ -212,7 +250,7 @@ impl StateMachine {
         let prior_gsrs_root = base_head.roots.gsr_history;
         let new_gsr = StateRoot::new(
             i64::from(block_number),
-            working.transactions.commitment(),
+            working.created.commitment(),
             working.nullifiers.commitment(),
             prior_gsrs_root,
         )
@@ -224,7 +262,7 @@ impl StateMachine {
 
         let new_head = CanonicalHead {
             roots: CanonicalRoots {
-                transactions: working.transactions.commitment(),
+                created: working.created.commitment(),
                 nullifiers: working.nullifiers.commitment(),
                 state_root_gsrs: prior_gsrs_root,
                 gsr_history: working.gsr_history.commitment(),
@@ -232,7 +270,7 @@ impl StateMachine {
             metadata: HeadMetadata {
                 current_gsr: Some(new_gsr),
                 current_block_number: Some(block_number),
-                tx_count: working.metadata.tx_count,
+                created_count: working.metadata.created_count,
                 nullifier_count: working.metadata.nullifier_count,
                 gsr_count: base_head.metadata.gsr_count + 1,
             },
@@ -256,7 +294,7 @@ impl StateMachine {
             .map(encode_hash_hex)
             .unwrap_or_else(|| "none".to_string());
         info!(
-            transaction_count = head.metadata.tx_count,
+            created_count = head.metadata.created_count,
             nullifier_count = head.metadata.nullifier_count,
             gsr_count = head.metadata.gsr_count,
             current_gsr = %current_gsr,
@@ -284,15 +322,25 @@ mod tests {
         hash_values(&[Value::from(n)])
     }
 
-    fn mock_txn_bytes(tx_final: Hash, nullifiers: &[Hash], state_root: Hash) -> Vec<u8> {
-        let nullifiers_json = nullifiers
-            .iter()
-            .map(|h| format!("\"{:#}\"", h))
-            .collect::<Vec<_>>()
-            .join(",");
+    fn mock_txn_bytes(
+        tx_final: Hash,
+        nullifiers: &[Hash],
+        live: &[Hash],
+        state_root: Hash,
+    ) -> Vec<u8> {
+        let hashes_json = |hashes: &[Hash]| {
+            hashes
+                .iter()
+                .map(|h| format!("\"{:#}\"", h))
+                .collect::<Vec<_>>()
+                .join(",")
+        };
         format!(
-            r#"{{"tx_final":"{:#}","nullifiers":[{}],"state_root_hash":"{:#}"}}"#,
-            tx_final, nullifiers_json, state_root
+            r#"{{"tx_final":"{:#}","nullifiers":[{}],"live":[{}],"state_root_hash":"{:#}"}}"#,
+            tx_final,
+            hashes_json(nullifiers),
+            hashes_json(live),
+            state_root
         )
         .into_bytes()
     }
@@ -320,19 +368,22 @@ mod tests {
 
         let tx_final = unique_hash(10);
         let nullifier = unique_hash(11);
-        let blob = mock_txn_bytes(tx_final, &[nullifier], gsr0);
+        let live_obj = unique_hash(12);
+        let blob = mock_txn_bytes(tx_final, &[nullifier], &[live_obj], gsr0);
         let head1 = sm
             .derive_slot_head(head0, [(gsr0, 0)], 1, 1, &[(0, blob)])
             .unwrap();
-        let tx_present = app_db.tx_exists_batch(&head1.roots, &[tx_final]).unwrap();
+        let created_present = app_db
+            .created_exists_batch(&head1.roots, &[live_obj])
+            .unwrap();
         let nullifier_present = app_db
             .nullifier_exists_batch(&head1.roots, &[nullifier])
             .unwrap();
 
-        assert_eq!(head1.metadata.tx_count, 1);
+        assert_eq!(head1.metadata.created_count, 1);
         assert_eq!(head1.metadata.nullifier_count, 1);
         assert_eq!(head1.metadata.gsr_count, 2);
-        assert_eq!(tx_present, vec![true]);
+        assert_eq!(created_present, vec![true]);
         assert_eq!(nullifier_present, vec![true]);
     }
 
@@ -342,9 +393,9 @@ mod tests {
         let head0 = seed_gsr0(&sm);
 
         let tx_final = unique_hash(21);
-        let blob = mock_txn_bytes(tx_final, &[], unique_hash(99));
+        let blob = mock_txn_bytes(tx_final, &[], &[unique_hash(22)], unique_hash(99));
         let head1 = sm.derive_slot_head(head0, [], 2, 2, &[(0, blob)]).unwrap();
-        assert_eq!(head1.metadata.tx_count, head0.metadata.tx_count);
+        assert_eq!(head1.metadata.created_count, head0.metadata.created_count);
     }
 
     #[test]
@@ -354,14 +405,42 @@ mod tests {
         let gsr0 = head0.metadata.current_gsr.unwrap();
 
         let tx_final = unique_hash(31);
-        let blob = mock_txn_bytes(tx_final, &[], gsr0);
+        let live_obj = unique_hash(32);
+        let blob = mock_txn_bytes(tx_final, &[], &[live_obj], gsr0);
         let head1 = sm
             .derive_slot_head(head0, [(gsr0, 0)], 1, 1, &[(0, blob)])
             .unwrap();
-        let old_membership = app_db.tx_exists_batch(&head0.roots, &[tx_final]).unwrap();
-        let new_membership = app_db.tx_exists_batch(&head1.roots, &[tx_final]).unwrap();
+        let old_membership = app_db
+            .created_exists_batch(&head0.roots, &[live_obj])
+            .unwrap();
+        let new_membership = app_db
+            .created_exists_batch(&head1.roots, &[live_obj])
+            .unwrap();
 
         assert_eq!(old_membership, vec![false]);
         assert_eq!(new_membership, vec![true]);
+    }
+
+    #[test]
+    fn test_rejects_duplicate_created_object() {
+        let (sm, _app_db, _dir) = make_sm();
+        let head0 = seed_gsr0(&sm);
+        let gsr0 = head0.metadata.current_gsr.unwrap();
+
+        let live_obj = unique_hash(40);
+        let blob1 = mock_txn_bytes(unique_hash(41), &[], &[live_obj], gsr0);
+        let head1 = sm
+            .derive_slot_head(head0, [(gsr0, 0)], 1, 1, &[(0, blob1)])
+            .unwrap();
+        assert_eq!(head1.metadata.created_count, 1);
+
+        // A second tx that re-creates the same object is rejected, exactly
+        // like a nullifier double-spend.
+        let gsr1 = head1.metadata.current_gsr.unwrap();
+        let blob2 = mock_txn_bytes(unique_hash(42), &[], &[live_obj], gsr1);
+        let head2 = sm
+            .derive_slot_head(head1, [(gsr1, 1)], 2, 2, &[(0, blob2)])
+            .unwrap();
+        assert_eq!(head2.metadata.created_count, head1.metadata.created_count);
     }
 }

--- a/synchronizer/src/sync_db.rs
+++ b/synchronizer/src/sync_db.rs
@@ -68,13 +68,13 @@ impl SyncDb {
                 execution_block_number INTEGER NULL,
                 current_gsr BYTEA NULL,
                 is_empty BOOLEAN NOT NULL,
-                head_transactions_root BYTEA NOT NULL,
+                head_created_root BYTEA NOT NULL,
                 head_nullifiers_root BYTEA NOT NULL,
                 head_state_root_gsrs_root BYTEA NOT NULL,
                 head_gsr_history_root BYTEA NOT NULL,
                 head_current_gsr BYTEA NULL,
                 head_current_block_number INTEGER NULL,
-                head_tx_count BIGINT NOT NULL,
+                head_created_count BIGINT NOT NULL,
                 head_nullifier_count BIGINT NOT NULL,
                 head_gsr_count BIGINT NOT NULL,
                 updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
@@ -144,13 +144,13 @@ impl SyncDb {
             r#"
             SELECT slot,
                    execution_block_number,
-                   head_transactions_root,
+                   head_created_root,
                    head_nullifiers_root,
                    head_state_root_gsrs_root,
                    head_gsr_history_root,
                    head_current_gsr,
                    head_current_block_number,
-                   head_tx_count,
+                   head_created_count,
                    head_nullifier_count,
                    head_gsr_count
             FROM canonical_slots
@@ -221,13 +221,13 @@ impl SyncDb {
                 execution_block_number,
                 current_gsr,
                 is_empty,
-                head_transactions_root,
+                head_created_root,
                 head_nullifiers_root,
                 head_state_root_gsrs_root,
                 head_gsr_history_root,
                 head_current_gsr,
                 head_current_block_number,
-                head_tx_count,
+                head_created_count,
                 head_nullifier_count,
                 head_gsr_count
             )
@@ -240,13 +240,13 @@ impl SyncDb {
         .bind(slot.block_number.map(|v| v as i32))
         .bind(slot.current_gsr.map(hash_to_db_bytes))
         .bind(slot.is_empty)
-        .bind(hash_to_db_bytes(head.roots.transactions))
+        .bind(hash_to_db_bytes(head.roots.created))
         .bind(hash_to_db_bytes(head.roots.nullifiers))
         .bind(hash_to_db_bytes(head.roots.state_root_gsrs))
         .bind(hash_to_db_bytes(head.roots.gsr_history))
         .bind(head.metadata.current_gsr.map(hash_to_db_bytes))
         .bind(head.metadata.current_block_number.map(|v| v as i32))
-        .bind(head.metadata.tx_count as i64)
+        .bind(head.metadata.created_count as i64)
         .bind(head.metadata.nullifier_count as i64)
         .bind(head.metadata.gsr_count as i64)
         .execute(&mut *tx)
@@ -302,7 +302,7 @@ impl SyncDb {
 fn decode_head_row(row: &PgRow) -> Result<CanonicalHead> {
     Ok(CanonicalHead {
         roots: CanonicalRoots {
-            transactions: db_bytes_to_hash(&row.get::<Vec<u8>, _>("head_transactions_root"))?,
+            created: db_bytes_to_hash(&row.get::<Vec<u8>, _>("head_created_root"))?,
             nullifiers: db_bytes_to_hash(&row.get::<Vec<u8>, _>("head_nullifiers_root"))?,
             state_root_gsrs: db_bytes_to_hash(&row.get::<Vec<u8>, _>("head_state_root_gsrs_root"))?,
             gsr_history: db_bytes_to_hash(&row.get::<Vec<u8>, _>("head_gsr_history_root"))?,
@@ -316,7 +316,7 @@ fn decode_head_row(row: &PgRow) -> Result<CanonicalHead> {
             current_block_number: row
                 .get::<Option<i32>, _>("head_current_block_number")
                 .map(|value| value as u32),
-            tx_count: row.get::<i64, _>("head_tx_count") as u64,
+            created_count: row.get::<i64, _>("head_created_count") as u64,
             nullifier_count: row.get::<i64, _>("head_nullifier_count") as u64,
             gsr_count: row.get::<i64, _>("head_gsr_count") as u64,
         },
@@ -370,7 +370,7 @@ mod tests {
     fn unique_head(block_number: u32, marker: i64) -> CanonicalHead {
         CanonicalHead {
             roots: CanonicalRoots {
-                transactions: unique_hash(marker),
+                created: unique_hash(marker),
                 nullifiers: unique_hash(marker + 1),
                 state_root_gsrs: unique_hash(marker + 2),
                 gsr_history: unique_hash(marker + 3),
@@ -378,7 +378,7 @@ mod tests {
             metadata: HeadMetadata {
                 current_gsr: Some(unique_hash(marker + 4)),
                 current_block_number: Some(block_number),
-                tx_count: block_number as u64,
+                created_count: block_number as u64,
                 nullifier_count: block_number as u64 + 1,
                 gsr_count: block_number as u64 + 2,
             },

--- a/txlib/README.md
+++ b/txlib/README.md
@@ -4,25 +4,25 @@ Transaction predicates for verifiable state transitions in the Digital Objects N
 
 ## SDK: actions and classes
 
-The SDK defines **actions** and **classes**. A class is a label for an object's type - what kind of thing it is. Some actions output objects of class "Wood"; others take "Wood" as input. The class is defined by the set of actions capable of producing, mutating, or deleting an object of that class. Concretely, every object dictionary carries a `type` field whose value is the hash of an `Is<Class>` predicate. That predicate is an OR over all the actions in the class.
+The SDK defines **actions** and **classes**. A class is a label for an object's type: what kind of thing it is. Some actions output objects of class "Wood"; others take "Wood" as input. The class is defined by the set of actions capable of producing, mutating, or deleting an object of that class. Concretely, every object dictionary carries a `type` field whose value is the hash of an `Is<Class>` predicate. That predicate is an OR over all the actions in the class.
 
 ## Transactions: verifying state changes
 
-A transaction verifies a set of state changes -- newly created object states and nullifications of existing object states. It checks both that the initial states are valid (grounded in the prior global state) and that every change -- creation of a new object, mutation or deletion of an existing one -- has a valid cause.
+A transaction verifies a set of state changes: newly created object states and nullifications of existing object states. It checks both that the initial states are valid (grounded in the prior global state) and that every change (creating a new object, mutating or deleting an existing one) has a valid cause.
 
-For this to work, actions need a way of saying "these are the changes I caused", and the system needs a way to look at any change and ask "is there a valid cause for this to have happened?" — i.e. "did this change originate in one of the permitted actions for the affected object's class?"
+For this to work, actions need a way of saying "these are the changes I caused", and the system needs a way to look at any change and ask whether there is a valid cause for it: did this change originate in one of the permitted actions for the affected object's class?
 
 ## Action statements
 
 Before the system can answer that question, the prover first produces **action statements**: proofs of action predicates like `FindLog`, `CraftWood`, `UseWoodPick`. Each action statement commits to:
 
-- The set of inputs the action consumed (possibly empty -- `FindLog` takes none).
-- The set of outputs the action produced (possibly empty -- a pure-delete action produces none).
+- The set of inputs the action consumed (possibly empty; `FindLog` takes none).
+- The set of outputs the action produced (possibly empty; a pure-delete action produces none).
 - A range on the transaction's hash chain (see next).
 
 ## The hash chain
 
-Every event in a transaction -- insert, mutate, delete -- is recorded as one step of a chained hash. For each event a small per-event hash is computed (insert: `H(0, new)`; mutate: `H(old, new)`; delete: `H(old, 0)`) and folded into the running chain (`chain = H(prev_chain, event_hash)`). The chain is the canonical, ordering-preserving commitment to "what happened, in what order".
+Every event in a transaction (insert, mutate, delete) is recorded as one step of a chained hash. For each event a small per-event hash is computed (insert: `H(0, new)`; mutate: `H(old, new)`; delete: `H(old, 0)`) and folded into the running chain (`chain = H(prev_chain, event_hash)`). The chain is the canonical, ordering-preserving commitment to "what happened, in what order".
 
 An **action's range** is the pair `(chain_start, chain_end)` that brackets the action's events. The first event in the action takes `chain_start` as its `prev_chain`; the last event produces `chain_end`. The action statement commits to its range publicly so other proofs can match against it.
 
@@ -42,7 +42,7 @@ A useful mental model: each action's range covers the entire dependency tree of 
 
 Once all action statements are proven, the transaction system "replays" the chain: walks it event by event, and for each event verifies that the affected object's change is authorized.
 
-This is the role of the **type predicate** (`IsX`): every object's `type` field stores the hash of `Is<Class>`, which is an OR over the action predicates valid for that class. The type predicate takes `(obj, chain_start, chain_end)` -- the object state plus the current action's range -- as arguments. Validating an event means producing a statement of one of those OR branches whose range matches the current range. In a valid proof, that match is exactly one of the action statements proved at the start.
+This is the role of the **type predicate** (`IsX`): every object's `type` field stores the hash of `Is<Class>`, which is an OR over the action predicates valid for that class. The type predicate takes the object state plus the current action's range, `(obj, chain_start, chain_end)`, as arguments. Validating an event means producing a statement of one of those OR branches whose range matches the current range. In a valid proof, that match is exactly one of the action statements proved at the start.
 
 This is what ties the two halves together. The action statement commits to a range; the replay's guard call dispatches into IsX, which selects the right action; the action's recorded range must equal the range the guard is asking about. Each guard call has one and only one action statement that can satisfy it.
 
@@ -67,10 +67,12 @@ Replay is structured as recursive OR-walking over the chain. Four layers, bottom
        if step is sub_action:       replay(sub_action)
    ```
 
-   In podlang this is encoded as a recursive OR walk, which would be expensive if written naively: each step would OR over five cases at every iteration. Because the prover knows the event sequence in advance, the loop can be unrolled and specialised -- at each step the prover picks the right branch, and the variants of the next step are specialised to the type of the head event so the OR-dispatch over event types folds out. See `ReplayActions`, `ReplayContents`, and the per-event predicates `Replay{Insert,Mutate,Delete,Action}` for the details. `ReplayAction` also writes the scope into the tx context and copies inner `live`/`nullifiers` back to the outer tx. The top-level walker requires every top-level event to be an action, so no bare event can escape an action's guard dispatch.
+   In podlang this is encoded as a recursive OR walk, which would be expensive if written naively: each step would OR over five cases at every iteration. Because the prover knows the event sequence in advance, the loop is unrolled and specialised: at each step the prover picks the right branch, and the variants of the next step are specialised to the type of the head event so the OR-dispatch over event types folds out. See `ReplayActions`, `ReplayContents`, and the per-event predicates `Replay{Insert,Mutate,Delete,Action}` for the details. `ReplayAction` also writes the scope into the tx context and copies inner `live`/`nullifiers` back to the outer tx. The top-level walker requires every top-level event to be an action, so no bare event can escape an action's guard dispatch.
 
-   `ReplayActions` also has a K=1 fast path (`ReplayActionInsert`) for the common "mining" case: a single top-level action whose body is one Insert. It folds the whole walk into 2 custom statements by bypassing `ReplayAction` -> `ReplayContents` -> `ReplayElement` -> `ReplayInsert`, lifting the Insert's guard call directly under the top-level OR. Safe because the action spans the full chain range in this case, so the action's `(chain_start, chain_end)` and the transaction's are the same values the guard would have seen inside a materialised `ReplayAction` scope.
+   `ReplayActions` also has a K=1 fast path (`ReplayActionInsert`) for the common "mining" case: a single top-level action whose body is one Insert. It folds the whole walk into 2 custom statements by bypassing `ReplayAction` -> `ReplayContents` -> `ReplayElement` -> `ReplayInsert`, lifting the Insert's guard call directly under the top-level OR. This is safe because the action spans the full chain range in this case, so the action's `(chain_start, chain_end)` and the transaction's are the same values the guard would have seen inside a materialised `ReplayAction` scope.
 
-3. **Grounding.** Each input object must be live in some prior finalized tx that's recorded in the state root. `InputsGrounded` is an OR with fast paths for 0/1/2/3 inputs (`Equal({},{})`, `Single`, `Pair`, `Triple`) plus a recursive branch for 4+; the fast paths avoid the per-input cost of the general recursion. `TxInStateRoot` unpacks the 3-layer state-root hash inline rather than calling a separate `StateRoot` predicate.
+3. **Grounding.** Each input object must be present in the global **created set** carried by the state root: a grow-only set holding the commitment of every object state ever created, maintained by the synchronizer. Grounding is one `ArrayContains(created, index, input)` membership check per input, with no indirection through a source transaction. `InputsGrounded` is an OR over `Equal(inputs, {})` (no inputs), `InputsGroundedSingle` (one input), `InputsGroundedPair` (two inputs, both grounded inline), and `InputsGroundedRecursive` (three or more: ground two inputs, then recurse, bottoming out at Single for odd counts or Pair for even). Since each input is only `ArrayContains` + `SetInsert`, Pair fits both inputs in one predicate and Recursive peels two per level. `created` is passed to `InputsGrounded` as a plain value so the membership checks cross POD boundaries cheaply; `TxFinalized` ties it back to the public state root's `created` field once.
 
-4. **`TxFinalized`.** The public entry point. It seeds the chain (`chain_start = H(live_set, 0)`), pins the initial `before_tx` schema (`nullifiers = {}`, `chain_start = chain_end = 0`, `live = inputs_set`) in a single `DictInsert` clause to remove malleability, and threads everything through one `ReplayActions` call. Public outputs: `(state_root_hash, tx_final, nullifiers)`.
+   The created set is grow-only and grounding runs against a possibly-stale state root, so a grounded input may already have been spent. The nullifier set, not grounding, is what rejects a re-spend.
+
+4. **`TxFinalized`.** The public entry point. It seeds the chain (`chain_start = H(live_set, 0)`), pins the initial `before_tx` schema (`nullifiers = {}`, `chain_start = chain_end = 0`, `live = inputs_set`) in a single `DictInsert` clause to remove malleability, and threads everything through one `ReplayActions` call. `TxFinalBindings` surfaces the final `nullifiers` and `live` sets as public args (factored out so `TxFinalized` stays within the clause limit), letting the synchronizer fold them into its global nullifier and created sets. Public outputs: `(state_root, tx_final, nullifiers, live)`.

--- a/txlib/src/lib.rs
+++ b/txlib/src/lib.rs
@@ -31,7 +31,7 @@ use std::{collections::HashMap, sync::Arc};
 
 use pod2::{
     backends::plonky2::primitives::merkletree::MerkleProof,
-    frontend::{Operation, OperationArg},
+    frontend::Operation,
     middleware::{
         EMPTY_VALUE, Hash, NativeOperation, OperationAux, OperationType, Statement, StrKey, Value,
         containers::{Array, Dictionary, Set},
@@ -49,13 +49,15 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 ///
 /// Holds only the Merkle roots needed to recompute the canonical global state
 /// root hash and to verify synchronizer-supplied membership proofs. Full
-/// containers are not carried -- callers prove source-tx inclusion with
-/// per-input Merkle proofs packaged in a [`GroundingWitness`].
+/// containers are not carried -- callers prove each input's liveness with a
+/// per-object Merkle proof packaged in a [`GroundingWitness`].
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct StateRoot {
     pub block_number: i64,
-    pub transactions_root: Hash,
+    /// Root of the global created-object set: the commitment of every object
+    /// state ever created. Grounding proves an input is a member here.
+    pub created_root: Hash,
     pub nullifiers_root: Hash,
     pub gsrs_root: Hash,
 }
@@ -63,13 +65,13 @@ pub struct StateRoot {
 impl StateRoot {
     pub fn new(
         block_number: i64,
-        transactions_root: Hash,
+        created_root: Hash,
         nullifiers_root: Hash,
         gsrs_root: Hash,
     ) -> Self {
         Self {
             block_number,
-            transactions_root,
+            created_root,
             nullifiers_root,
             gsrs_root,
         }
@@ -78,12 +80,12 @@ impl StateRoot {
     /// Padded-array view used as the canonical state root record. Slot
     /// layout matches the `record StateRoot` declaration in txlib.podlang.
     /// Predicates access fields via anchored-key syntax (e.g.
-    /// `state_root.transactions`).
+    /// `state_root.created`).
     pub fn array(&self) -> Array {
         Array::new(vec![
             Value::from(0_i64),
             Value::from(self.block_number),
-            Value::from(self.transactions_root),
+            Value::from(self.created_root),
             Value::from(self.nullifiers_root),
             Value::from(self.gsrs_root),
         ])
@@ -98,28 +100,32 @@ impl StateRoot {
 /// Slot indices for the `StateRoot` record. Slot 0 is `_pad` (works
 /// around pod2 issue #513); real fields start at slot 1.
 pub const STATE_ROOT_BLOCK_NUMBER_SLOT: usize = 1;
-pub const STATE_ROOT_TRANSACTIONS_SLOT: usize = 2;
+pub const STATE_ROOT_CREATED_SLOT: usize = 2;
 pub const STATE_ROOT_NULLIFIERS_SLOT: usize = 3;
 pub const STATE_ROOT_GSRS_SLOT: usize = 4;
 
 /// Proof-bearing grounding data required to build a new transaction.
 ///
 /// Callers use `state_root` as the committed global context and
-/// `source_tx_proofs` to prove that each consumed source transaction is
-/// present in `state_root.transactions_root`.
+/// `created_proofs` to prove that each consumed input object is present in
+/// `state_root.created_root` (the global created-object set). Proofs are keyed
+/// by object commitment (`Dictionary::commitment()`) and carry the object's
+/// array index, since grounding is `ArrayContains(created, index, obj)`. They
+/// are fetched fresh at consume time because the created set grows: a proof is
+/// only valid against the state root it was drawn from.
 #[derive(Clone, Debug)]
 pub struct GroundingWitness {
     pub state_root: StateRoot,
-    /// Merkle proofs for source transaction inclusion keyed by source tx
-    /// commitment (`Tx::dict().commitment()`).
-    pub source_tx_proofs: HashMap<Hash, MerkleProof>,
+    /// Per-object `(index, Merkle proof)` for membership in the global created
+    /// set, keyed by object commitment (`Dictionary::commitment()`).
+    pub created_proofs: HashMap<Hash, (i64, MerkleProof)>,
 }
 
 impl GroundingWitness {
-    pub fn new(state_root: StateRoot, source_tx_proofs: HashMap<Hash, MerkleProof>) -> Self {
+    pub fn new(state_root: StateRoot, created_proofs: HashMap<Hash, (i64, MerkleProof)>) -> Self {
         Self {
             state_root,
-            source_tx_proofs,
+            created_proofs,
         }
     }
 }
@@ -130,18 +136,33 @@ impl GroundingWitness {
 pub struct Tx {
     pub live: Set,
     pub nullifiers: Set,
-    /// The after_tx dictionary. Its commitment is tx_final (stored in
-    /// the state root's transactions set). Contains live, nullifiers,
-    /// chain_start, chain_end.
+    /// The after_tx dictionary. Its commitment is tx_final (the value the
+    /// relayer publishes). Contains live, nullifiers, chain_start, chain_end.
     pub ctx: Dictionary,
     pub state_root: Arc<StateRoot>,
 }
 
 impl Tx {
-    /// The transaction's committed dictionary. Its commitment is what
-    /// gets stored in the state root's transactions set.
+    /// The transaction's committed dictionary. Its commitment is tx_final,
+    /// the value the relayer publishes for this transaction.
     pub fn dict(&self) -> Dictionary {
         self.ctx.clone()
+    }
+
+    /// Commitments of the objects this tx leaves live.
+    pub fn live_commitments(&self) -> anyhow::Result<Vec<Hash>> {
+        self.live
+            .iter()
+            .map(|entry| Ok(Hash(entry?.raw().0)))
+            .collect()
+    }
+
+    /// The nullifiers this tx emits.
+    pub fn nullifier_hashes(&self) -> anyhow::Result<Vec<Hash>> {
+        self.nullifiers
+            .iter()
+            .map(|entry| Ok(Hash(entry?.raw().0)))
+            .collect()
     }
 }
 
@@ -180,51 +201,6 @@ impl<'de> Deserialize<'de> for Tx {
             nullifiers: payload.nullifiers,
             ctx: payload.ctx,
             state_root: Arc::new(payload.state_root),
-        })
-    }
-}
-
-/// Per-object membership evidence: the source transaction's commitment,
-/// the live-set commitment, and Merkle proofs that anchor the object
-/// inside that source transaction's live set. Produced at mint time by
-/// the source transaction's prover and packaged alongside each output
-/// object; consumed at proof time by [`TxBuilder`] when the object is
-/// spent.
-///
-/// State-root anchoring (proving the source tx is in `transactions_root`)
-/// is supplied separately at consume time by the synchronizer via
-/// [`GroundingWitness`]; it cannot be pre-computed at mint time because
-/// the source tx is not yet anchored.
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct GroundingEvidence {
-    /// Source transaction commitment (== `source_tx.ctx.commitment()`).
-    pub tx_final: Hash,
-    /// Commitment of the source transaction's live set.
-    pub live_root: Hash,
-    /// Merkle proof for `DictContains(source_tx_ctx, "live", live_root)`.
-    pub live_in_tx_proof: MerkleProof,
-    /// Merkle proof for `SetContains(live, obj)`.
-    pub obj_in_live_proof: MerkleProof,
-}
-
-impl GroundingEvidence {
-    /// Construct from the source transaction's `ctx` dict (which carries
-    /// the `live` set under the `"live"` key) plus the produced object
-    /// whose membership we attest.
-    pub fn new(ctx: &Dictionary, obj: &Dictionary) -> anyhow::Result<Self> {
-        let tx_final = ctx.commitment();
-        let (live_value, live_in_tx_proof) = ctx.prove(&StrKey::from("live"))?;
-        let live = live_value
-            .as_set()
-            .ok_or_else(|| anyhow::anyhow!("ctx.live is not a Set"))?;
-        let live_root = live.commitment();
-        let obj_in_live_proof = live.prove(&Value::from(obj.clone()))?;
-        Ok(Self {
-            tx_final,
-            live_root,
-            live_in_tx_proof,
-            obj_in_live_proof,
         })
     }
 }
@@ -521,7 +497,7 @@ impl TxBuilder {
     /// Seeds `chain_start = H(inputs, 0)`.
     pub fn new(
         ctx: &mut BuildContext,
-        inputs: &[(Dictionary, GroundingEvidence)],
+        inputs: &[Dictionary],
         grounding: Arc<GroundingWitness>,
     ) -> Self {
         let (st_inputs_grounded, inputs_set, stats) =
@@ -864,13 +840,28 @@ impl TxBuilder {
             frame,
         );
 
-        // TxFinalized -- rebind inputs_grounded and chain_start hash
-        // to reference before_tx.live instead of a literal inputs set.
+        // Tie grounding to the public state root: rebind the InputsGrounded
+        // statement's `inputs` to `before_tx.live` (the in-tx working set) and
+        // its created set to `state_root.created`. The latter is the single
+        // state-root array access anchoring the whole grounding tree. Two calls
+        // rather than one because the entries are different anchored-key types:
+        // a dict key and an array index.
         let st_inputs_rebound = ctx
             .builder
             .priv_op(Operation::replace_value_with_entry(
                 vec![Some((&before_tx, "live")), None],
                 self.st_inputs_grounded.clone(),
+            ))
+            .unwrap();
+        let state_root_arr = self.state_root.array();
+        let st_inputs_rebound = ctx
+            .builder
+            .priv_op(Operation::replace_value_with_entry(
+                vec![
+                    None,
+                    Some((&state_root_arr, STATE_ROOT_CREATED_SLOT as i64)),
+                ],
+                st_inputs_rebound,
             ))
             .unwrap();
         let st_hash = ctx
@@ -910,10 +901,23 @@ impl TxBuilder {
                 st_dict_insert_lit,
             ))
             .unwrap();
+        // Surface the final nullifier and live sets as public args.
         let st_dc_null_after = ctx
             .builder
             .priv_op(op!(DictContains(after_tx, "nullifiers", self.nullifiers)))
             .unwrap();
+        let st_dc_live_after = ctx
+            .builder
+            .priv_op(op!(DictContains(after_tx, "live", self.live)))
+            .unwrap();
+        let st_bindings = ctx
+            .apply_custom_pred_simple(
+                false,
+                "TxFinalBindings",
+                vec![st_dc_null_after, st_dc_live_after],
+            )
+            .unwrap();
+        record(&mut stats, "TxFinalBindings");
         let st = ctx
             .apply_custom_pred_simple(
                 false,
@@ -922,7 +926,7 @@ impl TxBuilder {
                     st_inputs_rebound,
                     st_hash_rebound,
                     st_dict_insert,
-                    st_dc_null_after,
+                    st_bindings,
                     st_replay,
                 ],
             )
@@ -952,19 +956,21 @@ impl TxBuilder {
 
     fn build_inputs_grounded(
         ctx: &mut BuildContext,
-        inputs: &[(Dictionary, GroundingEvidence)],
+        inputs: &[Dictionary],
         grounding: &GroundingWitness,
     ) -> (Statement, Set, TxStats) {
         let mut stats = TxStats::new();
-        let state_root_arr = grounding.state_root.array();
+        // Ground against the created-set commitment as a plain value; TxFinalized
+        // is what ties it back to `state_root.created`.
+        let created_root = grounding.state_root.created_root;
+        let created_value = Value::from(created_root);
 
         if inputs.is_empty() {
-            // Base case: empty inputs. state_root is unconstrained here.
+            // Base case: empty inputs. `created` is unconstrained here.
             let st = st_custom!(
                 ctx,
-                InputsGrounded(state_root = state_root_arr) = (
+                InputsGrounded(created = created_value) = (
                     Equal(set!(), set!()),
-                    Statement::None,
                     Statement::None,
                     Statement::None,
                     Statement::None
@@ -975,191 +981,90 @@ impl TxBuilder {
             return (st, set!(), stats);
         }
 
-        // One ArrayContains witness for `state_root.transactions`, reused
-        // as the anchored-key arg for every per-input SetContains below.
-        let (_, txns_proof) = state_root_arr
-            .prove(STATE_ROOT_TRANSACTIONS_SLOT)
-            .expect("state_root array has transactions slot");
-        let st_state_root_transactions = ctx
-            .builder
-            .priv_op(Operation(
-                OperationType::Native(NativeOperation::ArrayContainsFromEntries),
-                vec![
-                    Value::from(state_root_arr.commitment()).into(),
-                    Value::from(STATE_ROOT_TRANSACTIONS_SLOT as i64).into(),
-                    Value::from(grounding.state_root.transactions_root).into(),
-                ],
-                OperationAux::MerkleProof(txns_proof),
-            ))
-            .unwrap();
-
         let extend_set = |set: &Set, obj: &Dictionary| -> Set {
             let mut new_set = set.clone();
             new_set.insert(&Value::from(obj.clone())).unwrap();
             new_set
         };
 
-        let prove_input = |ctx: &mut BuildContext,
-                           evidence: &GroundingEvidence,
-                           obj: &Dictionary|
-         -> (Statement, Statement) {
-            let st_tx_in_transactions = prove_source_tx_membership(
-                ctx,
-                &st_state_root_transactions,
-                grounding,
-                evidence.tx_final,
-            );
-            let st_set_contains_live = prove_obj_in_source_tx_live(ctx, evidence, obj);
-            (st_tx_in_transactions, st_set_contains_live)
+        let prove_input = |ctx: &mut BuildContext, obj: &Dictionary| {
+            prove_obj_in_created(ctx, created_root, grounding, obj)
         };
 
-        if inputs.len() == 1 {
-            let (obj, evidence) = &inputs[0];
+        // Bottom of the recursion: Single for odd N, Pair (both inputs inline)
+        // for even N. Then peel two inputs per InputsGroundedRecursive level.
+        let (mut st, mut prev_set, mut consumed) = if inputs.len() % 2 == 1 {
+            let obj = &inputs[0];
             let inputs_set = extend_set(&set!(), obj);
-            let (st_tx_in_sr, st_set_contains_live) = prove_input(ctx, evidence, obj);
+            let st_live = prove_input(ctx, obj);
             let st_single = st_custom!(
                 ctx,
-                InputsGroundedSingle() = (
-                    st_tx_in_sr,
-                    st_set_contains_live,
-                    SetInsert(inputs_set, set!(), obj)
-                )
+                InputsGroundedSingle() = (st_live, SetInsert(inputs_set, set!(), obj))
             )
             .unwrap();
             record(&mut stats, "InputsGroundedSingle");
             let st = st_custom!(
                 ctx,
-                InputsGrounded(state_root = state_root_arr) = (
-                    Statement::None,
-                    st_single,
-                    Statement::None,
-                    Statement::None,
-                    Statement::None
-                )
+                InputsGrounded(created = created_value) =
+                    (Statement::None, st_single, Statement::None, Statement::None)
             )
             .unwrap();
             record(&mut stats, "InputsGrounded");
-            return (st, inputs_set, stats);
-        }
-
-        // For 2+ inputs: bottom out at InputsGroundedPair (N=2) or
-        // InputsGroundedTriple (N>=3), then peel any remaining inputs via
-        // InputsGroundedRecursive.
-
-        let (first_obj, first_evidence) = &inputs[0];
-        let (second_obj, second_evidence) = &inputs[1];
-
-        let set_first = extend_set(&set!(), first_obj);
-        let (st_first_tx_in_sr, st_first_set_contains_live) =
-            prove_input(ctx, first_evidence, first_obj);
-        let st_igsv = st_custom!(
-            ctx,
-            InputsGroundedSingleVar() = (
-                st_first_tx_in_sr,
-                st_first_set_contains_live,
-                SetInsert(set_first, set!(), first_obj)
-            )
-        )
-        .unwrap();
-        record(&mut stats, "InputsGroundedSingleVar");
-
-        let inputs_pair = extend_set(&set_first, second_obj);
-        let (st_second_tx_in_sr, st_second_set_contains_live) =
-            prove_input(ctx, second_evidence, second_obj);
-
-        if inputs.len() == 2 {
+            (st, inputs_set, 1usize)
+        } else {
+            let first = &inputs[0];
+            let second = &inputs[1];
+            let set_first = extend_set(&set!(), first);
+            let inputs_pair = extend_set(&set_first, second);
+            let st_first = prove_input(ctx, first);
+            let st_second = prove_input(ctx, second);
             let st_pair = st_custom!(
                 ctx,
                 InputsGroundedPair() = (
-                    st_igsv,
-                    st_second_tx_in_sr,
-                    st_second_set_contains_live,
-                    SetInsert(inputs_pair, set_first, second_obj)
+                    st_first,
+                    SetInsert(set_first, set!(), first),
+                    st_second,
+                    SetInsert(inputs_pair, set_first, second)
                 )
             )
             .unwrap();
             record(&mut stats, "InputsGroundedPair");
             let st = st_custom!(
                 ctx,
-                InputsGrounded(state_root = state_root_arr) = (
-                    Statement::None,
-                    Statement::None,
-                    st_pair,
-                    Statement::None,
-                    Statement::None
-                )
+                InputsGrounded(created = created_value) =
+                    (Statement::None, Statement::None, st_pair, Statement::None)
             )
             .unwrap();
             record(&mut stats, "InputsGrounded");
-            return (st, inputs_pair, stats);
-        }
+            (st, inputs_pair, 2usize)
+        };
 
-        let st_igpv = st_custom!(
-            ctx,
-            InputsGroundedPairVar() = (
-                st_igsv,
-                st_second_tx_in_sr,
-                st_second_set_contains_live,
-                SetInsert(inputs_pair, set_first, second_obj)
-            )
-        )
-        .unwrap();
-        record(&mut stats, "InputsGroundedPairVar");
-
-        let (third_obj, third_evidence) = &inputs[2];
-        let inputs_triple = extend_set(&inputs_pair, third_obj);
-        let (st_third_tx_in_sr, st_third_set_contains_live) =
-            prove_input(ctx, third_evidence, third_obj);
-        let st_triple = st_custom!(
-            ctx,
-            InputsGroundedTriple() = (
-                st_igpv,
-                st_third_tx_in_sr,
-                st_third_set_contains_live,
-                SetInsert(inputs_triple, inputs_pair, third_obj)
-            )
-        )
-        .unwrap();
-        record(&mut stats, "InputsGroundedTriple");
-
-        let mut st = st_custom!(
-            ctx,
-            InputsGrounded(state_root = state_root_arr) = (
-                Statement::None,
-                Statement::None,
-                Statement::None,
-                st_triple,
-                Statement::None
-            )
-        )
-        .unwrap();
-        record(&mut stats, "InputsGrounded");
-        let mut prev_set = inputs_triple;
-
-        for (obj, evidence) in &inputs[3..] {
-            let next_set = extend_set(&prev_set, obj);
-            let (st_tx_in_sr, st_set_contains_live) = prove_input(ctx, evidence, obj);
+        // Peel two inputs per recursion level.
+        while consumed < inputs.len() {
+            let first = &inputs[consumed];
+            let second = &inputs[consumed + 1];
+            let mid = extend_set(&prev_set, first);
+            let next_set = extend_set(&mid, second);
+            let st_first = prove_input(ctx, first);
+            let st_second = prove_input(ctx, second);
             let st_rec = st_custom!(
                 ctx,
                 InputsGroundedRecursive() = (
-                    st_tx_in_sr,
-                    st_set_contains_live,
-                    SetInsert(next_set, prev_set, obj),
+                    st_first,
+                    SetInsert(mid, prev_set, first),
+                    st_second,
+                    SetInsert(next_set, mid, second),
                     st
                 )
             )
             .unwrap();
             record(&mut stats, "InputsGroundedRecursive");
             prev_set = next_set;
+            consumed += 2;
             st = st_custom!(
                 ctx,
-                InputsGrounded() = (
-                    Statement::None,
-                    Statement::None,
-                    Statement::None,
-                    Statement::None,
-                    st_rec
-                )
+                InputsGrounded(created = created_value) =
+                    (Statement::None, Statement::None, Statement::None, st_rec)
             )
             .unwrap();
             record(&mut stats, "InputsGrounded");
@@ -1168,67 +1073,33 @@ impl TxBuilder {
     }
 }
 
-/// Prove `SetContains(state_root.transactions, tx_hash)`. The supplied
-/// statement must already witness `state_root["transactions"]` so we can
-/// use it for the anchored key.
-fn prove_source_tx_membership(
+/// Prove `ArrayContains(created, index, obj)` for one input object against the
+/// global created-set commitment `created_root`, passed as a plain literal.
+///
+/// The created set stores object commitments at sequential indices, but
+/// `Value::from(obj)` hashes to that same commitment, so the per-object proof
+/// lines up against the full object dict here. The index comes from the
+/// grounding witness.
+fn prove_obj_in_created(
     ctx: &mut BuildContext,
-    st_state_root_transactions: &Statement,
+    created_root: Hash,
     grounding: &GroundingWitness,
-    tx_hash: Hash,
-) -> Statement {
-    let proof = grounding
-        .source_tx_proofs
-        .get(&tx_hash)
-        .cloned()
-        .expect("missing source tx proof in grounding witness");
-    ctx.builder
-        .priv_op(Operation(
-            OperationType::Native(NativeOperation::SetContainsFromEntries),
-            vec![
-                OperationArg::Statement(st_state_root_transactions.clone()),
-                Value::from(tx_hash).into(),
-            ],
-            OperationAux::MerkleProof(proof),
-        ))
-        .unwrap()
-}
-
-/// Build `SetContains(source_tx.live, obj)` from a [`GroundingEvidence`].
-///
-/// Discharges two Merkle proofs:
-///   * `DictContains(source_tx_ctx, "live", live_root)` via `live_in_tx_proof`.
-///   * `SetContains(live_root, obj)` via `obj_in_live_proof`.
-///
-/// The DictContains statement is fed as the first arg of the SetContains
-/// op as `OperationArg::Statement(...)`. Pod2 then promotes that arg to
-/// `ValueRef::Key(AnchoredKey(tx_final, "live"))`, which is the form the
-/// `source_tx.live` template arg requires.
-fn prove_obj_in_source_tx_live(
-    ctx: &mut BuildContext,
-    evidence: &GroundingEvidence,
     obj: &Dictionary,
 ) -> Statement {
-    let st_dict_contains = ctx
-        .builder
-        .priv_op(Operation(
-            OperationType::Native(NativeOperation::DictContainsFromEntries),
-            vec![
-                Value::from(evidence.tx_final).into(),
-                Value::from("live").into(),
-                Value::from(evidence.live_root).into(),
-            ],
-            OperationAux::MerkleProof(evidence.live_in_tx_proof.clone()),
-        ))
-        .unwrap();
+    let (index, proof) = grounding
+        .created_proofs
+        .get(&obj.commitment())
+        .cloned()
+        .expect("missing created-set proof in grounding witness");
     ctx.builder
         .priv_op(Operation(
-            OperationType::Native(NativeOperation::SetContainsFromEntries),
+            OperationType::Native(NativeOperation::ArrayContainsFromEntries),
             vec![
-                OperationArg::Statement(st_dict_contains),
+                Value::from(created_root).into(),
+                Value::from(index).into(),
                 Value::from(obj.clone()).into(),
             ],
-            OperationAux::MerkleProof(evidence.obj_in_live_proof.clone()),
+            OperationAux::MerkleProof(proof),
         ))
         .unwrap()
 }
@@ -1249,13 +1120,14 @@ mod tests {
 
     use super::*;
 
-    /// Running test state that mirrors what the synchronizer tracks. Keeps
-    /// full transactions/nullifier sets on the prover side so it can hand
-    /// out real Merkle proofs; exposes the canonical commitments-only
-    /// `StateRoot` to callers.
+    /// Running grounding state for the tests: keeps the full created-object set
+    /// (as an array, plus a reverse index for proofs) and the nullifier set so
+    /// it can hand out real Merkle proofs, while exposing only the
+    /// commitments-only `StateRoot`. The created set is grow-only.
     struct TestState {
         block_number: i64,
-        transactions: Set,
+        created: Array,
+        created_index: HashMap<Hash, i64>,
         nullifiers: Set,
         gsrs: Array,
     }
@@ -1264,7 +1136,8 @@ mod tests {
         fn empty(block_number: i64) -> Self {
             Self {
                 block_number,
-                transactions: set!(),
+                created: Array::new(Vec::new()),
+                created_index: HashMap::new(),
                 nullifiers: set!(),
                 gsrs: Array::new(Vec::new()),
             }
@@ -1273,35 +1146,46 @@ mod tests {
         fn state_root(&self) -> StateRoot {
             StateRoot::new(
                 self.block_number,
-                self.transactions.commitment(),
+                self.created.commitment(),
                 self.nullifiers.commitment(),
                 self.gsrs.commitment(),
             )
         }
 
         fn apply_tx(&mut self, tx: &Tx) {
-            self.transactions
-                .insert(&Value::from(tx.ctx.clone()))
-                .unwrap();
+            for obj in tx.live.iter() {
+                let obj = obj.expect("tx live entry should decode");
+                let commitment = Hash(obj.raw().0);
+                // 1-indexed: slot 0 stays empty so nothing grounds at index 0.
+                let index = self.created_index.len() as i64 + 1;
+                self.created.insert(index as usize, obj).unwrap();
+                self.created_index.insert(commitment, index);
+            }
             for nullifier in tx.nullifiers.iter() {
                 let nullifier = nullifier.expect("tx nullifier should decode");
                 self.nullifiers.insert(&nullifier).unwrap();
             }
         }
 
-        fn grounding_witness(&self, source_txs: &[Tx]) -> Arc<GroundingWitness> {
-            let source_tx_proofs = source_txs
+        /// Build a grounding witness for the given input objects: one created-set
+        /// `(index, membership proof)` per object, keyed by commitment.
+        fn grounding_witness(&self, inputs: &[Dictionary]) -> Arc<GroundingWitness> {
+            let created_proofs = inputs
                 .iter()
-                .map(|tx| {
-                    let commitment = tx.ctx.commitment();
-                    let proof = self
-                        .transactions
-                        .prove(&Value::from(commitment))
-                        .expect("source tx should be provable from test state");
-                    (commitment, proof)
+                .map(|obj| {
+                    let commitment = obj.commitment();
+                    let index = *self
+                        .created_index
+                        .get(&commitment)
+                        .expect("input object should be present in created set");
+                    let (_value, proof) = self
+                        .created
+                        .prove(index as usize)
+                        .expect("input object should be provable from created set");
+                    (commitment, (index, proof))
                 })
                 .collect();
-            Arc::new(GroundingWitness::new(self.state_root(), source_tx_proofs))
+            Arc::new(GroundingWitness::new(self.state_root(), created_proofs))
         }
     }
 
@@ -1358,7 +1242,7 @@ mod tests {
         let encoded = serde_json::to_value(&original).unwrap();
         assert_eq!(encoded["blockNumber"], serde_json::json!(9));
         assert_eq!(
-            encoded["transactionsRoot"],
+            encoded["createdRoot"],
             serde_json::json!(hex::encode([1_u8; 32]))
         );
         assert_eq!(
@@ -1445,9 +1329,8 @@ mod tests {
             .unwrap();
         let stone_initial = make_object(is_stone.clone(), &[]);
 
-        let witness = state.grounding_witness(std::slice::from_ref(&tx0));
-        let evidence = GroundingEvidence::new(&tx0.ctx, &pick).unwrap();
-        let inputs = vec![(pick.clone(), evidence)];
+        let inputs = vec![pick.clone()];
+        let witness = state.grounding_witness(&inputs);
         let mut tx2 = TxBuilder::new(&mut ctx, &inputs, witness);
 
         let scope_outer = tx2.begin_action();
@@ -1573,9 +1456,8 @@ mod tests {
 
         let wood_initial = make_object(is_wood.clone(), &[]);
 
-        let witness = state.grounding_witness(std::slice::from_ref(&tx1_out));
-        let evidence = GroundingEvidence::new(&tx1_out.ctx, &log).unwrap();
-        let inputs = vec![(log.clone(), evidence)];
+        let inputs = vec![log.clone()];
+        let witness = state.grounding_witness(&inputs);
         let mut tx2 = TxBuilder::new(&mut ctx, &inputs, witness);
 
         let scope_outer = tx2.begin_action();
@@ -1626,9 +1508,8 @@ mod tests {
         let stick_a_initial = make_object(is_stick.clone(), &[]);
         let stick_b_initial = make_object(is_stick, &[]);
 
-        let witness = state.grounding_witness(std::slice::from_ref(&tx2_out));
-        let evidence = GroundingEvidence::new(&tx2_out.ctx, &wood).unwrap();
-        let inputs = vec![(wood.clone(), evidence)];
+        let inputs = vec![wood.clone()];
+        let witness = state.grounding_witness(&inputs);
         let mut tx3 = TxBuilder::new(&mut ctx, &inputs, witness);
 
         let scope_outer = tx3.begin_action();
@@ -1723,5 +1604,87 @@ mod tests {
                 .contains(&Value::from(compute_nullifier(&wood)))
                 .unwrap()
         );
+    }
+
+    /// Grounding three inputs exercises InputsGroundedRecursive (peel two per
+    /// level) bottoming out at InputsGroundedSingle -- the N>=3 path that the
+    /// one- and two-input tests never reach.
+    #[test]
+    fn test_grounds_three_inputs() {
+        let txlib = Arc::new(crate::predicates::module());
+        let craft = Arc::new(crate::predicates::crafting_test_module());
+        let modules = vec![txlib.clone(), craft.clone()];
+
+        let is_log =
+            Value::from(Predicate::Custom(craft.predicate_ref_by_name("IsLog").unwrap()).hash());
+
+        let mut state = TestState::empty(0);
+        let params = Params::default();
+        let vd_set = VDSet::new(&[]);
+
+        // Spawn three logs (one FindLog tx each) and fold them into the live
+        // set so the burn tx below can ground all three.
+        let mut logs = Vec::new();
+        for _ in 0..3 {
+            let builder = MultiPodBuilder::new(&params, &vd_set);
+            let mut ctx = BuildContext {
+                builder,
+                modules: modules.clone(),
+            };
+            let log_initial = make_object(is_log.clone(), &[]);
+            let mut tx = TxBuilder::new(&mut ctx, &[], state.grounding_witness(&[]));
+            let scope = tx.begin_action();
+            let (log, st_insert, h) = tx.insert(&mut ctx, &log_initial);
+            let st_find = ctx
+                .apply_custom_pred_simple(false, "FindLog", vec![st_insert])
+                .unwrap();
+            let st_guard = ctx
+                .apply_custom_pred_simple(false, "IsLog", vec![st_find, Statement::None])
+                .unwrap();
+            tx.set_guard(h, st_guard);
+            tx.end_action(scope);
+            let (st, tx_out, _stats) = tx.finalize(&mut ctx);
+            ctx.builder.reveal(&st).unwrap();
+            solve_and_verify(ctx.builder);
+            state.apply_tx(&tx_out);
+            logs.push(log);
+        }
+
+        // Burn all three logs in one tx: TxBuilder::new grounds three inputs,
+        // driving InputsGrounded -> Recursive -> InputsGrounded -> Single.
+        let builder = MultiPodBuilder::new(&params, &vd_set);
+        let mut ctx = BuildContext { builder, modules };
+
+        let inputs = logs.clone();
+        let witness = state.grounding_witness(&inputs);
+        let mut burn = TxBuilder::new(&mut ctx, &inputs, witness);
+
+        for log in &logs {
+            let scope = burn.begin_action();
+            let (st_del, h) = burn.delete(&mut ctx, log);
+            let st_action = ctx
+                .apply_custom_pred_simple(false, "DeleteLog", vec![st_del])
+                .unwrap();
+            let st_guard = ctx
+                .apply_custom_pred_simple(false, "IsLog", vec![Statement::None, st_action])
+                .unwrap();
+            burn.set_guard(h, st_guard);
+            burn.end_action(scope);
+        }
+
+        eprintln!("{burn}");
+        let (st, burn_out, stats) = burn.finalize(&mut ctx);
+        print_stats(&stats);
+        ctx.builder.reveal(&st).unwrap();
+        solve_and_verify(ctx.builder);
+
+        for log in &logs {
+            assert!(
+                burn_out
+                    .nullifiers
+                    .contains(&Value::from(compute_nullifier(log)))
+                    .unwrap()
+            );
+        }
     }
 }

--- a/txlib/src/predicates/mod.rs
+++ b/txlib/src/predicates/mod.rs
@@ -87,19 +87,11 @@ mod tests {
         module
             .predicate_ref_by_name("InputsGroundedSingle")
             .unwrap();
-        module
-            .predicate_ref_by_name("InputsGroundedSingleVar")
-            .unwrap();
         module.predicate_ref_by_name("InputsGroundedPair").unwrap();
-        module
-            .predicate_ref_by_name("InputsGroundedPairVar")
-            .unwrap();
-        module
-            .predicate_ref_by_name("InputsGroundedTriple")
-            .unwrap();
         module
             .predicate_ref_by_name("InputsGroundedRecursive")
             .unwrap();
+        module.predicate_ref_by_name("TxFinalBindings").unwrap();
         module.predicate_ref_by_name("TxFinalized").unwrap();
     }
 }

--- a/txlib/src/predicates/txlib.podlang
+++ b/txlib/src/predicates/txlib.podlang
@@ -13,12 +13,12 @@
      hash step, updating the live/nullifier sets, and calling the
      affected object's type guard to authorize the event.
 
-  3. InputsGrounded -- proves each input object existed in a prior
-     finalized transaction referenced by the state root.
+  3. InputsGrounded -- proves each input object is present in the
+     global live set carried by the state root.
 
   4. TxFinalized -- the public entry point. Ties input grounding,
      chain seeding, and full replay together. Exposes
-     (state_root, tx_final, nullifiers) publicly.
+     (state_root, tx_final, nullifiers, live) publicly.
 
   State convention: most predicates thread four public arguments:
   (before_tx, after_tx, before_chain, after_chain). Each step
@@ -315,100 +315,47 @@ ReplayDelete(before_tx, after_tx, before_chain, after_chain,
 // Inputs Grounded
 // ========================================================
 //
-// The state root is a Record (typed padded array) whose commitment
-// is the canonical GSR. Slot 0 is `_pad` (workaround for pod2 issue
-// #513); real entries are `block_number`, `transactions`, `nullifiers`,
-// `gsrs`. Predicates access fields via anchored-key syntax (e.g.
-// `state_root.transactions` resolves to the transactions set).
-//
-// InputsGrounded proves each input object was live in some prior
-// finalized transaction in `state_root.transactions`.
-//
-// Same loop-unrolling pattern as ReplayContents above: a recursive
-// OR over inputs, with explicit fast paths for small N (0/1/2/3) to
-// avoid the per-input dispatch cost of the general recursion. The
-// `Var` siblings of Single and Pair exist because the outer
-// InputsGrounded OR requires all branches to share the
-// `(inputs, state_root)` signature; Pair/Triple chain through
-// them to expose additional inputs as public args along the way.
+// InputsGrounded proves each input object is a member of `created`, the
+// global created-object set (every object state ever created, maintained
+// by the synchronizer).
 
-record StateRoot = (_pad, block_number, transactions, nullifiers, gsrs)
+record StateRoot = (_pad, block_number, created, nullifiers, gsrs)
 
-InputsGrounded(inputs, state_root StateRoot) = OR(
-  // Base case: empty inputs. state_root is intentionally
-  // unconstrained -- an empty-input tx needs no prior state.
+InputsGrounded(inputs, created) = OR(
+  // Base case: empty inputs. `created` is intentionally unconstrained --
+  // an empty-input tx grounds nothing.
   Equal(inputs, {})
-  InputsGroundedSingle(inputs, state_root)
-  InputsGroundedPair(inputs, state_root)
-  InputsGroundedTriple(inputs, state_root)
-  InputsGroundedRecursive(inputs, state_root)
+  InputsGroundedSingle(inputs, created)
+  InputsGroundedPair(inputs, created)
+  InputsGroundedRecursive(inputs, created)
 )
 
 // Single-input fast path: avoids the cost of a recursive
 // InputsGrounded call.
-InputsGroundedSingle(inputs, state_root StateRoot,
-    private: input, source_tx) = AND(
-  SetContains(state_root.transactions, source_tx)
-  SetContains(source_tx.live, input)
+InputsGroundedSingle(inputs, created, private: input, index) = AND(
+  ArrayContains(created, index, input)
   SetInsert(inputs, {}, input)
 )
 
-// Same body as InputsGroundedSingle, but `input` is a public arg so a
-// caller (e.g. InputsGroundedPair) can reuse it in a subsequent SetInsert.
-// Not eligible for the InputsGrounded OR directly because the OR requires
-// all branches to share the (inputs, state_root) signature.
-InputsGroundedSingleVar(inputs, state_root StateRoot, input,
-    private: source_tx) = AND(
-  SetContains(state_root.transactions, source_tx)
-  SetContains(source_tx.live, input)
-  SetInsert(inputs, {}, input)
-)
-
-// Two-input fast path: grounds two inputs without recursion. Saves one
-// IG-dispatch + one IGR vs. the recursive chain for N=2.
-// IGSV builds the {first} singleton; the second input is verified inline
-// and inserted into the singleton to form `inputs`.
-InputsGroundedPair(inputs, state_root StateRoot,
-    private: first_input, second_input, set_first, source_tx_second) = AND(
-  InputsGroundedSingleVar(set_first, state_root, first_input)
-  SetContains(state_root.transactions, source_tx_second)
-  SetContains(source_tx_second.live, second_input)
+// Two-input fast path: both inputs grounded inline, no sub-predicate
+// dispatch.
+InputsGroundedPair(inputs, created,
+    private: first_input, second_input, set_first, first_index, second_index) = AND(
+  ArrayContains(created, first_index, first_input)
+  SetInsert(set_first, {}, first_input)
+  ArrayContains(created, second_index, second_input)
   SetInsert(inputs, set_first, second_input)
 )
 
-// Same body as InputsGroundedPair, but first_input and second_input are
-// public args so a caller (InputsGroundedTriple) can chain through them.
-// Not eligible for the InputsGrounded OR directly because the OR requires
-// all branches to share the (inputs, state_root) signature.
-InputsGroundedPairVar(inputs, state_root StateRoot, first_input, second_input,
-    private: set_first, source_tx_second) = AND(
-  InputsGroundedSingleVar(set_first, state_root, first_input)
-  SetContains(state_root.transactions, source_tx_second)
-  SetContains(source_tx_second.live, second_input)
-  SetInsert(inputs, set_first, second_input)
-)
-
-// Three-input fast path: grounds three inputs in 4 statements (IG + IGT +
-// IGPV + IGSV). Used directly for N=3, or as the bottom-out for N>=4 (after
-// IGR peels off the outer inputs).
-InputsGroundedTriple(inputs, state_root StateRoot,
-    private: first_input, second_input, third_input, set_pair,
-             source_tx_third) = AND(
-  InputsGroundedPairVar(set_pair, state_root, first_input, second_input)
-  SetContains(state_root.transactions, source_tx_third)
-  SetContains(source_tx_third.live, third_input)
-  SetInsert(inputs, set_pair, third_input)
-)
-
-// 4+ inputs: ground one input, then recurse for the rest. Bottoms out at
-// InputsGroundedTriple for N=4, or at a further IGR -> ... -> IGT chain
-// for larger N.
-InputsGroundedRecursive(inputs, state_root StateRoot,
-    private: input, prev_inputs, source_tx) = AND(
-  SetContains(state_root.transactions, source_tx)
-  SetContains(source_tx.live, input)
-  SetInsert(inputs, prev_inputs, input)
-  InputsGrounded(prev_inputs, state_root)
+// 3+ inputs: ground two inputs, then recurse for the rest. The recursion
+// bottoms out at Single (odd N) or Pair (even N).
+InputsGroundedRecursive(inputs, created,
+    private: first_input, second_input, mid, prev_inputs, first_index, second_index) = AND(
+  ArrayContains(created, first_index, first_input)
+  SetInsert(mid, prev_inputs, first_input)
+  ArrayContains(created, second_index, second_input)
+  SetInsert(inputs, mid, second_input)
+  InputsGrounded(prev_inputs, created)
 )
 
 // ========================================================
@@ -419,14 +366,17 @@ InputsGroundedRecursive(inputs, state_root StateRoot,
 // certificate: it attests to the final state without revealing the
 // event sequence that produced it.
 
-// Exposes (state_root, tx_final, nullifiers) publicly. The verifier
-// sees `state_root` as a single hash -- the commitment of the
+// Exposes (state_root, tx_final, nullifiers, live) publicly. The
+// verifier sees `state_root` as a single hash -- the commitment of the
 // `StateRoot` record.
 // tx_final is the after_tx dictionary commitment, which binds the
-// live set, nullifiers, and final chain_start/chain_end together. The
-// live set and chain are private. The top-level walker is
-// ReplayActions, so every top-level event is guaranteed to be an
-// action (no bare events can escape an action's guard dispatch).
+// live set, nullifiers, and final chain_start/chain_end together. Both
+// the nullifier set and the final live set are also surfaced as their
+// own public args (via TxFinalBindings) so the synchronizer can fold
+// them into its global nullifier and created sets; the chain stays
+// private. The top-level walker is ReplayActions, so every top-level
+// event is guaranteed to be an action (no bare events can escape an
+// action's guard dispatch).
 //
 // The DictInsert clause pins the full schema of `before_tx`:
 // `nullifiers = {}` prevents a tx from inheriting nullifiers it did
@@ -435,11 +385,16 @@ InputsGroundedRecursive(inputs, state_root StateRoot,
 // values for those two fields (they pass through ReplayActions
 // verbatim into `tx_final`, since ReplayAction only updates the
 // `live` and `nullifiers` keys).
-TxFinalized(state_root StateRoot, tx_final, nullifiers,
+TxFinalBindings(tx_final, nullifiers, live) = AND(
+  DictContains(tx_final, "nullifiers", nullifiers)
+  DictContains(tx_final, "live", live)
+)
+
+TxFinalized(state_root StateRoot, tx_final, nullifiers, live,
      private: before_tx, chain_start, chain_final) = AND(
-  InputsGrounded(before_tx.live, state_root)
+  InputsGrounded(before_tx.live, state_root.created)
   HashOf(chain_start, before_tx.live, 0)
   DictInsert(before_tx, {"nullifiers": {}, "chain_start": 0, "chain_end": 0}, "live", before_tx.live)
-  DictContains(tx_final, "nullifiers", nullifiers)
+  TxFinalBindings(tx_final, nullifiers, live)
   ReplayActions(before_tx, tx_final, chain_start, chain_final)
 )

--- a/txlib/src/predicates/txlib.podlang
+++ b/txlib/src/predicates/txlib.podlang
@@ -14,7 +14,7 @@
      affected object's type guard to authorize the event.
 
   3. InputsGrounded -- proves each input object is present in the
-     global live set carried by the state root.
+     global created set carried by the state root.
 
   4. TxFinalized -- the public entry point. Ties input grounding,
      chain seeding, and full replay together. Exposes

--- a/wire-types/src/synchronizer.rs
+++ b/wire-types/src/synchronizer.rs
@@ -8,7 +8,7 @@
 //! lets `dobjd` build clean on Windows.
 //!
 //! Most types here are pure serde DTOs. The two proof-bearing types
-//! ([`SourceTxProofResponse`] and [`GroundingWitnessResponse`]) embed a
+//! ([`ObjectProofResponse`] and [`GroundingWitnessResponse`]) embed a
 //! pod2 `MerkleProof`, so they live behind the `chain` feature. Server
 //! code and the driver enable the feature; `cli` and `mcp` don't.
 
@@ -44,8 +44,8 @@ pub struct StateHeadResponse {
     pub current_gsr: Option<String>,
     /// Execution block number committed inside the current state root, if any.
     pub current_block_number: Option<i64>,
-    /// Number of accepted transactions in canonical state.
-    pub tx_count: usize,
+    /// Number of objects in the canonical global created set.
+    pub created_count: usize,
     /// Number of spent nullifiers in canonical state.
     pub nullifier_count: usize,
     /// Number of GSR entries in canonical history.
@@ -53,30 +53,30 @@ pub struct StateHeadResponse {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-/// Batch transaction-membership request.
-pub struct TxContainsRequest {
-    /// Transaction hashes to look up in the canonical transactions set.
-    pub tx_hashes: Vec<String>,
+/// Batch created-object-membership request.
+pub struct ObjectContainsRequest {
+    /// Object commitments to look up in the canonical created set.
+    pub object_commitments: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-/// Membership result for one transaction hash.
-pub struct TxContainsEntry {
-    /// Queried transaction hash.
-    pub tx_hash: String,
-    /// Whether the hash is present in the canonical transactions set.
+/// Membership result for one object commitment.
+pub struct ObjectContainsEntry {
+    /// Queried object commitment.
+    pub commitment: String,
+    /// Whether the object is present in the canonical created set.
     pub present: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-/// Batch transaction-membership response.
-pub struct TxContainsResponse {
+/// Batch created-object-membership response.
+pub struct ObjectContainsResponse {
     /// Last canonical slot fully committed by the synchronizer.
     pub last_processed_slot: u32,
     /// Current canonical global state root encoded as hex, if one exists.
     pub current_gsr: Option<String>,
-    /// Per-hash membership results.
-    pub results: Vec<TxContainsEntry>,
+    /// Per-commitment membership results.
+    pub results: Vec<ObjectContainsEntry>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -107,10 +107,10 @@ pub struct NullifierContainsResponse {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-/// Combined batch membership request for both transactions and nullifiers.
+/// Combined batch membership request for both created objects and nullifiers.
 pub struct MembershipRequest {
-    /// Transaction hashes to look up in the canonical transactions set.
-    pub tx_hashes: Vec<String>,
+    /// Object commitments to look up in the canonical created set.
+    pub object_commitments: Vec<String>,
     /// Nullifier hashes to look up in the canonical nullifiers set.
     pub nullifiers: Vec<String>,
 }
@@ -122,46 +122,36 @@ pub struct MembershipResponse {
     pub last_processed_slot: u32,
     /// Current canonical global state root encoded as hex, if one exists.
     pub current_gsr: Option<String>,
-    /// Per-transaction membership results.
-    pub tx_results: Vec<TxContainsEntry>,
+    /// Per-object created-set membership results.
+    pub created_results: Vec<ObjectContainsEntry>,
     /// Per-nullifier membership results.
     pub nullifier_results: Vec<NullifierContainsEntry>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-/// Point lookup response for one transaction hash.
-pub struct TxStatusResponse {
-    /// Queried transaction hash.
-    pub tx_hash: String,
-    /// Whether the hash is present in the canonical transactions set.
-    pub present: bool,
-    /// Last canonical slot fully committed by the synchronizer.
-    pub last_processed_slot: u32,
-    /// Current canonical global state root encoded as hex, if one exists.
-    pub current_gsr: Option<String>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-/// Request for transaction-grounding proofs used by txlib execution.
+/// Request for created-object grounding proofs used by txlib execution.
 pub struct GroundingWitnessRequest {
-    /// Source transaction hashes that must be proven against the canonical transactions set.
-    pub source_tx_hashes: Vec<String>,
+    /// Input object commitments that must be proven present in the canonical created set.
+    pub object_commitments: Vec<String>,
 }
 
 #[cfg(feature = "chain")]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-/// Membership proof response for one source transaction.
+/// Created-set membership proof response for one object.
 ///
 /// `chain`-feature only — embeds a pod2 `MerkleProof`.
-pub struct SourceTxProofResponse {
-    /// Source transaction hash the client asked about.
-    pub tx_hash: String,
-    /// Whether the source transaction is present in the canonical transactions set.
+pub struct ObjectProofResponse {
+    /// Object commitment the client asked about.
+    pub commitment: String,
+    /// Whether the object is present in the canonical created set.
     pub present: bool,
-    /// Merkle proof against the canonical transactions root.
-    pub proof: MerkleProof,
+    /// Array index of the object in the created set. `None` when not present.
+    pub index: Option<i64>,
+    /// `ArrayContains` Merkle proof against the canonical created-set root.
+    /// `None` when the object is not present (the array has no such leaf).
+    pub proof: Option<MerkleProof>,
 }
 
 #[cfg(feature = "chain")]
@@ -169,18 +159,18 @@ pub struct SourceTxProofResponse {
 #[serde(rename_all = "camelCase")]
 /// txlib witness response anchored to one canonical state root.
 ///
-/// `chain`-feature only — embeds a `Vec<SourceTxProofResponse>`.
+/// `chain`-feature only — embeds a `Vec<ObjectProofResponse>`.
 pub struct GroundingWitnessResponse {
     /// Hash of the compact `txlib::StateRoot` built from the canonical roots.
     pub state_root_hash: String,
     /// Execution block number committed inside that state root.
     pub block_number: i64,
-    /// Canonical transactions set root encoded as hex.
-    pub transactions_root: String,
+    /// Canonical created-set root encoded as hex.
+    pub created_root: String,
     /// Canonical nullifiers set root encoded as hex.
     pub nullifiers_root: String,
     /// Prior-GSR array root committed inside the state root.
     pub gsrs_root: String,
-    /// Per-source transaction membership proofs.
-    pub source_tx_proofs: Vec<SourceTxProofResponse>,
+    /// Per-input-object created-set membership proofs.
+    pub created_proofs: Vec<ObjectProofResponse>,
 }


### PR DESCRIPTION
`txlib` now produces a `TxFinalized` statement which includes the live set along with the nullifier set and tx hash. The synchronizer collects the live object hashes and adds them to a global set of created items. For reasons of collision-avoidance, this is materialized as a POD2 array.

Proving that an object is a valid input means proving that the object is in the `created` array for a given state root. `InputsGrounded` in `txlib` now uses that as evidence, rather than the previous approach which required proving the presence of a transaction first, and then the presence of the object in the transaction's live set. This simplifies `txlib`'s Podlang a bit.

`TxFinalized` still includes a tx hash. However, the synchronizer no longer makes Merkle proofs about transactions, and the transaction set is not Merkleized or referenced in the global state root hash (the `created` objects set replaces it).

Clients still ask the synchronizer to confirm the acceptance of a transaction, but this is done by checking for the inclusion of the created items and nullifiers, not by transaction hash.