### PR TITLE
remove database auto-creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,8 +153,8 @@ just reset
 
 Clears local RocksDB, local object files (`~/.dobj/objects/`), local
 plugin installs (`~/.dobj/actions/`), and the local Postgres databases
-used by the synchronizer and relayer. The next `just dev` re-installs
-plugins automatically.
+used by the synchronizer and relayer. The next `just dev` re-creates the
+databases (via `just ensure-db`) and re-installs plugins automatically.
 
 If you're not using the default local `postgres` role/admin database,
 either adjust the `just reset` command or drop the `synchronizer` and

--- a/justfile
+++ b/justfile
@@ -36,7 +36,7 @@ dobjd:
 # shell — all backed by one dobjd process. Open http://localhost:1420 in a
 # browser to use the website client; the desktop window opens automatically.
 # https://github.com/pvolok/mprocs
-dev: ensure-plugins ensure-mcp
+dev: ensure-db ensure-plugins ensure-mcp
     mprocs --config mprocs.yaml
 
 # Like `just dev`, but without spawning the local synchronizer + relayer —
@@ -75,6 +75,13 @@ ensure-mcp:
     claude mcp remove bitcraft 2>/dev/null || true
     claude mcp add --transport http bitcraft http://127.0.0.1:7718/mcp \
         && echo "registered: bitcraft MCP (project scope, http://127.0.0.1:7718/mcp)"
+
+# Ensure the local Postgres databases the synchronizer + relayer expect exist.
+# `just dev` runs this automatically; run it yourself before `just sync` /
+# `just relayer`. Idempotent: skips a database that already exists.
+ensure-db:
+    @psql postgres://postgres@localhost:5432/postgres -tAc "SELECT 1 FROM pg_database WHERE datname='synchronizer'" | grep -q 1 || psql postgres://postgres@localhost:5432/postgres -c 'CREATE DATABASE synchronizer'
+    @psql postgres://postgres@localhost:5432/postgres -tAc "SELECT 1 FROM pg_database WHERE datname='relayer'" | grep -q 1 || psql postgres://postgres@localhost:5432/postgres -c 'CREATE DATABASE relayer'
 
 # Wipe local state (RocksDB + local Postgres DBs + objects)
 reset:

--- a/relayer/src/api.rs
+++ b/relayer/src/api.rs
@@ -345,11 +345,25 @@ mod tests {
         Ok(())
     }
 
+    async fn create_db(admin_url: &str, db_name: &str) -> anyhow::Result<()> {
+        let pool = PgPoolOptions::new()
+            .max_connections(1)
+            .connect(admin_url)
+            .await?;
+        let escaped = db_name.replace('"', "\"\"");
+        pool.execute(format!("CREATE DATABASE \"{escaped}\"").as_str())
+            .await?;
+        Ok(())
+    }
+
     async fn test_app(mode: ParseMode) -> (Router, String, String) {
         let (admin_url, db_url, db_name) = test_urls();
         drop_db(&admin_url, &db_name)
             .await
             .expect("drop test db before run");
+        create_db(&admin_url, &db_name)
+            .await
+            .expect("create test db before run");
         let db = Arc::new(Db::connect(&db_url).await.expect("connect test db"));
         let state = AppState {
             db,

--- a/relayer/src/db.rs
+++ b/relayer/src/db.rs
@@ -1,6 +1,5 @@
 use anyhow::{anyhow, Context, Result};
 use sqlx::{postgres::PgPoolOptions, Executor, PgPool, Row};
-use url::Url;
 
 use crate::model::{JobStatus, RelayJob};
 
@@ -18,9 +17,11 @@ pub struct Db {
 }
 
 impl Db {
-    /// Connect to Postgres, create database if needed, and bootstrap schema/indexes.
+    /// Connect to an existing Postgres database and bootstrap schema/indexes.
+    ///
+    /// The database itself must already exist — provisioning is an explicit
+    /// operator step so the app role does not need the `CREATEDB` privilege.
     pub async fn connect(database_url: &str) -> Result<Self> {
-        ensure_database_exists(database_url).await?;
         let pool = PgPoolOptions::new()
             .max_connections(5)
             .connect(database_url)
@@ -345,39 +346,6 @@ fn row_to_job(row: sqlx::postgres::PgRow) -> Result<RelayJob> {
     })
 }
 
-/// Local-dev convenience: ensure the target database exists before connecting.
-async fn ensure_database_exists(database_url: &str) -> Result<()> {
-    let parsed = Url::parse(database_url).with_context(|| "Invalid DB_URL")?;
-    let db_name = parsed
-        .path_segments()
-        .and_then(|mut segments| segments.next_back())
-        .filter(|segment| !segment.is_empty())
-        .ok_or_else(|| anyhow!("DB_URL must include a database name"))?;
-
-    let mut admin_url = parsed.clone();
-    admin_url.set_path("/postgres");
-
-    let admin_pool = PgPoolOptions::new()
-        .max_connections(1)
-        .connect(admin_url.as_str())
-        .await
-        .with_context(|| "Failed to connect to postgres admin database")?;
-
-    let exists = sqlx::query_scalar::<_, i32>("SELECT 1 FROM pg_database WHERE datname = $1")
-        .bind(db_name)
-        .fetch_optional(&admin_pool)
-        .await?
-        .is_some();
-
-    if !exists {
-        let escaped = db_name.replace('"', "\"\"");
-        let create_stmt = format!("CREATE DATABASE \"{escaped}\"");
-        sqlx::query(&create_stmt).execute(&admin_pool).await?;
-    }
-
-    Ok(())
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -386,6 +354,7 @@ mod tests {
     use std::sync::OnceLock;
     use std::time::{SystemTime, UNIX_EPOCH};
     use tokio::sync::Mutex;
+    use url::Url;
 
     fn now() -> i64 {
         1_700_000_000
@@ -453,9 +422,21 @@ mod tests {
         Ok(())
     }
 
+    async fn create_db(admin_url: &str, db_name: &str) -> Result<()> {
+        let pool = PgPoolOptions::new()
+            .max_connections(1)
+            .connect(admin_url)
+            .await?;
+        let escaped = db_name.replace('"', "\"\"");
+        pool.execute(format!("CREATE DATABASE \"{escaped}\"").as_str())
+            .await?;
+        Ok(())
+    }
+
     async fn setup_db() -> Result<(Db, String, String)> {
         let (admin_url, db_url, db_name) = test_urls();
         drop_db(&admin_url, &db_name).await?;
+        create_db(&admin_url, &db_name).await?;
         let db = Db::connect(&db_url).await?;
         Ok((db, admin_url, db_name))
     }

--- a/relayer/src/worker.rs
+++ b/relayer/src/worker.rs
@@ -692,9 +692,21 @@ mod tests {
         Ok(())
     }
 
+    async fn create_db(admin_url: &str, db_name: &str) -> Result<()> {
+        let pool = PgPoolOptions::new()
+            .max_connections(1)
+            .connect(admin_url)
+            .await?;
+        let escaped = db_name.replace('"', "\"\"");
+        pool.execute(format!("CREATE DATABASE \"{escaped}\"").as_str())
+            .await?;
+        Ok(())
+    }
+
     async fn setup_db() -> Result<(Db, String, String)> {
         let (admin_url, db_url, db_name) = test_urls();
         drop_db(&admin_url, &db_name).await?;
+        create_db(&admin_url, &db_name).await?;
         let db = Db::connect(&db_url).await?;
         Ok((db, admin_url, db_name))
     }

--- a/synchronizer/src/sync_db.rs
+++ b/synchronizer/src/sync_db.rs
@@ -5,7 +5,6 @@ use sqlx::{
     postgres::{PgPoolOptions, PgRow},
     Executor, PgPool, Row,
 };
-use url::Url;
 
 use crate::{
     app_db::{db_bytes_to_hash, hash_to_db_bytes},
@@ -39,11 +38,13 @@ pub struct SyncDb {
 impl SyncDb {
     /// Connect to the synchronizer's Postgres metadata database.
     ///
+    /// The database must already exist — provisioning is an explicit operator
+    /// step so the app role does not need the `CREATEDB` privilege.
+    ///
     /// Postgres is the sole source of canonical heads. Each committed slot stores its
     /// `CanonicalHead`,
     /// while RocksDB only stores the content-addressed Merkle node/value backing store.
     pub async fn connect(database_url: &str) -> Result<Self> {
-        ensure_database_exists(database_url).await?;
         let pool = PgPoolOptions::new()
             .max_connections(5)
             .connect(database_url)
@@ -323,39 +324,6 @@ fn decode_head_row(row: &PgRow) -> Result<CanonicalHead> {
     })
 }
 
-/// Ensure target Postgres database exists (local/dev convenience).
-async fn ensure_database_exists(database_url: &str) -> Result<()> {
-    let parsed = Url::parse(database_url).with_context(|| "Invalid SYNC_METADATA_DB_URL value")?;
-    let db_name = parsed
-        .path_segments()
-        .and_then(|mut segments| segments.next_back())
-        .filter(|segment| !segment.is_empty())
-        .ok_or_else(|| anyhow!("SYNC_METADATA_DB_URL must include a database name"))?;
-
-    let mut admin_url = parsed.clone();
-    admin_url.set_path("/postgres");
-
-    let admin_pool = PgPoolOptions::new()
-        .max_connections(1)
-        .connect(admin_url.as_str())
-        .await
-        .with_context(|| "Failed to connect to postgres admin database")?;
-
-    let exists = sqlx::query_scalar::<_, i32>("SELECT 1 FROM pg_database WHERE datname = $1")
-        .bind(db_name)
-        .fetch_optional(&admin_pool)
-        .await?
-        .is_some();
-
-    if !exists {
-        let escaped = db_name.replace('"', "\"\"");
-        let create_stmt = format!("CREATE DATABASE \"{escaped}\"");
-        sqlx::query(&create_stmt).execute(&admin_pool).await?;
-    }
-
-    Ok(())
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -401,8 +369,21 @@ mod tests {
         (db_name, db_url, admin_url)
     }
 
+    async fn create_db(db_name: &str, admin_url: &str) -> Result<()> {
+        let pool = PgPoolOptions::new()
+            .max_connections(1)
+            .connect(admin_url)
+            .await?;
+        let escaped = db_name.replace('"', "\"\"");
+        sqlx::query(&format!("CREATE DATABASE \"{escaped}\""))
+            .execute(&pool)
+            .await?;
+        Ok(())
+    }
+
     async fn fresh_sync_db() -> Result<(SyncDb, String, String)> {
         let (db_name, db_url, admin_url) = test_urls();
+        create_db(&db_name, &admin_url).await?;
         let sync_db = SyncDb::connect(&db_url).await?;
         Ok((sync_db, db_name, admin_url))
     }


### PR DESCRIPTION
The synchronizer and relayer no longer `CREATE DATABASE` at startup — provisioning moves to an idempotent `just ensure-db` recipe (and `bootstrap.sh` in prod (no changes, we were already doing this)), so the DB role no longer needs the `CREATEDB` privilege.

Fixes https://github.com/dobjlabs/zk-craft/issues/61