### PR TITLE
Manage created index via Postgres for simpler reorg handling

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,7 +100,7 @@ Use `just` (recipes in `justfile`):
 - **`txlib/src/lib.rs`** — `StateRoot` (typed record), `GroundingWitness`, `Tx`, `TxBuilder`. No `Object` struct: object state is a `pod2::Dictionary` whose `identity` field is the commitment of its initial form (`with_identity`), stable across mutations.
 - **`txlib/src/predicates/txlib.podlang`** — the transaction state machine. See "txlib and the SDK" below.
 - **`synchronizer/src/state_machine.rs`** — `MAX_GSR_AGE_BLOCKS = 300`. Pure derivation: takes a base head + recent GSRs + decoded blob bytes; returns a candidate head.
-- **`synchronizer/src/api.rs`** — Axum routes (`/v1/state/head`, `/v1/state/membership`, `/v1/state/nullifier/contains`, `/v1/state/tx/contains`, `/v1/state/tx/{tx_hash}`, `/v1/txlib/grounding-witness`, plus `/healthz`, `/sync-progress`).
+- **`synchronizer/src/api.rs`** — Axum routes (`/v1/state/head`, `/v1/state/membership`, `/v1/state/object/contains`, `/v1/state/nullifier/contains`, `/v1/txlib/grounding-witness`, plus `/healthz`, `/sync-progress`).
 - **`common/src/shrink.rs`** — Plonky2 wrapper circuit that re-proves a MainPod in a smaller circuit so it fits in a blob.
 - **`common/src/payload.rs`** — blob payload encoding (`PAYLOAD_MAGIC`, proof type, `tx_final`, state root, nullifiers, and the `live` object commitments).
 - **`mcp/src/lib.rs`** — `DEFAULT_PORT = 7718`; crate is named `craft-mcp` (depend on it as `craft-mcp = { path = "../mcp" }`). dobjd runs MCP at `DOBJD_PORT + 1`.

--- a/synchronizer/README.md
+++ b/synchronizer/README.md
@@ -13,9 +13,10 @@ Service that tracks Digital Object blob transactions on Ethereum, derives canoni
    - finds blob txs sent to `TO_ADDRESS`
    - fetches matching blob sidecars
    - parses and verifies `TxFinalized` payloads
+   - prefetches the payloads' created-object commitments from the Postgres created index
    - opens the current Merkle containers from the canonical `CanonicalHead`
    - derives the next `CanonicalHead`
-4. Publishes the new canonical slot/head in Postgres and serves state/proof APIs for clients like `app-gui`.
+4. Publishes the new canonical slot/head and its created-index rows in one Postgres transaction, and serves state/proof APIs for clients like `app-gui`.
 
 ## State model
 
@@ -27,6 +28,7 @@ The synchronizer splits state into two layers:
 - Postgres stores the canonical control plane
   - canonical slot metadata
   - the canonical `CanonicalHead` for each slot
+  - the created index: object commitment -> position in the created array
 
 There is no canonical head stored in RocksDB, and no resident in-memory head/cache. Every slot derivation and API read loads the current canonical head from Postgres, then reopens the needed persistent containers from RocksDB by root.
 
@@ -35,14 +37,14 @@ There is no canonical head stored in RocksDB, and no resident in-memory head/cac
 `CanonicalHead` is the compact committed app-state snapshot stored on canonical slot rows. It is split into:
 
 - `CanonicalRoots`
-  - `transactions`
+  - `created`
   - `nullifiers`
   - `state_root_gsrs`
   - `gsr_history`
 - `HeadMetadata`
   - `current_gsr`
   - `current_block_number`
-  - `tx_count`
+  - `created_count`
   - `nullifier_count`
   - `gsr_count`
 
@@ -62,7 +64,7 @@ RocksDB stores:
 
 The Merkle-backed containers are:
 
-- transactions: persistent `Set`
+- created objects: persistent `Array` of object commitments (0-indexed)
 - nullifiers: persistent `Set`
 - GSR history: persistent `Array`
 
@@ -81,6 +83,14 @@ Postgres stores the canonical synchronization state:
   - if `start_slot - 1` was an empty beacon slot, its block fields remain `NULL`
   - includes `block_root`, `parent_root`, `execution_block_number`, `current_gsr`, `is_empty`
   - includes normalized `head_*` columns for the canonical `CanonicalHead` at that slot
+- `created_index`
+  - reverse index from object commitment to its position in the created array
+  - one row per created object: `commitment` (primary key), `array_index`, `slot`
+  - rows are inserted in the same transaction that commits their slot and
+    deleted in the same transaction that rolls the slot back, so the index
+    never diverges from the canonical head
+  - reads treat the index as a hint: every membership and proof answer
+    cross-checks it against the created array at the queried root
 
 Postgres is the sole source of canonical `CanonicalHead`. The highest committed
 `canonical_slots.slot` is the current canonical head.
@@ -92,14 +102,18 @@ For each decoded blob payload, the synchronizer:
 - skips blobs that do not decode into a valid `TxFinalized` proof
 - rejects payloads whose `state_root_hash` is not in recent canonical GSR history
 - rejects payloads whose grounding GSR is older than `MAX_GSR_AGE_BLOCKS` (currently 300)
-- rejects duplicate `tx_final`
+- rejects creation collisions: a created-object commitment that repeats within
+  the payload, repeats within the slot, or already exists in committed state
+  (prefetched from the created index and cross-checked against the created
+  array). This is what gives no-input (mining) txs their replay protection.
 - rejects duplicate/spent nullifiers
-- inserts accepted txs/nullifiers into the persistent sets
+- appends accepted object commitments to the created array and inserts
+  nullifiers into the persistent set
 
 After processing all blobs in the slot, it computes the next GSR from:
 
 - current execution block number
-- transactions set root
+- created array root
 - nullifiers set root
 - prior GSR-array root
 
@@ -114,6 +128,7 @@ Important: GSR history advances for each canonical processed slot, even if that 
 The synchronizer derives candidate state by mutating persistent containers in RocksDB. Once derivation succeeds, canonical publication is a single Postgres transaction:
 
 1. Insert the canonical slot row, including the normalized `head_*` columns
+2. Insert one `created_index` row per object commitment the slot added
 
 Because the Merkle nodes were already materialized during derivation, there is no second canonical write to RocksDB.
 
@@ -127,7 +142,8 @@ Because the Merkle nodes were already materialized during derivation, there is n
 On reorg:
 
 - the synchronizer finds the last common ancestor slot
-- deletes `canonical_slots` rows after the keep-point
+- deletes `canonical_slots` rows after the keep-point, and the `created_index`
+  rows those slots added, in one transaction
 - resumes syncing from the first divergent slot
 
 Reorg rollback does not modify RocksDB. The surviving Postgres `CanonicalHead` determines which Merkle roots are canonical after rewind.
@@ -144,25 +160,25 @@ Reorg rollback does not modify RocksDB. The surviving Postgres `CanonicalHead` d
     - `last_processed_block_number`
     - `current_gsr`
     - `current_block_number`
-    - `tx_count`
+    - `created_count`
     - `nullifier_count`
     - `gsr_count`
 - `POST /v1/state/membership`
   - request body:
-    - `tx_hashes` (array of hash strings)
+    - `object_commitments` (array of hash strings)
     - `nullifiers` (array of hash strings)
   - returns membership for both sets from one captured canonical head:
     - `last_processed_slot`
     - `current_gsr`
-    - `tx_results` (array of `{ tx_hash, present }`)
+    - `created_results` (array of `{ commitment, present }`)
     - `nullifier_results` (array of `{ nullifier, present }`)
-- `POST /v1/state/tx/contains`
+- `POST /v1/state/object/contains`
   - request body:
-    - `tx_hashes` (array of hash strings)
+    - `object_commitments` (array of hash strings)
   - returns:
     - `last_processed_slot`
     - `current_gsr`
-    - `results` (array of `{ tx_hash, present }`)
+    - `results` (array of `{ commitment, present }`)
 - `POST /v1/state/nullifier/contains`
   - request body:
     - `nullifiers` (array of hash strings)
@@ -170,24 +186,23 @@ Reorg rollback does not modify RocksDB. The surviving Postgres `CanonicalHead` d
     - `last_processed_slot`
     - `current_gsr`
     - `results` (array of `{ nullifier, present }`)
-- `GET /v1/state/tx/{tx_hash}`
-  - returns:
-    - `tx_hash`
-    - `present`
-    - `last_processed_slot`
-    - `current_gsr`
 - `POST /v1/txlib/grounding-witness`
   - request body:
-    - `sourceTxHashes` (array of hash strings)
+    - `objectCommitments` (array of hash strings)
   - returns:
     - `stateRootHash`
     - `blockNumber`
-    - `transactionsRoot`
+    - `createdRoot`
     - `nullifiersRoot`
     - `gsrsRoot`
-    - `sourceTxProofs` (array of `{ txHash, present, proof }`)
+    - `createdProofs` (array of `{ commitment, present, index, proof }`)
 
-Each request captures one current Postgres snapshot, then uses that exact `CanonicalHead` for all RocksDB membership/proof reads in the response.
+Membership and grounding-witness requests read the canonical head and the
+created index from one `REPEATABLE READ` Postgres transaction, so the index
+entries always match the captured head's roots. The RocksDB reads then run
+against those pinned roots; Merkle nodes are content-addressed and immutable
+by root, so a concurrent commit or rollback cannot change what the captured
+roots resolve to.
 
 Hash parsing accepts `0x`-prefixed or raw hex input; responses are normalized to lowercase `0x...`.
 

--- a/synchronizer/src/api.rs
+++ b/synchronizer/src/api.rs
@@ -302,14 +302,14 @@ fn grounding_witness(
     object_commitments: &[Hash],
     indices: &HashMap<Hash, i64>,
 ) -> anyhow::Result<GroundingWitnessSnapshot> {
-    let proofs = app_db.prove_created_for(roots, object_commitments, indices)?;
+    let witnesses = app_db.prove_created_for(roots, object_commitments, indices)?;
     let object_proofs = object_commitments
         .iter()
-        .zip(proofs)
-        .map(|(commitment, proof)| ObjectMembershipProof {
+        .zip(witnesses)
+        .map(|(commitment, witness)| ObjectMembershipProof {
             commitment: *commitment,
-            present: proof.present,
-            witness: proof.witness,
+            present: witness.is_some(),
+            witness,
         })
         .collect();
     Ok(GroundingWitnessSnapshot { object_proofs })

--- a/synchronizer/src/api.rs
+++ b/synchronizer/src/api.rs
@@ -302,18 +302,16 @@ fn grounding_witness(
     object_commitments: &[Hash],
     indices: &HashMap<Hash, i64>,
 ) -> anyhow::Result<GroundingWitnessSnapshot> {
+    let proofs = app_db.prove_created_for(roots, object_commitments, indices)?;
     let object_proofs = object_commitments
         .iter()
-        .map(|commitment| {
-            let (present, witness) =
-                app_db.prove_created_at(roots, *commitment, indices.get(commitment).copied())?;
-            Ok(ObjectMembershipProof {
-                commitment: *commitment,
-                present,
-                witness,
-            })
+        .zip(proofs)
+        .map(|(commitment, proof)| ObjectMembershipProof {
+            commitment: *commitment,
+            present: proof.present,
+            witness: proof.witness,
         })
-        .collect::<anyhow::Result<Vec<_>>>()?;
+        .collect();
     Ok(GroundingWitnessSnapshot { object_proofs })
 }
 

--- a/synchronizer/src/api.rs
+++ b/synchronizer/src/api.rs
@@ -1,4 +1,4 @@
-use std::{net::SocketAddr, sync::Arc};
+use std::{collections::HashMap, net::SocketAddr, sync::Arc};
 
 use anyhow::Result;
 use axum::{
@@ -212,14 +212,23 @@ async fn post_grounding_witness(
     Json(body): Json<GroundingWitnessRequest>,
 ) -> Result<Json<GroundingWitnessResponse>, (StatusCode, String)> {
     ensure_hash_query_limit("objectCommitments", body.object_commitments.len())?;
-    let snapshot = load_current_snapshot(&app_state).await?;
     let object_commitments = body
         .object_commitments
         .iter()
         .map(|raw| parse_hash_hex(raw))
         .collect::<Result<Vec<_>, _>>()?;
-    let witness = grounding_witness(&app_state.app_db, &snapshot.head.roots, &object_commitments)
+    let (snapshot, indices) = app_state
+        .sync_db
+        .snapshot_with_created_indices(&object_commitments)
+        .await
         .map_err(internal_error)?;
+    let witness = grounding_witness(
+        &app_state.app_db,
+        &snapshot.head.roots,
+        &object_commitments,
+        &indices,
+    )
+    .map_err(internal_error)?;
     let head = snapshot.head;
     let state_root = head.current_state_root().ok_or_else(|| {
         (
@@ -279,9 +288,10 @@ fn membership_snapshot(
     roots: &CanonicalRoots,
     object_commitments: &[Hash],
     nullifiers: &[Hash],
+    indices: &HashMap<Hash, i64>,
 ) -> anyhow::Result<MembershipSnapshot> {
     Ok(MembershipSnapshot {
-        created_present: app_db.created_exists_batch(roots, object_commitments)?,
+        created_present: app_db.created_exists_for(roots, object_commitments, indices)?,
         nullifier_present: app_db.nullifier_exists_batch(roots, nullifiers)?,
     })
 }
@@ -290,11 +300,13 @@ fn grounding_witness(
     app_db: &AppDb,
     roots: &CanonicalRoots,
     object_commitments: &[Hash],
+    indices: &HashMap<Hash, i64>,
 ) -> anyhow::Result<GroundingWitnessSnapshot> {
     let object_proofs = object_commitments
         .iter()
         .map(|commitment| {
-            let (present, witness) = app_db.prove_created(roots, *commitment)?;
+            let (present, witness) =
+                app_db.prove_created_at(roots, *commitment, indices.get(commitment).copied())?;
             Ok(ObjectMembershipProof {
                 commitment: *commitment,
                 present,
@@ -311,14 +323,19 @@ async fn load_membership_context(
     nullifiers: &[String],
 ) -> Result<MembershipContext, (StatusCode, String)> {
     ensure_membership_query_limit(object_commitments.len(), nullifiers.len())?;
-    let snapshot = load_current_snapshot(app_state).await?;
     let object_commitments = parse_hashes(object_commitments)?;
     let nullifiers = parse_hashes(nullifiers)?;
+    let (snapshot, indices) = app_state
+        .sync_db
+        .snapshot_with_created_indices(&object_commitments)
+        .await
+        .map_err(internal_error)?;
     let membership = membership_snapshot(
         &app_state.app_db,
         &snapshot.head.roots,
         &object_commitments,
         &nullifiers,
+        &indices,
     )
     .map_err(internal_error)?;
 

--- a/synchronizer/src/app_db.rs
+++ b/synchronizer/src/app_db.rs
@@ -35,6 +35,22 @@ pub fn created_array_holds(created: &Array, index: i64, commitment: Hash) -> Res
     Ok(created.get(index as usize)? == Some(Value::from(commitment)))
 }
 
+/// One commitment's authenticated membership result against the created `Array`:
+/// whether it is present, and the `(array index, ArrayContains proof)` when it is.
+pub struct CreatedProof {
+    pub present: bool,
+    pub witness: Option<(i64, MerkleProof)>,
+}
+
+impl CreatedProof {
+    fn absent() -> Self {
+        Self {
+            present: false,
+            witness: None,
+        }
+    }
+}
+
 #[derive(Clone)]
 pub struct AppDb {
     db: Arc<TransactionDB>,
@@ -71,26 +87,31 @@ impl AppDb {
         Ok(Array::from_db(root, self.db_box())?)
     }
 
-    /// `(index, membership proof)` for one object commitment against the created
-    /// `Array` at `roots.created`, or `(false, None)` when absent. `index` is the
-    /// candidate position prefetched from the Postgres created index; proving it
-    /// against the array is what authenticates membership.
-    pub fn prove_created_at(
+    /// Authenticated membership result for each object commitment against the
+    /// created `Array` at `roots.created`, using candidate indices prefetched
+    /// from the Postgres created index. A commitment with no index is absent;
+    /// otherwise proving the array leaf at its index is what authenticates
+    /// membership. The array is opened once for the whole batch.
+    pub fn prove_created_for(
         &self,
         roots: &CanonicalRoots,
-        obj_commitment: Hash,
-        index: Option<i64>,
-    ) -> Result<(bool, Option<(i64, MerkleProof)>)> {
-        let Some(index) = index else {
-            return Ok((false, None));
-        };
+        obj_commitments: &[Hash],
+        indices: &HashMap<Hash, i64>,
+    ) -> Result<Vec<CreatedProof>> {
         let created = self.open_created(roots.created)?;
-        match created.prove(index as usize) {
-            Ok((value, proof)) if value == Value::from(obj_commitment) => {
-                Ok((true, Some((index, proof))))
-            }
-            _ => Ok((false, None)),
-        }
+        obj_commitments
+            .iter()
+            .map(|commitment| match indices.get(commitment) {
+                None => Ok(CreatedProof::absent()),
+                Some(&index) => match created.prove(index as usize) {
+                    Ok((value, proof)) if value == Value::from(*commitment) => Ok(CreatedProof {
+                        present: true,
+                        witness: Some((index, proof)),
+                    }),
+                    _ => Ok(CreatedProof::absent()),
+                },
+            })
+            .collect()
     }
 
     /// Membership bits for `obj_commitments` against the created `Array` at
@@ -256,11 +277,12 @@ mod tests {
                 .unwrap(),
             vec![true]
         );
-        let (present, witness) = app_db
-            .prove_created_at(&roots, obj_commitment, Some(1))
+        let proofs = app_db
+            .prove_created_for(&roots, &[obj_commitment], &indices)
             .unwrap();
-        assert!(present);
-        assert_eq!(witness.map(|(index, _proof)| index), Some(0));
+        let proof = proofs.into_iter().next().unwrap();
+        assert!(proof.present);
+        assert_eq!(proof.witness.map(|(index, _proof)| index), Some(0));
 
         // A commitment with no index is absent, and an index the array root
         // does not actually contain resolves to absent too.

--- a/synchronizer/src/app_db.rs
+++ b/synchronizer/src/app_db.rs
@@ -35,22 +35,6 @@ pub fn created_array_holds(created: &Array, index: i64, commitment: Hash) -> Res
     Ok(created.get(index as usize)? == Some(Value::from(commitment)))
 }
 
-/// One commitment's authenticated membership result against the created `Array`:
-/// whether it is present, and the `(array index, ArrayContains proof)` when it is.
-pub struct CreatedProof {
-    pub present: bool,
-    pub witness: Option<(i64, MerkleProof)>,
-}
-
-impl CreatedProof {
-    fn absent() -> Self {
-        Self {
-            present: false,
-            witness: None,
-        }
-    }
-}
-
 #[derive(Clone)]
 pub struct AppDb {
     db: Arc<TransactionDB>,
@@ -87,28 +71,27 @@ impl AppDb {
         Ok(Array::from_db(root, self.db_box())?)
     }
 
-    /// Authenticated membership result for each object commitment against the
-    /// created `Array` at `roots.created`, using candidate indices prefetched
-    /// from the Postgres created index. A commitment with no index is absent;
-    /// otherwise proving the array leaf at its index is what authenticates
-    /// membership. The array is opened once for the whole batch.
+    /// Membership witness for each object commitment against the created `Array`
+    /// at `roots.created`: `Some((array index, ArrayContains proof))` when the
+    /// array authenticates the commitment at its prefetched index, `None` when
+    /// absent (no index, or a leaf mismatch). The array is opened once for the
+    /// whole batch.
     pub fn prove_created_for(
         &self,
         roots: &CanonicalRoots,
         obj_commitments: &[Hash],
         indices: &HashMap<Hash, i64>,
-    ) -> Result<Vec<CreatedProof>> {
+    ) -> Result<Vec<Option<(i64, MerkleProof)>>> {
         let created = self.open_created(roots.created)?;
         obj_commitments
             .iter()
             .map(|commitment| match indices.get(commitment) {
-                None => Ok(CreatedProof::absent()),
+                None => Ok(None),
                 Some(&index) => match created.prove(index as usize) {
-                    Ok((value, proof)) if value == Value::from(*commitment) => Ok(CreatedProof {
-                        present: true,
-                        witness: Some((index, proof)),
-                    }),
-                    _ => Ok(CreatedProof::absent()),
+                    Ok((value, proof)) if value == Value::from(*commitment) => {
+                        Ok(Some((index, proof)))
+                    }
+                    _ => Ok(None),
                 },
             })
             .collect()
@@ -269,7 +252,7 @@ mod tests {
             created: created.commitment(),
             ..CanonicalRoots::empty()
         };
-        let indices = HashMap::from([(obj_commitment, 1i64)]);
+        let indices = HashMap::from([(obj_commitment, 0i64)]);
 
         assert_eq!(
             app_db
@@ -277,12 +260,11 @@ mod tests {
                 .unwrap(),
             vec![true]
         );
-        let proofs = app_db
+        let witnesses = app_db
             .prove_created_for(&roots, &[obj_commitment], &indices)
             .unwrap();
-        let proof = proofs.into_iter().next().unwrap();
-        assert!(proof.present);
-        assert_eq!(proof.witness.map(|(index, _proof)| index), Some(0));
+        let witness = witnesses.into_iter().next().unwrap();
+        assert_eq!(witness.map(|(index, _proof)| index), Some(0));
 
         // A commitment with no index is absent, and an index the array root
         // does not actually contain resolves to absent too.

--- a/synchronizer/src/app_db.rs
+++ b/synchronizer/src/app_db.rs
@@ -1,4 +1,4 @@
-use std::{fmt, sync::Arc};
+use std::{collections::HashMap, fmt, sync::Arc};
 
 use anyhow::{anyhow, Context, Result};
 use pod2::{
@@ -27,11 +27,12 @@ fn value_key(raw: RawValue) -> Vec<u8> {
     k
 }
 
-fn created_index_key(commitment: Hash) -> Vec<u8> {
-    let mut k = Vec::with_capacity(35);
-    k.extend_from_slice(b"ci/");
-    k.extend_from_slice(&hash_to_db_bytes(commitment));
-    k
+/// Whether the created `Array` holds `commitment` at `index`: the leaf there
+/// must equal it. A prefetched index is only a hint until this confirms the
+/// array actually holds the commitment at that position, so the read path and
+/// the derivation collision check both call it to authenticate an index.
+pub fn created_array_holds(created: &Array, index: i64, commitment: Hash) -> Result<bool> {
+    Ok(created.get(index as usize)? == Some(Value::from(commitment)))
 }
 
 #[derive(Clone)]
@@ -70,42 +71,17 @@ impl AppDb {
         Ok(Array::from_db(root, self.db_box())?)
     }
 
-    /// Record an object commitment's position in the created `Array`.
-    ///
-    /// The cache is a plain `commitment -> index` map: not Merkleized, not part
-    /// of any committed root. It is only ever read as a hint -- every membership
-    /// or proof query cross-checks the index against the `Array` at the queried
-    /// root, so a stale entry (e.g. one left behind by an abandoned reorg branch)
-    /// resolves to "absent" rather than a wrong answer.
-    pub fn created_index_put(&self, commitment: Hash, index: i64) -> Result<()> {
-        self.db
-            .put(created_index_key(commitment), index.to_le_bytes())
-            .map_err(|err| anyhow!("rocksdb created-index put failed: {err}"))
-    }
-
-    pub fn created_index_get(&self, commitment: Hash) -> Result<Option<i64>> {
-        match self.db.get(created_index_key(commitment))? {
-            None => Ok(None),
-            Some(bytes) => {
-                let limbs: [u8; 8] = bytes
-                    .as_slice()
-                    .try_into()
-                    .map_err(|_| anyhow!("invalid created-index entry length"))?;
-                Ok(Some(i64::from_le_bytes(limbs)))
-            }
-        }
-    }
-
     /// `(index, membership proof)` for one object commitment against the created
-    /// `Array` at `roots.created`, or `(false, None)` when it is not present
-    /// there. The cache supplies the candidate index; proving it against the
-    /// array is what authenticates membership (and rejects stale cache hits).
-    pub fn prove_created(
+    /// `Array` at `roots.created`, or `(false, None)` when absent. `index` is the
+    /// candidate position prefetched from the Postgres created index; proving it
+    /// against the array is what authenticates membership.
+    pub fn prove_created_at(
         &self,
         roots: &CanonicalRoots,
         obj_commitment: Hash,
+        index: Option<i64>,
     ) -> Result<(bool, Option<(i64, MerkleProof)>)> {
-        let Some(index) = self.created_index_get(obj_commitment)? else {
+        let Some(index) = index else {
             return Ok((false, None));
         };
         let created = self.open_created(roots.created)?;
@@ -117,17 +93,23 @@ impl AppDb {
         }
     }
 
-    pub fn created_exists_batch(
+    /// Membership bits for `obj_commitments` against the created `Array` at
+    /// `roots.created`, using candidate indices prefetched from the Postgres
+    /// created index. A commitment with no index is absent; otherwise the array
+    /// leaf at its index must equal it -- the cross-check that authenticates the
+    /// index against the authoritative root.
+    pub fn created_exists_for(
         &self,
         roots: &CanonicalRoots,
         obj_commitments: &[Hash],
+        indices: &HashMap<Hash, i64>,
     ) -> Result<Vec<bool>> {
         let created = self.open_created(roots.created)?;
         obj_commitments
             .iter()
-            .map(|commitment| match self.created_index_get(*commitment)? {
+            .map(|commitment| match indices.get(commitment) {
                 None => Ok(false),
-                Some(index) => Ok(created.get(index as usize)? == Some(Value::from(*commitment))),
+                Some(&index) => created_array_holds(&created, index, *commitment),
             })
             .collect()
     }
@@ -256,39 +238,43 @@ mod tests {
     }
 
     #[test]
-    fn test_persistent_created_membership() {
+    fn test_created_membership_via_index() {
         let (app_db, _dir) = open_test_db();
         let mut created = app_db.open_created(EMPTY_HASH).unwrap();
         let obj_commitment = test_hash(9);
         created.insert(0, Value::from(obj_commitment)).unwrap();
-        app_db.created_index_put(obj_commitment, 0).unwrap();
 
         let roots = CanonicalRoots {
             created: created.commitment(),
             ..CanonicalRoots::empty()
         };
+        let indices = HashMap::from([(obj_commitment, 1i64)]);
 
         assert_eq!(
             app_db
-                .created_exists_batch(&roots, &[obj_commitment])
+                .created_exists_for(&roots, &[obj_commitment], &indices)
                 .unwrap(),
             vec![true]
         );
-        let (present, witness) = app_db.prove_created(&roots, obj_commitment).unwrap();
+        let (present, witness) = app_db
+            .prove_created_at(&roots, obj_commitment, Some(1))
+            .unwrap();
         assert!(present);
         assert_eq!(witness.map(|(index, _proof)| index), Some(0));
 
-        // A commitment never recorded in the cache is absent, and a cache hit
-        // that the array root does not actually contain resolves to absent too.
+        // A commitment with no index is absent, and an index the array root
+        // does not actually contain resolves to absent too.
         let absent = test_hash(7);
         assert_eq!(
-            app_db.created_exists_batch(&roots, &[absent]).unwrap(),
+            app_db
+                .created_exists_for(&roots, &[absent], &HashMap::new())
+                .unwrap(),
             vec![false]
         );
         let empty_roots = CanonicalRoots::empty();
         assert_eq!(
             app_db
-                .created_exists_batch(&empty_roots, &[obj_commitment])
+                .created_exists_for(&empty_roots, &[obj_commitment], &indices)
                 .unwrap(),
             vec![false]
         );

--- a/synchronizer/src/node.rs
+++ b/synchronizer/src/node.rs
@@ -46,71 +46,25 @@ struct SlotContext {
     has_blob_commitments: bool,
 }
 
-/// Fully-derived result for one slot, ready to be committed.
-pub struct ProcessedSlot {
-    pub slot: u32,
-    pub block_root: B256,
-    pub parent_root: B256,
-    pub block_number: Option<u32>,
-    pub is_empty: bool,
-    pub new_head: CanonicalHead,
-    /// Object commitments this slot added to `created`, keyed to their array
-    /// indices, persisted to the created index in the slot's commit transaction.
-    pub created_added: HashMap<Hash, i64>,
-}
-
-impl ProcessedSlot {
-    pub(crate) fn empty(
+/// Outcome of processing one beacon slot, ready to be committed.
+pub enum ProcessedSlot {
+    /// Beacon produced no block for the slot. With no execution block there is
+    /// nothing to derive against, so the previous canonical head is carried
+    /// forward unchanged, committed under the new slot number to keep canonical
+    /// slot history contiguous.
+    Missing {
         slot: u32,
-        block_root: B256,
-        parent_root: B256,
-        new_head: CanonicalHead,
-    ) -> Self {
-        Self {
-            slot,
-            block_root,
-            parent_root,
-            block_number: None,
-            is_empty: true,
-            new_head,
-            created_added: HashMap::new(),
-        }
-    }
-
-    fn present(
+        carried_head: CanonicalHead,
+    },
+    /// Beacon produced a block and the state machine derived the slot against
+    /// it (deriving a fresh GSR even when the block carries no usable blobs).
+    Present {
         slot: u32,
         block_root: B256,
         parent_root: B256,
         block_number: u32,
-        new_head: CanonicalHead,
-        created_added: HashMap<Hash, i64>,
-    ) -> Self {
-        Self {
-            slot,
-            block_root,
-            parent_root,
-            block_number: Some(block_number),
-            is_empty: false,
-            new_head,
-            created_added,
-        }
-    }
-
-    fn canonical_block_root(&self) -> Option<B256> {
-        (!self.is_empty).then_some(self.block_root)
-    }
-
-    fn canonical_parent_root(&self) -> Option<B256> {
-        (!self.is_empty).then_some(self.parent_root)
-    }
-
-    fn canonical_current_gsr(&self) -> Option<Hash> {
-        if self.is_empty {
-            None
-        } else {
-            self.new_head.metadata.current_gsr
-        }
-    }
+        derived: DerivedSlot,
+    },
 }
 
 impl Node {
@@ -283,14 +237,7 @@ impl Node {
         slot: u32,
     ) -> Result<CommittedSlotRecord> {
         let Some(header) = self.get_beacon_slot_header_with_retry(slot).await? else {
-            return Ok(CommittedSlotRecord {
-                slot,
-                block_root: None,
-                parent_root: None,
-                block_number: None,
-                current_gsr: None,
-                is_empty: true,
-            });
+            return Ok(CommittedSlotRecord::empty(slot));
         };
 
         let block = self
@@ -437,14 +384,13 @@ impl Node {
             let derived = self
                 .derive_slot(base_head, recent_gsrs, slot_ctx.slot, block_number, &[])
                 .await?;
-            return Ok(ProcessedSlot::present(
-                slot_ctx.slot,
-                slot_ctx.beacon_block_root,
-                slot_ctx.parent_root,
+            return Ok(ProcessedSlot::Present {
+                slot: slot_ctx.slot,
+                block_root: slot_ctx.beacon_block_root,
+                parent_root: slot_ctx.parent_root,
                 block_number,
-                derived.head,
-                derived.created_added,
-            ));
+                derived,
+            });
         }
 
         let mut blob_payloads = Vec::new();
@@ -500,14 +446,13 @@ impl Node {
             let derived = self
                 .derive_slot(base_head, recent_gsrs, slot_ctx.slot, block_number, &[])
                 .await?;
-            return Ok(ProcessedSlot::present(
-                slot_ctx.slot,
-                slot_ctx.beacon_block_root,
-                slot_ctx.parent_root,
+            return Ok(ProcessedSlot::Present {
+                slot: slot_ctx.slot,
+                block_root: slot_ctx.beacon_block_root,
+                parent_root: slot_ctx.parent_root,
                 block_number,
-                derived.head,
-                derived.created_added,
-            ));
+                derived,
+            });
         }
 
         let blob_versioned_hashes: Vec<B256> = indexed_do_blob_txs
@@ -564,30 +509,47 @@ impl Node {
             )
             .await?;
 
-        Ok(ProcessedSlot::present(
-            slot_ctx.slot,
-            slot_ctx.beacon_block_root,
-            slot_ctx.parent_root,
+        Ok(ProcessedSlot::Present {
+            slot: slot_ctx.slot,
+            block_root: slot_ctx.beacon_block_root,
+            parent_root: slot_ctx.parent_root,
             block_number,
-            derived.head,
-            derived.created_added,
-        ))
+            derived,
+        })
     }
 
-    /// Commit one derived slot to Postgres as the new canonical head, writing
+    /// Commit one processed slot to Postgres as the new canonical head, writing
     /// its created-index rows in the same transaction.
     pub async fn commit_slot(&self, processed: &ProcessedSlot) -> Result<()> {
-        let slot = CommittedSlotRecord {
-            slot: processed.slot,
-            block_root: processed.canonical_block_root(),
-            parent_root: processed.canonical_parent_root(),
-            block_number: processed.block_number,
-            current_gsr: processed.canonical_current_gsr(),
-            is_empty: processed.is_empty,
-        };
-
-        self.sync_db
-            .commit_slot(&slot, &processed.new_head, &processed.created_added)
-            .await
+        match processed {
+            ProcessedSlot::Missing { slot, carried_head } => {
+                self.sync_db
+                    .commit_slot(
+                        &CommittedSlotRecord::empty(*slot),
+                        carried_head,
+                        &HashMap::new(),
+                    )
+                    .await
+            }
+            ProcessedSlot::Present {
+                slot,
+                block_root,
+                parent_root,
+                block_number,
+                derived,
+            } => {
+                let record = CommittedSlotRecord {
+                    slot: *slot,
+                    block_root: Some(*block_root),
+                    parent_root: Some(*parent_root),
+                    block_number: Some(*block_number),
+                    current_gsr: derived.head.metadata.current_gsr,
+                    is_empty: false,
+                };
+                self.sync_db
+                    .commit_slot(&record, &derived.head, &derived.created_added)
+                    .await
+            }
+        }
     }
 }

--- a/synchronizer/src/node.rs
+++ b/synchronizer/src/node.rs
@@ -23,7 +23,7 @@ use tracing::{debug, info, trace, warn};
 
 use crate::config::AppConfig;
 use crate::head::CanonicalHead;
-use crate::state_machine::{StateMachine, MAX_GSR_AGE_BLOCKS};
+use crate::state_machine::{DerivedSlot, StateMachine, MAX_GSR_AGE_BLOCKS};
 use crate::sync_db::{CommittedSlotRecord, SyncDb};
 
 /// Runtime integration layer that connects network inputs (beacon/execution),
@@ -54,6 +54,9 @@ pub struct ProcessedSlot {
     pub block_number: Option<u32>,
     pub is_empty: bool,
     pub new_head: CanonicalHead,
+    /// Object commitments this slot added to `created`, with array indices,
+    /// persisted to the created index in the slot's commit transaction.
+    pub created_added: Vec<(Hash, i64)>,
 }
 
 impl ProcessedSlot {
@@ -70,6 +73,7 @@ impl ProcessedSlot {
             block_number: None,
             is_empty: true,
             new_head,
+            created_added: Vec::new(),
         }
     }
 
@@ -79,6 +83,7 @@ impl ProcessedSlot {
         parent_root: B256,
         block_number: u32,
         new_head: CanonicalHead,
+        created_added: Vec<(Hash, i64)>,
     ) -> Self {
         Self {
             slot,
@@ -87,6 +92,7 @@ impl ProcessedSlot {
             block_number: Some(block_number),
             is_empty: false,
             new_head,
+            created_added,
         }
     }
 
@@ -147,7 +153,8 @@ impl Node {
         self.sync_db.current_head().await
     }
 
-    /// Rewind to `keep_slot` by deleting later canonical slot rows.
+    /// Rewind to `keep_slot` by deleting later canonical slot rows; the created
+    /// index rows those slots added are pruned in the same Postgres transaction.
     pub async fn rollback_to_slot(&self, keep_slot: u32) -> Result<()> {
         self.sync_db.rollback_to_slot(keep_slot).await
     }
@@ -365,6 +372,40 @@ impl Node {
         self.derive_from_context(slot_ctx).await
     }
 
+    /// Parse the slot's blobs, prefetch the array positions of their created
+    /// commitments that already exist in canonical state, and derive the next
+    /// head.
+    ///
+    /// The prefetch is one batched query against the created index, mirroring how
+    /// `recent_gsrs` is prefetched, so the state machine never has to query the
+    /// database itself. It returns indices (not just a membership set) so the
+    /// state machine can cross-check each hit against the array at the base root.
+    async fn derive_slot(
+        &self,
+        base_head: CanonicalHead,
+        recent_gsrs: Vec<(Hash, i64)>,
+        slot: u32,
+        block_number: u32,
+        blob_payloads: &[(u32, Vec<u8>)],
+    ) -> Result<DerivedSlot> {
+        let parsed = self
+            .state_machine
+            .parse_blobs(blob_payloads, slot, block_number);
+        let candidates: Vec<Hash> = parsed
+            .iter()
+            .flat_map(|(_, payload)| payload.live.iter().copied())
+            .collect();
+        let prior_indices = self.sync_db.created_indices(&candidates).await?;
+        self.state_machine.derive_slot_head(
+            base_head,
+            recent_gsrs,
+            slot,
+            block_number,
+            &parsed,
+            &prior_indices,
+        )
+    }
+
     /// Shared derivation logic: given an already-resolved `SlotContext`, fetch execution data
     /// as needed, run the state machine, and return the processed slot.
     async fn derive_from_context(&self, slot_ctx: SlotContext) -> Result<ProcessedSlot> {
@@ -393,19 +434,16 @@ impl Node {
 
         if !slot_ctx.has_blob_commitments {
             debug!(slot = slot_ctx.slot, "Slot has no blob commitments");
-            let new_head = self.state_machine.derive_slot_head(
-                base_head,
-                recent_gsrs,
-                slot_ctx.slot,
-                block_number,
-                &[],
-            )?;
+            let derived = self
+                .derive_slot(base_head, recent_gsrs, slot_ctx.slot, block_number, &[])
+                .await?;
             return Ok(ProcessedSlot::present(
                 slot_ctx.slot,
                 slot_ctx.beacon_block_root,
                 slot_ctx.parent_root,
                 block_number,
-                new_head,
+                derived.head,
+                derived.created_added,
             ));
         }
 
@@ -459,19 +497,16 @@ impl Node {
                 to_address = ?self.config.to_address,
                 "No matching target blob transactions in execution block"
             );
-            let new_head = self.state_machine.derive_slot_head(
-                base_head,
-                recent_gsrs,
-                slot_ctx.slot,
-                block_number,
-                &[],
-            )?;
+            let derived = self
+                .derive_slot(base_head, recent_gsrs, slot_ctx.slot, block_number, &[])
+                .await?;
             return Ok(ProcessedSlot::present(
                 slot_ctx.slot,
                 slot_ctx.beacon_block_root,
                 slot_ctx.parent_root,
                 block_number,
-                new_head,
+                derived.head,
+                derived.created_added,
             ));
         }
 
@@ -519,24 +554,28 @@ impl Node {
             }
         }
 
-        let new_head = self.state_machine.derive_slot_head(
-            base_head,
-            recent_gsrs,
-            slot_ctx.slot,
-            block_number,
-            &blob_payloads,
-        )?;
+        let derived = self
+            .derive_slot(
+                base_head,
+                recent_gsrs,
+                slot_ctx.slot,
+                block_number,
+                &blob_payloads,
+            )
+            .await?;
 
         Ok(ProcessedSlot::present(
             slot_ctx.slot,
             slot_ctx.beacon_block_root,
             slot_ctx.parent_root,
             block_number,
-            new_head,
+            derived.head,
+            derived.created_added,
         ))
     }
 
-    /// Commit one derived slot to Postgres as the new canonical head.
+    /// Commit one derived slot to Postgres as the new canonical head, writing
+    /// its created-index rows in the same transaction.
     pub async fn commit_slot(&self, processed: &ProcessedSlot) -> Result<()> {
         let slot = CommittedSlotRecord {
             slot: processed.slot,
@@ -547,6 +586,8 @@ impl Node {
             is_empty: processed.is_empty,
         };
 
-        self.sync_db.commit_slot(&slot, &processed.new_head).await
+        self.sync_db
+            .commit_slot(&slot, &processed.new_head, &processed.created_added)
+            .await
     }
 }

--- a/synchronizer/src/node.rs
+++ b/synchronizer/src/node.rs
@@ -54,9 +54,9 @@ pub struct ProcessedSlot {
     pub block_number: Option<u32>,
     pub is_empty: bool,
     pub new_head: CanonicalHead,
-    /// Object commitments this slot added to `created`, with array indices,
-    /// persisted to the created index in the slot's commit transaction.
-    pub created_added: Vec<(Hash, i64)>,
+    /// Object commitments this slot added to `created`, keyed to their array
+    /// indices, persisted to the created index in the slot's commit transaction.
+    pub created_added: HashMap<Hash, i64>,
 }
 
 impl ProcessedSlot {
@@ -73,7 +73,7 @@ impl ProcessedSlot {
             block_number: None,
             is_empty: true,
             new_head,
-            created_added: Vec::new(),
+            created_added: HashMap::new(),
         }
     }
 
@@ -83,7 +83,7 @@ impl ProcessedSlot {
         parent_root: B256,
         block_number: u32,
         new_head: CanonicalHead,
-        created_added: Vec<(Hash, i64)>,
+        created_added: HashMap<Hash, i64>,
     ) -> Self {
         Self {
             slot,

--- a/synchronizer/src/state_machine.rs
+++ b/synchronizer/src/state_machine.rs
@@ -536,7 +536,7 @@ mod tests {
             &HashMap::new(),
         );
         assert_eq!(derived.head.metadata.created_count, 1);
-        assert_eq!(derived.created_added.get(&dup), Some(&1));
+        assert_eq!(derived.created_added.get(&dup), Some(&0));
     }
 
     #[test]
@@ -554,6 +554,6 @@ mod tests {
         let blob = mock_txn_bytes(unique_hash(61), &[], &[obj], gsr0);
         let derived = derive(&sm, head0, [(gsr0, 0)], 1, 1, &[(0, blob)], &phantom);
         assert_eq!(derived.head.metadata.created_count, 1);
-        assert_eq!(derived.created_added.get(&obj), Some(&1));
+        assert_eq!(derived.created_added.get(&obj), Some(&0));
     }
 }

--- a/synchronizer/src/state_machine.rs
+++ b/synchronizer/src/state_machine.rs
@@ -4,12 +4,12 @@ use std::{
 };
 
 use anyhow::{Context, Result};
-use common::{encode_hash_hex, proof::BlobParser};
+use common::{encode_hash_hex, payload::Payload, proof::BlobParser};
 use pod2::middleware::{containers::Array, containers::Set, Hash, Value};
 use tracing::{info, warn};
 
 use crate::{
-    app_db::AppDb,
+    app_db::{created_array_holds, AppDb},
     head::{CanonicalHead, CanonicalRoots, HeadMetadata},
 };
 use txlib::StateRoot;
@@ -34,6 +34,42 @@ struct WorkingState {
     gsr_history: Array,
     /// Recent canonical GSRs keyed by hash for grounding validation.
     recent_gsrs: HashMap<Hash, i64>,
+    /// Commitments this slot appended to `created`, with their array indices.
+    /// The persistent index is not written here; the caller persists these to
+    /// the created index in the slot's commit transaction.
+    created_added: CreatedAdditions,
+}
+
+/// Objects an in-progress slot has appended to `created`, paired with a
+/// membership view of the same set. `record` is the only writer, so the ordered
+/// list and the lookup set cannot drift apart.
+///
+/// The lookup set answers within-slot duplicate detection: the persistent
+/// created index reflects only committed slots, so it cannot see objects added
+/// earlier in this same slot.
+#[derive(Default)]
+struct CreatedAdditions {
+    added: Vec<(Hash, i64)>,
+    seen: HashSet<Hash>,
+}
+
+impl CreatedAdditions {
+    fn record(&mut self, commitment: Hash, index: i64) {
+        self.added.push((commitment, index));
+        self.seen.insert(commitment);
+    }
+
+    fn contains(&self, commitment: &Hash) -> bool {
+        self.seen.contains(commitment)
+    }
+}
+
+/// One slot's derivation result: the candidate next canonical head plus the
+/// object commitments (with array indices) it appended to `created`. The caller
+/// persists the additions to the created index when committing the slot.
+pub struct DerivedSlot {
+    pub head: CanonicalHead,
+    pub created_added: Vec<(Hash, i64)>,
 }
 
 /// Domain logic for the synchronizer: proof verification, state validation, and Merkle storage.
@@ -42,7 +78,8 @@ struct WorkingState {
 /// Callers supply the `CanonicalHead` they want to operate against, and Postgres remains the sole
 /// source of truth for which head is canonical.
 pub struct StateMachine {
-    /// RocksDB-backed app-state store used to open persistent containers and prove membership.
+    /// RocksDB-backed app-state store used to open the created, nullifier, and
+    /// GSR containers during derivation.
     app_db: AppDb,
     /// Blob parser/verifier used to decode TxFinalized payloads from blob bytes.
     proof_parser: Arc<dyn BlobParser>,
@@ -56,60 +93,70 @@ impl StateMachine {
         }
     }
 
-    /// Parse and validate one blob payload against the in-progress slot state.
+    /// Parse and verify each blob as a `TxFinalized` payload, returning the
+    /// valid ones in order.
     ///
-    /// This is the core per-blob derivation step used by `derive_slot_head`.
-    /// The method is intentionally fail-soft for invalid blob contents: malformed payloads,
-    /// proofs grounded in unknown/too-old GSRs, duplicate transactions, and duplicate
-    /// nullifiers are logged and skipped rather than aborting the whole slot.
+    /// Fail-soft: malformed or unverifiable blobs are logged and skipped, never
+    /// aborting the slot. Verification happens here once so the parsed payloads
+    /// can be reused for both the existence prefetch (the caller queries the
+    /// created index for their `live` commitments) and the apply pass in
+    /// `derive_slot_head`. Each kept payload carries its originating blob index
+    /// so the apply pass can attribute a hard error to the right blob.
+    pub fn parse_blobs(
+        &self,
+        blob_payloads: &[(u32, Vec<u8>)],
+        slot: u32,
+        block_number: u32,
+    ) -> Vec<(u32, Payload)> {
+        let mut parsed = Vec::with_capacity(blob_payloads.len());
+        for (blob_index, bytes) in blob_payloads {
+            match self.proof_parser.parse_blob(bytes) {
+                Ok(Some(payload)) => parsed.push((*blob_index, payload)),
+                Ok(None) => info!(
+                    slot,
+                    block_number,
+                    blob_index,
+                    "Blob did not contain a valid TxFinalized proof; skipping"
+                ),
+                Err(err) => warn!(
+                    slot,
+                    block_number,
+                    blob_index,
+                    ?err,
+                    "Failed to parse/verify TxFinalized payload; skipping blob"
+                ),
+            }
+        }
+        parsed
+    }
+
+    /// Validate one already-parsed payload against the in-progress slot state and
+    /// apply it, or skip it (fail-soft) on a grounding or duplicate violation.
     ///
     /// Validation order:
-    /// 1. Parse and verify the blob as a `TxFinalized` payload via `proof_parser`
-    /// 2. Check that `payload.state_root_hash` exists in the recent canonical GSR cache
-    /// 3. Enforce the maximum grounding age window (`MAX_GSR_AGE_BLOCKS`)
-    /// 4. Reject duplicate created-object commitments both within the payload and against the
-    ///    in-progress created set: a tx that creates an object that already exists fails the same
-    ///    way a nullifier double-spend does. This is also what gives no-input (mining) txs their
+    /// 1. `payload.state_root_hash` must exist in the recent canonical GSR window
+    /// 2. that grounding must be within `MAX_GSR_AGE_BLOCKS`
+    /// 3. created-object commitments must not collide -- within the payload, with
+    ///    objects added earlier this slot, or with prior committed state
+    ///    (`prior_indices`, prefetched from the created index and cross-checked
+    ///    against the array). This is what gives no-input (mining) txs their
     ///    replay protection.
-    /// 5. Reject duplicate nullifiers both within the payload and against the in-progress
-    ///    nullifiers set, which starts from canonical state and includes earlier accepted blobs
+    /// 4. nullifiers must not collide within the payload or with the in-progress
+    ///    nullifier set
     ///
-    /// If all checks pass, the method mutates the slot-local `WorkingState` by:
-    /// - appending each created-object commitment to the persistent in-progress created array
-    ///   and recording its index in the reverse-index cache
-    /// - inserting each nullifier into the persistent in-progress nullifiers set handle
-    /// - incrementing the corresponding counts in `state.metadata`
-    ///
-    /// No new canonical head is committed here. Mutating the persistent container handles may
-    /// materialize Merkle nodes/values in RocksDB, but the canonical state changes only if the
-    /// caller later publishes the resulting `CanonicalHead` in Postgres.
-    fn process_blob(
+    /// On success it appends each created commitment to the in-progress array
+    /// (recording the addition in `created_added`), inserts each nullifier, and
+    /// bumps the counts. Mutating the container handles may materialize Merkle
+    /// nodes in RocksDB, but nothing becomes canonical until the caller commits
+    /// the resulting head.
+    fn apply_payload(
         &self,
         state: &mut WorkingState,
-        bytes: &[u8],
+        payload: &Payload,
+        prior_indices: &HashMap<Hash, i64>,
         slot: u32,
         block_number: u32,
     ) -> Result<()> {
-        let payload = match self.proof_parser.parse_blob(bytes) {
-            Ok(Some(payload)) => payload,
-            Ok(None) => {
-                info!(
-                    slot,
-                    block_number, "Blob did not contain a valid TxFinalized proof; skipping"
-                );
-                return Ok(());
-            }
-            Err(err) => {
-                warn!(
-                    slot,
-                    block_number,
-                    ?err,
-                    "Failed to parse/verify TxFinalized payload; skipping blob"
-                );
-                return Ok(());
-            }
-        };
-
         let Some(&gsr_block) = state.recent_gsrs.get(&payload.state_root_hash) else {
             warn!(
                 slot,
@@ -118,8 +165,7 @@ impl StateMachine {
             );
             return Ok(());
         };
-        let current_block = i64::from(block_number);
-        let age = current_block - gsr_block;
+        let age = i64::from(block_number) - gsr_block;
         if age > MAX_GSR_AGE_BLOCKS {
             warn!(
                 slot,
@@ -139,7 +185,7 @@ impl StateMachine {
                 );
                 return Ok(());
             }
-            if self.is_created(state, *obj)? {
+            if self.already_created(state, prior_indices, obj)? {
                 warn!(
                     slot,
                     block_number, "Created object already exists (creation collision); rejecting"
@@ -168,7 +214,7 @@ impl StateMachine {
             // `created_count`, which doubles as the true object count.
             let index = state.metadata.created_count as usize;
             state.created.insert(index, Value::from(*obj))?;
-            self.app_db.created_index_put(*obj, index as i64)?;
+            state.created_added.record(*obj, index as i64);
             state.metadata.created_count += 1;
         }
         for nullifier in &payload.nullifiers {
@@ -186,33 +232,45 @@ impl StateMachine {
         Ok(())
     }
 
-    /// Whether `commitment` is already in the in-progress created set. The cache
-    /// gives a candidate index; the in-progress array is the authority, so a
-    /// stale cache hit (pointing at an index this array does not hold, or holds
-    /// a different commitment at) correctly reads as "not created".
-    fn is_created(&self, state: &WorkingState, commitment: Hash) -> Result<bool> {
-        match self.app_db.created_index_get(commitment)? {
+    /// Whether `obj` already exists as of the in-progress slot state: it was
+    /// either added earlier this slot, or the prefetched created index points at
+    /// a position the array at the base root actually holds it in. Re-reading the
+    /// array rejects a phantom index entry (one the root does not contain), so a
+    /// stale index never wrongly rejects a legitimate creation.
+    fn already_created(
+        &self,
+        state: &WorkingState,
+        prior_indices: &HashMap<Hash, i64>,
+        obj: &Hash,
+    ) -> Result<bool> {
+        if state.created_added.contains(obj) {
+            return Ok(true);
+        }
+        match prior_indices.get(obj) {
+            Some(&index) => created_array_holds(&state.created, index, *obj),
             None => Ok(false),
-            Some(index) => Ok(state.created.get(index as usize)? == Some(Value::from(commitment))),
         }
     }
 
-    /// Derive the next canonical head for one execution slot from a caller-provided base head.
+    /// Derive the next canonical head for one execution slot from a caller
+    /// provided base head and the slot's already-parsed payloads.
     ///
-    /// This method is the slot-level orchestration layer around `process_blob`.
     /// It:
     /// - reopens the persistent created-object, nullifiers, and GSR-history containers from
     ///   `base_head.roots`
     /// - seeds the per-slot `WorkingState` with the caller-provided recent-GSR window
-    /// - feeds every decoded blob payload through `process_blob`, accumulating accepted updates
-    ///   in the in-progress container handles
+    /// - applies every payload via `apply_payload`, using `prior_indices` (the created-object
+    ///   commitments already canonical as of the base head, with their array positions,
+    ///   prefetched from the created index) for the creation-collision check
     /// - computes the next GSR from the updated created/nullifiers roots and the prior
     ///   GSR-history root committed into the resulting `StateRoot`
     /// - appends that new GSR to the full history array and returns the resulting `CanonicalHead`
+    ///   together with the object commitments this slot added, as a `DerivedSlot`
     ///
     /// The returned head is only a candidate next canonical state. By the time this method
     /// returns, RocksDB may already contain Merkle nodes for the derived containers, but the
-    /// head does not become canonical until the caller persists it in Postgres.
+    /// head does not become canonical until the caller persists it (and the `created_added`
+    /// index rows) in Postgres.
     ///
     /// Empty or fully rejected slots still produce a new head with the same created and
     /// nullifiers roots as `base_head`, but with a newly derived `current_gsr` and an appended
@@ -223,23 +281,22 @@ impl StateMachine {
         recent_gsrs: impl IntoIterator<Item = (Hash, i64)>,
         slot: u32,
         block_number: u32,
-        blob_payloads: &[(u32, Vec<u8>)],
-    ) -> Result<CanonicalHead> {
+        payloads: &[(u32, Payload)],
+        prior_indices: &HashMap<Hash, i64>,
+    ) -> Result<DerivedSlot> {
         let mut working = WorkingState {
             metadata: base_head.metadata,
             created: self.app_db.open_created(base_head.roots.created)?,
             nullifiers: self.app_db.open_nullifiers(base_head.roots.nullifiers)?,
             gsr_history: self.app_db.open_gsr_history(base_head.roots.gsr_history)?,
             recent_gsrs: recent_gsrs.into_iter().collect(),
+            created_added: CreatedAdditions::default(),
         };
 
-        for (blob_index, bytes) in blob_payloads {
-            self.process_blob(&mut working, bytes, slot, block_number)
+        for (blob_index, payload) in payloads {
+            self.apply_payload(&mut working, payload, prior_indices, slot, block_number)
                 .with_context(|| {
-                    format!(
-                        "Failed to process blob at slot {}, blob_index {}",
-                        slot, blob_index
-                    )
+                    format!("applying blob at slot {slot}, blob_index {blob_index}")
                 })?;
         }
 
@@ -279,7 +336,10 @@ impl StateMachine {
             "Slot data"
         );
 
-        Ok(new_head)
+        Ok(DerivedSlot {
+            head: new_head,
+            created_added: working.created_added.added,
+        })
     }
 
     pub fn log_current_state(&self, head: CanonicalHead) {
@@ -342,16 +402,42 @@ mod tests {
     }
 
     fn seed_gsr0(sm: &StateMachine) -> CanonicalHead {
-        sm.derive_slot_head(CanonicalHead::empty(), [], 0, 0, &[])
+        sm.derive_slot_head(CanonicalHead::empty(), [], 0, 0, &[], &HashMap::new())
             .unwrap()
+            .head
+    }
+
+    /// Parse blobs and derive one slot in one step (mirroring `Node::derive_slot`
+    /// minus the Postgres existence prefetch, which tests supply directly).
+    fn derive(
+        sm: &StateMachine,
+        base_head: CanonicalHead,
+        recent_gsrs: impl IntoIterator<Item = (Hash, i64)>,
+        slot: u32,
+        block_number: u32,
+        blobs: &[(u32, Vec<u8>)],
+        prior_indices: &HashMap<Hash, i64>,
+    ) -> DerivedSlot {
+        let parsed = sm.parse_blobs(blobs, slot, block_number);
+        sm.derive_slot_head(
+            base_head,
+            recent_gsrs,
+            slot,
+            block_number,
+            &parsed,
+            prior_indices,
+        )
+        .unwrap()
+    }
+
+    fn index_of(added: &[(Hash, i64)]) -> HashMap<Hash, i64> {
+        added.iter().copied().collect()
     }
 
     #[test]
     fn test_empty_slot_produces_new_head() {
         let (sm, _app_db, _dir) = make_sm();
-        let head = sm
-            .derive_slot_head(CanonicalHead::empty(), [], 1, 7, &[])
-            .unwrap();
+        let head = derive(&sm, CanonicalHead::empty(), [], 1, 7, &[], &HashMap::new()).head;
         assert_eq!(head.metadata.current_block_number, Some(7));
         assert_eq!(head.metadata.gsr_count, 1);
     }
@@ -366,11 +452,10 @@ mod tests {
         let nullifier = unique_hash(11);
         let live_obj = unique_hash(12);
         let blob = mock_txn_bytes(tx_final, &[nullifier], &[live_obj], gsr0);
-        let head1 = sm
-            .derive_slot_head(head0, [(gsr0, 0)], 1, 1, &[(0, blob)])
-            .unwrap();
+        let derived = derive(&sm, head0, [(gsr0, 0)], 1, 1, &[(0, blob)], &HashMap::new());
+        let head1 = derived.head;
         let created_present = app_db
-            .created_exists_batch(&head1.roots, &[live_obj])
+            .created_exists_for(&head1.roots, &[live_obj], &index_of(&derived.created_added))
             .unwrap();
         let nullifier_present = app_db
             .nullifier_exists_batch(&head1.roots, &[nullifier])
@@ -390,27 +475,29 @@ mod tests {
 
         let tx_final = unique_hash(21);
         let blob = mock_txn_bytes(tx_final, &[], &[unique_hash(22)], unique_hash(99));
-        let head1 = sm.derive_slot_head(head0, [], 2, 2, &[(0, blob)]).unwrap();
+        let head1 = derive(&sm, head0, [], 2, 2, &[(0, blob)], &HashMap::new()).head;
         assert_eq!(head1.metadata.created_count, head0.metadata.created_count);
     }
 
     #[test]
-    fn test_uncommitted_derived_nodes_do_not_affect_old_head() {
+    fn test_membership_is_scoped_to_head_root() {
         let (sm, app_db, _dir) = make_sm();
         let head0 = seed_gsr0(&sm);
         let gsr0 = head0.metadata.current_gsr.unwrap();
 
-        let tx_final = unique_hash(31);
         let live_obj = unique_hash(32);
-        let blob = mock_txn_bytes(tx_final, &[], &[live_obj], gsr0);
-        let head1 = sm
-            .derive_slot_head(head0, [(gsr0, 0)], 1, 1, &[(0, blob)])
-            .unwrap();
+        let blob = mock_txn_bytes(unique_hash(31), &[], &[live_obj], gsr0);
+        let derived = derive(&sm, head0, [(gsr0, 0)], 1, 1, &[(0, blob)], &HashMap::new());
+        let head1 = derived.head;
+        let indices = index_of(&derived.created_added);
+
+        // The same index cross-checks against each head's root: present under
+        // the new head, absent under the old.
         let old_membership = app_db
-            .created_exists_batch(&head0.roots, &[live_obj])
+            .created_exists_for(&head0.roots, &[live_obj], &indices)
             .unwrap();
         let new_membership = app_db
-            .created_exists_batch(&head1.roots, &[live_obj])
+            .created_exists_for(&head1.roots, &[live_obj], &indices)
             .unwrap();
 
         assert_eq!(old_membership, vec![false]);
@@ -425,18 +512,68 @@ mod tests {
 
         let live_obj = unique_hash(40);
         let blob1 = mock_txn_bytes(unique_hash(41), &[], &[live_obj], gsr0);
-        let head1 = sm
-            .derive_slot_head(head0, [(gsr0, 0)], 1, 1, &[(0, blob1)])
-            .unwrap();
+        let derived1 = derive(
+            &sm,
+            head0,
+            [(gsr0, 0)],
+            1,
+            1,
+            &[(0, blob1)],
+            &HashMap::new(),
+        );
+        let head1 = derived1.head;
         assert_eq!(head1.metadata.created_count, 1);
 
-        // A second tx that re-creates the same object is rejected, exactly
-        // like a nullifier double-spend.
+        // A second tx in a later slot re-creates the same object. In production
+        // slot 1's index row is committed; here it is passed as prior-existing.
         let gsr1 = head1.metadata.current_gsr.unwrap();
+        let prior_indices = index_of(&derived1.created_added);
         let blob2 = mock_txn_bytes(unique_hash(42), &[], &[live_obj], gsr1);
-        let head2 = sm
-            .derive_slot_head(head1, [(gsr1, 1)], 2, 2, &[(0, blob2)])
-            .unwrap();
+        let head2 = derive(&sm, head1, [(gsr1, 1)], 2, 2, &[(0, blob2)], &prior_indices).head;
         assert_eq!(head2.metadata.created_count, head1.metadata.created_count);
+    }
+
+    #[test]
+    fn test_rejects_duplicate_created_object_within_slot() {
+        let (sm, _app_db, _dir) = make_sm();
+        let head0 = seed_gsr0(&sm);
+        let gsr0 = head0.metadata.current_gsr.unwrap();
+
+        // Two blobs in one slot create the same object; the second is rejected
+        // via the in-slot view, with no prior committed state.
+        let dup = unique_hash(50);
+        let blob_a = mock_txn_bytes(unique_hash(51), &[], &[dup], gsr0);
+        let blob_b = mock_txn_bytes(unique_hash(52), &[], &[dup], gsr0);
+        let derived = derive(
+            &sm,
+            head0,
+            [(gsr0, 0)],
+            1,
+            1,
+            &[(0, blob_a), (1, blob_b)],
+            &HashMap::new(),
+        );
+        assert_eq!(derived.head.metadata.created_count, 1);
+        assert_eq!(derived.created_added.len(), 1);
+        assert_eq!(derived.created_added[0].0, dup);
+    }
+
+    #[test]
+    fn test_phantom_prior_index_does_not_reject_creation() {
+        let (sm, _app_db, _dir) = make_sm();
+        let head0 = seed_gsr0(&sm);
+        let gsr0 = head0.metadata.current_gsr.unwrap();
+
+        // The prefetched index claims this object exists at index 1, but the
+        // array at the base root does not actually hold it (a phantom/stale
+        // entry). The array cross-check must treat it as absent and accept the
+        // creation rather than rejecting a legitimate object.
+        let obj = unique_hash(60);
+        let phantom = HashMap::from([(obj, 1i64)]);
+        let blob = mock_txn_bytes(unique_hash(61), &[], &[obj], gsr0);
+        let derived = derive(&sm, head0, [(gsr0, 0)], 1, 1, &[(0, blob)], &phantom);
+        assert_eq!(derived.head.metadata.created_count, 1);
+        assert_eq!(derived.created_added.len(), 1);
+        assert_eq!(derived.created_added[0].0, obj);
     }
 }

--- a/synchronizer/src/state_machine.rs
+++ b/synchronizer/src/state_machine.rs
@@ -34,34 +34,12 @@ struct WorkingState {
     gsr_history: Array,
     /// Recent canonical GSRs keyed by hash for grounding validation.
     recent_gsrs: HashMap<Hash, i64>,
-    /// Commitments this slot appended to `created`, with their array indices.
-    /// The persistent index is not written here; the caller persists these to
+    /// Commitments this slot appended to `created`, keyed to their array
+    /// indices. Doubles as the within-slot duplicate check: the persistent
+    /// created index reflects only committed slots, so it cannot see objects
+    /// added earlier in this same slot. The caller persists these entries to
     /// the created index in the slot's commit transaction.
-    created_added: CreatedAdditions,
-}
-
-/// Objects an in-progress slot has appended to `created`, paired with a
-/// membership view of the same set. `record` is the only writer, so the ordered
-/// list and the lookup set cannot drift apart.
-///
-/// The lookup set answers within-slot duplicate detection: the persistent
-/// created index reflects only committed slots, so it cannot see objects added
-/// earlier in this same slot.
-#[derive(Default)]
-struct CreatedAdditions {
-    added: Vec<(Hash, i64)>,
-    seen: HashSet<Hash>,
-}
-
-impl CreatedAdditions {
-    fn record(&mut self, commitment: Hash, index: i64) {
-        self.added.push((commitment, index));
-        self.seen.insert(commitment);
-    }
-
-    fn contains(&self, commitment: &Hash) -> bool {
-        self.seen.contains(commitment)
-    }
+    created_added: HashMap<Hash, i64>,
 }
 
 /// One slot's derivation result: the candidate next canonical head plus the
@@ -69,7 +47,7 @@ impl CreatedAdditions {
 /// persists the additions to the created index when committing the slot.
 pub struct DerivedSlot {
     pub head: CanonicalHead,
-    pub created_added: Vec<(Hash, i64)>,
+    pub created_added: HashMap<Hash, i64>,
 }
 
 /// Domain logic for the synchronizer: proof verification, state validation, and Merkle storage.
@@ -214,7 +192,7 @@ impl StateMachine {
             // `created_count`, which doubles as the true object count.
             let index = state.metadata.created_count as usize;
             state.created.insert(index, Value::from(*obj))?;
-            state.created_added.record(*obj, index as i64);
+            state.created_added.insert(*obj, index as i64);
             state.metadata.created_count += 1;
         }
         for nullifier in &payload.nullifiers {
@@ -243,7 +221,7 @@ impl StateMachine {
         prior_indices: &HashMap<Hash, i64>,
         obj: &Hash,
     ) -> Result<bool> {
-        if state.created_added.contains(obj) {
+        if state.created_added.contains_key(obj) {
             return Ok(true);
         }
         match prior_indices.get(obj) {
@@ -290,7 +268,7 @@ impl StateMachine {
             nullifiers: self.app_db.open_nullifiers(base_head.roots.nullifiers)?,
             gsr_history: self.app_db.open_gsr_history(base_head.roots.gsr_history)?,
             recent_gsrs: recent_gsrs.into_iter().collect(),
-            created_added: CreatedAdditions::default(),
+            created_added: HashMap::new(),
         };
 
         for (blob_index, payload) in payloads {
@@ -338,7 +316,7 @@ impl StateMachine {
 
         Ok(DerivedSlot {
             head: new_head,
-            created_added: working.created_added.added,
+            created_added: working.created_added,
         })
     }
 
@@ -430,10 +408,6 @@ mod tests {
         .unwrap()
     }
 
-    fn index_of(added: &[(Hash, i64)]) -> HashMap<Hash, i64> {
-        added.iter().copied().collect()
-    }
-
     #[test]
     fn test_empty_slot_produces_new_head() {
         let (sm, _app_db, _dir) = make_sm();
@@ -455,7 +429,7 @@ mod tests {
         let derived = derive(&sm, head0, [(gsr0, 0)], 1, 1, &[(0, blob)], &HashMap::new());
         let head1 = derived.head;
         let created_present = app_db
-            .created_exists_for(&head1.roots, &[live_obj], &index_of(&derived.created_added))
+            .created_exists_for(&head1.roots, &[live_obj], &derived.created_added)
             .unwrap();
         let nullifier_present = app_db
             .nullifier_exists_batch(&head1.roots, &[nullifier])
@@ -489,7 +463,7 @@ mod tests {
         let blob = mock_txn_bytes(unique_hash(31), &[], &[live_obj], gsr0);
         let derived = derive(&sm, head0, [(gsr0, 0)], 1, 1, &[(0, blob)], &HashMap::new());
         let head1 = derived.head;
-        let indices = index_of(&derived.created_added);
+        let indices = derived.created_added;
 
         // The same index cross-checks against each head's root: present under
         // the new head, absent under the old.
@@ -527,9 +501,17 @@ mod tests {
         // A second tx in a later slot re-creates the same object. In production
         // slot 1's index row is committed; here it is passed as prior-existing.
         let gsr1 = head1.metadata.current_gsr.unwrap();
-        let prior_indices = index_of(&derived1.created_added);
         let blob2 = mock_txn_bytes(unique_hash(42), &[], &[live_obj], gsr1);
-        let head2 = derive(&sm, head1, [(gsr1, 1)], 2, 2, &[(0, blob2)], &prior_indices).head;
+        let head2 = derive(
+            &sm,
+            head1,
+            [(gsr1, 1)],
+            2,
+            2,
+            &[(0, blob2)],
+            &derived1.created_added,
+        )
+        .head;
         assert_eq!(head2.metadata.created_count, head1.metadata.created_count);
     }
 
@@ -554,8 +536,7 @@ mod tests {
             &HashMap::new(),
         );
         assert_eq!(derived.head.metadata.created_count, 1);
-        assert_eq!(derived.created_added.len(), 1);
-        assert_eq!(derived.created_added[0].0, dup);
+        assert_eq!(derived.created_added.get(&dup), Some(&1));
     }
 
     #[test]
@@ -573,7 +554,6 @@ mod tests {
         let blob = mock_txn_bytes(unique_hash(61), &[], &[obj], gsr0);
         let derived = derive(&sm, head0, [(gsr0, 0)], 1, 1, &[(0, blob)], &phantom);
         assert_eq!(derived.head.metadata.created_count, 1);
-        assert_eq!(derived.created_added.len(), 1);
-        assert_eq!(derived.created_added[0].0, obj);
+        assert_eq!(derived.created_added.get(&obj), Some(&1));
     }
 }

--- a/synchronizer/src/sync_db.rs
+++ b/synchronizer/src/sync_db.rs
@@ -1,9 +1,12 @@
+use std::collections::HashMap;
+
 use alloy::primitives::B256;
 use anyhow::{anyhow, Context, Result};
+use common::encode_hash_hex;
 use pod2::middleware::Hash;
 use sqlx::{
     postgres::{PgPoolOptions, PgRow},
-    Executor, PgPool, Row,
+    Executor, PgExecutor, PgPool, Row,
 };
 
 use crate::{
@@ -91,6 +94,22 @@ impl SyncDb {
                 ON canonical_slots(execution_block_number)
                 WHERE current_gsr IS NOT NULL AND execution_block_number IS NOT NULL
             "#,
+            // Reverse index from object commitment to its position in the created
+            // `Array`. A materialized view of committed state: rows are inserted in
+            // the same transaction that commits their slot and deleted in the same
+            // transaction that rolls the slot back, so the index never diverges
+            // from the canonical head. `slot` carries the rollback axis.
+            r#"
+            CREATE TABLE IF NOT EXISTS created_index (
+                commitment BYTEA PRIMARY KEY,
+                array_index BIGINT NOT NULL,
+                slot INTEGER NOT NULL
+            )
+            "#,
+            r#"
+            CREATE INDEX IF NOT EXISTS created_index_slot_idx
+                ON created_index(slot)
+            "#,
         ];
 
         for stmt in statements {
@@ -122,7 +141,7 @@ impl SyncDb {
             return Ok(stored_last);
         }
 
-        self.commit_slot(&bootstrap_slot, &CanonicalHead::empty())
+        self.commit_slot(&bootstrap_slot, &CanonicalHead::empty(), &[])
             .await?;
         Ok(bootstrap_slot.slot)
     }
@@ -141,6 +160,12 @@ impl SyncDb {
 
     /// Return the current canonical head plus sync progress from one Postgres snapshot.
     pub async fn current_snapshot(&self) -> Result<CurrentSnapshot> {
+        Self::read_snapshot(&self.pool).await
+    }
+
+    /// Read the current canonical head plus progress over any executor (pool or
+    /// transaction), so a caller can pin it to the same snapshot as other reads.
+    async fn read_snapshot<'e, E: PgExecutor<'e>>(executor: E) -> Result<CurrentSnapshot> {
         let row = sqlx::query(
             r#"
             SELECT slot,
@@ -159,7 +184,7 @@ impl SyncDb {
             LIMIT 1
             "#,
         )
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await?;
 
         let row = row.ok_or_else(|| anyhow!("sync metadata not initialized"))?;
@@ -203,13 +228,16 @@ impl SyncDb {
         }
     }
 
-    /// Commit one new canonical slot as the new highest canonical slot.
+    /// Commit one new canonical slot as the new highest canonical slot, writing
+    /// its created-index rows in the same transaction so the index is always
+    /// consistent with the committed head.
     ///
     /// Duplicate slot inserts are treated as logic bugs and must fail loudly.
     pub async fn commit_slot(
         &self,
         slot: &CommittedSlotRecord,
         head: &CanonicalHead,
+        created_added: &[(Hash, i64)],
     ) -> Result<()> {
         let mut tx = self.pool.begin().await?;
 
@@ -253,11 +281,32 @@ impl SyncDb {
         .execute(&mut *tx)
         .await?;
 
+        for (commitment, index) in created_added {
+            // `commitment` is the PRIMARY KEY; a conflict is a bug and fails loudly.
+            sqlx::query(
+                "INSERT INTO created_index(commitment, array_index, slot) VALUES ($1, $2, $3)",
+            )
+            .bind(hash_to_db_bytes(*commitment))
+            .bind(*index)
+            .bind(slot.slot as i32)
+            .execute(&mut *tx)
+            .await
+            .with_context(|| {
+                format!(
+                    "inserting created_index row for {} at slot {}",
+                    encode_hash_hex(commitment),
+                    slot.slot
+                )
+            })?;
+        }
+
         tx.commit().await?;
         Ok(())
     }
 
-    /// Delete canonical slots after `keep_slot`, leaving the highest remaining row as current.
+    /// Delete canonical slots after `keep_slot`, leaving the highest remaining
+    /// row as current, and prune the created-index rows those slots added in the
+    /// same transaction.
     pub async fn rollback_to_slot(&self, keep_slot: u32) -> Result<()> {
         let mut tx = self.pool.begin().await?;
 
@@ -266,8 +315,69 @@ impl SyncDb {
             .execute(&mut *tx)
             .await?;
 
+        sqlx::query("DELETE FROM created_index WHERE slot > $1")
+            .bind(keep_slot as i32)
+            .execute(&mut *tx)
+            .await?;
+
         tx.commit().await?;
         Ok(())
+    }
+
+    /// Map each known object commitment to its position in the created `Array`.
+    /// Commitments absent from the index are omitted; a membership read treats a
+    /// missing entry as "not present". Used both by the read API and as the
+    /// derivation-time existence prefetch (where the index is cross-checked
+    /// against the array before a commitment is treated as already created).
+    pub async fn created_indices(&self, commitments: &[Hash]) -> Result<HashMap<Hash, i64>> {
+        Self::read_created_indices(&self.pool, commitments).await
+    }
+
+    /// Read the created indices for `commitments` over any executor (pool or
+    /// transaction), so a caller can pin them to the same snapshot as other reads.
+    async fn read_created_indices<'e, E: PgExecutor<'e>>(
+        executor: E,
+        commitments: &[Hash],
+    ) -> Result<HashMap<Hash, i64>> {
+        if commitments.is_empty() {
+            return Ok(HashMap::new());
+        }
+        let keys: Vec<Vec<u8>> = commitments.iter().map(|c| hash_to_db_bytes(*c)).collect();
+        let rows = sqlx::query(
+            "SELECT commitment, array_index FROM created_index WHERE commitment = ANY($1)",
+        )
+        .bind(keys)
+        .fetch_all(executor)
+        .await?;
+
+        let mut map = HashMap::with_capacity(rows.len());
+        for row in rows {
+            let commitment: Vec<u8> = row.get("commitment");
+            let index: i64 = row.get("array_index");
+            map.insert(db_bytes_to_hash(&commitment)?, index);
+        }
+        Ok(map)
+    }
+
+    /// Read the current snapshot and the created indices for `commitments` from
+    /// one `REPEATABLE READ` transaction, so the head roots and the index rows
+    /// reflect a single consistent Postgres snapshot. Without this a concurrent
+    /// `commit_slot`/`rollback_to_slot` could land between the two reads and make
+    /// the index inconsistent with the head a query is answering against. The
+    /// RocksDB array read needs no coordination: nodes are content-addressed and
+    /// immutable by root, so reading at the pinned root is stable regardless.
+    pub async fn snapshot_with_created_indices(
+        &self,
+        commitments: &[Hash],
+    ) -> Result<(CurrentSnapshot, HashMap<Hash, i64>)> {
+        let mut tx = self
+            .pool
+            .begin_with("BEGIN ISOLATION LEVEL REPEATABLE READ READ ONLY")
+            .await?;
+        let snapshot = Self::read_snapshot(&mut *tx).await?;
+        let indices = Self::read_created_indices(&mut *tx, commitments).await?;
+        tx.commit().await?;
+        Ok((snapshot, indices))
     }
 
     /// Return the recent canonical GSRs at or above the given execution block number.
@@ -444,7 +554,7 @@ mod tests {
             is_empty: false,
         };
 
-        sync_db.commit_slot(&slot, &head).await?;
+        sync_db.commit_slot(&slot, &head, &[]).await?;
 
         let snapshot = sync_db.current_snapshot().await?;
         assert_eq!(snapshot.head, head);
@@ -470,9 +580,9 @@ mod tests {
             is_empty: false,
         };
 
-        sync_db.commit_slot(&slot, &head1).await?;
+        sync_db.commit_slot(&slot, &head1, &[]).await?;
 
-        let err = sync_db.commit_slot(&slot, &head2).await.unwrap_err();
+        let err = sync_db.commit_slot(&slot, &head2, &[]).await.unwrap_err();
         assert!(
             err.to_string().contains("duplicate key")
                 || err.to_string().contains("unique constraint"),
@@ -499,6 +609,7 @@ mod tests {
                     is_empty: false,
                 },
                 &h1,
+                &[],
             )
             .await?;
 
@@ -514,6 +625,7 @@ mod tests {
                     is_empty: false,
                 },
                 &h2,
+                &[],
             )
             .await?;
 
@@ -540,6 +652,7 @@ mod tests {
                     is_empty: false,
                 },
                 &h1,
+                &[],
             )
             .await?;
 
@@ -555,6 +668,7 @@ mod tests {
                     is_empty: false,
                 },
                 &h2,
+                &[],
             )
             .await?;
 
@@ -563,6 +677,65 @@ mod tests {
         let snapshot = sync_db.current_snapshot().await?;
         assert_eq!(snapshot.head, h1);
         assert_eq!(snapshot.last_processed_slot, 1);
+
+        drop_db(&db_name, &admin_url).await?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    #[ignore = "requires local postgres"]
+    async fn test_created_index_commit_and_rollback() -> Result<()> {
+        let (sync_db, db_name, admin_url) = fresh_sync_db().await?;
+        let a = unique_hash(1);
+        let b = unique_hash(2);
+
+        let h1 = unique_head(1, 10);
+        sync_db
+            .commit_slot(
+                &CommittedSlotRecord {
+                    slot: 1,
+                    block_root: None,
+                    parent_root: None,
+                    block_number: Some(1),
+                    current_gsr: h1.metadata.current_gsr,
+                    is_empty: false,
+                },
+                &h1,
+                &[(a, 1)],
+            )
+            .await?;
+        let h2 = unique_head(2, 20);
+        sync_db
+            .commit_slot(
+                &CommittedSlotRecord {
+                    slot: 2,
+                    block_root: None,
+                    parent_root: None,
+                    block_number: Some(2),
+                    current_gsr: h2.metadata.current_gsr,
+                    is_empty: false,
+                },
+                &h2,
+                &[(b, 2)],
+            )
+            .await?;
+
+        let indices = sync_db.created_indices(&[a, b]).await?;
+        assert_eq!(indices.get(&a), Some(&1));
+        assert_eq!(indices.get(&b), Some(&2));
+
+        // Rolling back to slot 1 prunes slot 2's index row in the same
+        // transaction as the canonical-slot delete.
+        sync_db.rollback_to_slot(1).await?;
+        let indices = sync_db.created_indices(&[a, b]).await?;
+        assert_eq!(indices.get(&a), Some(&1));
+        assert_eq!(indices.get(&b), None);
+
+        // The atomic read returns the same index against the current head.
+        let (snapshot, indices) = sync_db.snapshot_with_created_indices(&[a, b]).await?;
+        assert_eq!(snapshot.last_processed_slot, 1);
+        assert_eq!(indices.get(&a), Some(&1));
+        assert_eq!(indices.get(&b), None);
 
         drop_db(&db_name, &admin_url).await?;
         Ok(())

--- a/synchronizer/src/sync_db.rs
+++ b/synchronizer/src/sync_db.rs
@@ -33,6 +33,21 @@ pub struct CommittedSlotRecord {
     pub is_empty: bool,
 }
 
+impl CommittedSlotRecord {
+    /// Record for a slot with no canonical block content: every block field
+    /// absent, marked empty.
+    pub fn empty(slot: u32) -> Self {
+        Self {
+            slot,
+            block_root: None,
+            parent_root: None,
+            block_number: None,
+            current_gsr: None,
+            is_empty: true,
+        }
+    }
+}
+
 #[derive(Clone)]
 pub struct SyncDb {
     pool: PgPool,

--- a/synchronizer/src/sync_db.rs
+++ b/synchronizer/src/sync_db.rs
@@ -141,7 +141,7 @@ impl SyncDb {
             return Ok(stored_last);
         }
 
-        self.commit_slot(&bootstrap_slot, &CanonicalHead::empty(), &[])
+        self.commit_slot(&bootstrap_slot, &CanonicalHead::empty(), &HashMap::new())
             .await?;
         Ok(bootstrap_slot.slot)
     }
@@ -237,7 +237,7 @@ impl SyncDb {
         &self,
         slot: &CommittedSlotRecord,
         head: &CanonicalHead,
-        created_added: &[(Hash, i64)],
+        created_added: &HashMap<Hash, i64>,
     ) -> Result<()> {
         let mut tx = self.pool.begin().await?;
 
@@ -554,7 +554,7 @@ mod tests {
             is_empty: false,
         };
 
-        sync_db.commit_slot(&slot, &head, &[]).await?;
+        sync_db.commit_slot(&slot, &head, &HashMap::new()).await?;
 
         let snapshot = sync_db.current_snapshot().await?;
         assert_eq!(snapshot.head, head);
@@ -580,9 +580,12 @@ mod tests {
             is_empty: false,
         };
 
-        sync_db.commit_slot(&slot, &head1, &[]).await?;
+        sync_db.commit_slot(&slot, &head1, &HashMap::new()).await?;
 
-        let err = sync_db.commit_slot(&slot, &head2, &[]).await.unwrap_err();
+        let err = sync_db
+            .commit_slot(&slot, &head2, &HashMap::new())
+            .await
+            .unwrap_err();
         assert!(
             err.to_string().contains("duplicate key")
                 || err.to_string().contains("unique constraint"),
@@ -609,7 +612,7 @@ mod tests {
                     is_empty: false,
                 },
                 &h1,
-                &[],
+                &HashMap::new(),
             )
             .await?;
 
@@ -625,7 +628,7 @@ mod tests {
                     is_empty: false,
                 },
                 &h2,
-                &[],
+                &HashMap::new(),
             )
             .await?;
 
@@ -652,7 +655,7 @@ mod tests {
                     is_empty: false,
                 },
                 &h1,
-                &[],
+                &HashMap::new(),
             )
             .await?;
 
@@ -668,7 +671,7 @@ mod tests {
                     is_empty: false,
                 },
                 &h2,
-                &[],
+                &HashMap::new(),
             )
             .await?;
 
@@ -701,7 +704,7 @@ mod tests {
                     is_empty: false,
                 },
                 &h1,
-                &[(a, 1)],
+                &HashMap::from([(a, 1)]),
             )
             .await?;
         let h2 = unique_head(2, 20);
@@ -716,7 +719,7 @@ mod tests {
                     is_empty: false,
                 },
                 &h2,
-                &[(b, 2)],
+                &HashMap::from([(b, 2)]),
             )
             .await?;
 

--- a/synchronizer/src/sync_loop.rs
+++ b/synchronizer/src/sync_loop.rs
@@ -192,10 +192,12 @@ async fn handle_missing_slot(node: &Node, slot: u32) -> Result<MissingSlotAction
         ));
     }
 
-    // Empty slots are valid on beacon; commit an empty processed slot so canonical slot history
-    // stays contiguous.
-    let head = node.current_head().await?;
-    let processed = ProcessedSlot::empty(slot, Default::default(), Default::default(), head);
+    // Skipped slots are valid on beacon; commit a Missing slot so canonical
+    // slot history stays contiguous.
+    let processed = ProcessedSlot::Missing {
+        slot,
+        carried_head: node.current_head().await?,
+    };
 
     info!(slot, "No block produced for slot");
     node.commit_slot(&processed).await?;


### PR DESCRIPTION
This builds on #130 by storing the indices into the `created` array in Postgres, making it easy to delete stale entries on reorg.

The most visible change is to `process_blob`, which is split into two stages. The most visible change is to process_blob, which is split into two stages. The first (parse_blobs) parses and verifies the incoming blob(s), revealing which created-object commitments are affected. Then we can query Postgres to see if any of these already exist, and pass that into the second stage (apply_payload), which validates and applies each blob.

There are some tests which exercise Postgres machinery, and which are ignored by default. I have run these tests locally, where they pass.

I think we are still assuming that the synchronizer is reset frequently, and so we don't handle any upgrade paths here.