### PR TITLE
fix ignored test_vdf_pod broken by pod2 statement-reveal API change

### DIFF
--- a/intro_pods/vdfpod/src/lib.rs
+++ b/intro_pods/vdfpod/src/lib.rs
@@ -830,7 +830,7 @@ mod tests {
         let mut main_pod_builder = frontend::MainPodBuilder::new(&params, vd_set);
         main_pod_builder.add_pod(main_vdf_pod.clone())?;
 
-        let _ = main_pod_builder.reveal(&main_vdf_pod.public_statements[0]);
+        main_pod_builder.open_input_st(true, 0, &main_vdf_pod.public_statements[0])?;
 
         let prover = pod2::backends::plonky2::mock::mainpod::MockProver {};
         let pod = main_pod_builder.prove(&prover)?;


### PR DESCRIPTION
`test_vdf_pod` was panicking with `index out of bounds: len is 0` at `pub_statements()[0]`: the outer MainPod had zero public statements.

`just test-ignored` now passes