### PR TITLE
Bump to latest pod2, remove array padding and fix 0/EMPTY mismatches

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,4 +160,4 @@ While coding, write a comment only if all three hold:
 - it does not transcribe another unit's mechanism, name a specific that will rot (a fixture, a sibling function, a field elsewhere), or lean on what you'd have to leave the repo to check (a prior version, a use case, our conversation);
 - it carries something an intelligent reader could not easily infer from this unit -- not control flow, not types, not return values, not general knowledge, not a paraphrase of the line beside it.
 
-Test: cut any clause that transcribes mechanism, states general knowledge, or names a rot-prone specific; then cut any "because X" you can't check against the repo. If nothing survives, delete the comment. If what survives is inferable from the code, delete that too.
+Test: cut any clause that transcribes mechanism, states general knowledge, or names a rot-prone specific; then cut any "because X" you can't check against the repo. If nothing survives, delete the comment. If what survives is inferable from the code, delete that too. Comments should not quote code directly, as this makes drift between code and comment more likely.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5975,7 +5975,7 @@ dependencies = [
 [[package]]
 name = "pod2"
 version = "0.1.0"
-source = "git+https://github.com/0xPARC/pod2?rev=2b61720cd7103d97d708ab8b15dbcc8a04880fcc#2b61720cd7103d97d708ab8b15dbcc8a04880fcc"
+source = "git+https://github.com/0xPARC/pod2?rev=17177e055b56595c29e2588707da324fad7f5f36#17177e055b56595c29e2588707da324fad7f5f36"
 dependencies = [
  "annotate-snippets",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 resolver = "2"
 
 [workspace.dependencies]
-pod2 = { git = "https://github.com/0xPARC/pod2", rev = "2b61720cd7103d97d708ab8b15dbcc8a04880fcc", default-features = false, features = [
+pod2 = { git = "https://github.com/0xPARC/pod2", rev = "17177e055b56595c29e2588707da324fad7f5f36", default-features = false, features = [
     "backend_plonky2",
     "disk_cache",
     "zk",

--- a/common/src/test_state.rs
+++ b/common/src/test_state.rs
@@ -102,8 +102,7 @@ impl TestState {
         nullifier_hashes: impl IntoIterator<Item = Hash>,
     ) {
         for commitment in created_commitments {
-            // 1-indexed: slot 0 stays empty so nothing grounds at index 0.
-            let index = self.created_index.len() as i64 + 1;
+            let index = self.created_index.len() as i64;
             self.created
                 .insert(index as usize, Value::from(commitment))
                 .expect("created object should insert into test state");

--- a/intro_pods/lt_eq_u256_pod/src/lib.rs
+++ b/intro_pods/lt_eq_u256_pod/src/lib.rs
@@ -432,7 +432,7 @@ mod tests {
     };
     use pod2::{
         backends::plonky2::{basetypes::DEFAULT_VD_SET, recursion::circuit::hash_verifier_data},
-        middleware::hash_str,
+        middleware::{EMPTY_VALUE, hash_str},
     };
 
     use super::*;
@@ -556,7 +556,7 @@ mod tests {
         let params = Params::default();
         let vd_set = &*DEFAULT_VD_SET;
         let rhs = RawValue([F::ZERO, F::ZERO, F::ZERO, F(0x0020_0000_0000_0000u64)]);
-        let hash = RawValue([F::ZERO, F::ZERO, F::ZERO, F::ZERO]);
+        let hash = EMPTY_VALUE;
 
         let pod = LtEqU256Pod::new_boxed(&params, vd_set.clone(), hash, rhs)?;
         pod.verify()?;

--- a/intro_pods/lt_eq_u256_pod/src/lib.rs
+++ b/intro_pods/lt_eq_u256_pod/src/lib.rs
@@ -556,7 +556,7 @@ mod tests {
         let params = Params::default();
         let vd_set = &*DEFAULT_VD_SET;
         let rhs = RawValue([F::ZERO, F::ZERO, F::ZERO, F(0x0020_0000_0000_0000u64)]);
-        let hash = RawValue::from(0i64);
+        let hash = RawValue([F::ZERO, F::ZERO, F::ZERO, F::ZERO]);
 
         let pod = LtEqU256Pod::new_boxed(&params, vd_set.clone(), hash, rhs)?;
         pod.verify()?;

--- a/intro_pods/vdfpod/src/lib.rs
+++ b/intro_pods/vdfpod/src/lib.rs
@@ -39,7 +39,7 @@
 
 use anyhow::{Result, anyhow};
 use plonky2::{
-    field::types::Field,
+    field::types::{Field, PrimeField64},
     hash::{
         hash_types::{HashOut, HashOutTarget},
         poseidon::PoseidonHash,
@@ -98,7 +98,9 @@ pub static STANDARD_VDF_VD_HASH: std::sync::LazyLock<Hash> = std::sync::LazyLock
 static STANDARD_VDF_POD_DATA: std::sync::LazyLock<
     CacheEntry<(VdfPodTarget, CircuitDataSerializer)>,
 > = std::sync::LazyLock::new(|| {
-    cache::get("standard_vdf_pod_circuit_data", &(), |_| {
+    // v2: the count arg in the public statement uses the tagged pod2 int
+    // encoding. The version suffix evicts cache entries built before that.
+    cache::get("standard_vdf_pod_circuit_data_v2", &(), |_| {
         let (target, circuit_data) = build().expect("successful build");
         (target, CircuitDataSerializer(circuit_data))
     })
@@ -397,6 +399,10 @@ fn single_statement_mt(st: &middleware::Statement) -> Array {
 }
 
 fn pub_raw_statements(count: F, input: RawValue, output: RawValue) -> Vec<middleware::Statement> {
+    // The circuit packs the count into a single limb (from_int_lo), while
+    // the int encoding splits lo/hi at 2^32; they only agree below that.
+    let count = count.to_canonical_u64();
+    assert!(count < (1 << 32));
     vec![middleware::Statement::Intro(
         IntroPredicateRef {
             name: VDF_POD_TYPE.1.to_string(),
@@ -404,7 +410,7 @@ fn pub_raw_statements(count: F, input: RawValue, output: RawValue) -> Vec<middle
             verifier_data_hash: EMPTY_HASH,
         },
         vec![
-            RawValue([count, F::ZERO, F::ZERO, F::ZERO]).into(),
+            RawValue::from(count as i64).into(),
             input.into(),
             output.into(),
         ],
@@ -417,11 +423,8 @@ fn pub_raw_statements_target(
     input: &[Target],
     output: &[Target],
 ) -> Vec<StatementTarget> {
-    let zero = builder.zero();
-    let st_arg_0 = StatementArgTarget::literal(
-        builder,
-        &ValueTarget::from_slice(&[count, zero, zero, zero]),
-    );
+    let count_value = ValueTarget::from_int_lo(builder, count);
+    let st_arg_0 = StatementArgTarget::literal(builder, &count_value);
     let st_arg_1 = StatementArgTarget::literal(builder, &ValueTarget::from_slice(input));
     let st_arg_2 = StatementArgTarget::literal(builder, &ValueTarget::from_slice(output));
     let args = [st_arg_0, st_arg_1, st_arg_2]

--- a/pexe/src/fixtures.rs
+++ b/pexe/src/fixtures.rs
@@ -110,8 +110,7 @@ pub fn build_synthetic_state(
         if indices.contains_key(&commitment) {
             continue;
         }
-        // 1-indexed: slot 0 stays empty so nothing grounds at index 0.
-        let index = indices.len() as i64 + 1;
+        let index = indices.len() as i64;
         created
             .insert(index as usize, Value::from(obj.clone()))
             .map_err(|err| anyhow!("recording synthetic created object: {err}"))?;

--- a/plugins/craft-basics/manifest.toml
+++ b/plugins/craft-basics/manifest.toml
@@ -2,7 +2,7 @@
 name = "craft-basics"
 version = "0.1.0"
 # Rewritten by `cargo run -p pexe -- build plugins/craft-basics`.
-module_hash = "5a8832ee1493ba772d6c29faf738ef7d68297837045378fd03783f7c4d54a6f2"
+module_hash = "92eeef2a638c02fc9ba3de5ba17c70bf5168e47522d8055c3e4b9ebf9a46d8cd"
 
 [[classes]]
 name = "Log"

--- a/plugins/craft-basics/manifest.toml
+++ b/plugins/craft-basics/manifest.toml
@@ -2,7 +2,7 @@
 name = "craft-basics"
 version = "0.1.0"
 # Rewritten by `cargo run -p pexe -- build plugins/craft-basics`.
-module_hash = "6b9c665f8f6cc0741ba86b710e371068dd335b6e38dcef177facb5df76d6bbb2"
+module_hash = "5a8832ee1493ba772d6c29faf738ef7d68297837045378fd03783f7c4d54a6f2"
 
 [[classes]]
 name = "Log"

--- a/plugins/episode-1/manifest.toml
+++ b/plugins/episode-1/manifest.toml
@@ -2,7 +2,7 @@
 name = "episode-1"
 version = "0.1.0"
 # Rewritten by `cargo run -p pexe -- build plugins/episode-1`.
-module_hash = "da71de6826cea1dfd19f57fa40acc51d521e4692366fa720ea62229ff2d602e1"
+module_hash = "2d352db701ea02eed4ebed75c7cf1f5bc7b7ffe2dde2e6c63b54f8b58cafba69"
 
 # ── raw resources ────────────────────────────────────────────────────────────
 

--- a/plugins/episode-1/manifest.toml
+++ b/plugins/episode-1/manifest.toml
@@ -2,7 +2,7 @@
 name = "episode-1"
 version = "0.1.0"
 # Rewritten by `cargo run -p pexe -- build plugins/episode-1`.
-module_hash = "9a2021bfb68f8a83190fa78fdf3495293bc4b96caa8fc13823a6f5d98fe581d9"
+module_hash = "da71de6826cea1dfd19f57fa40acc51d521e4692366fa720ea62229ff2d602e1"
 
 # ── raw resources ────────────────────────────────────────────────────────────
 

--- a/pod2utils/src/mockintro.rs
+++ b/pod2utils/src/mockintro.rs
@@ -22,7 +22,7 @@ fn intro_self_statement(name: String, args: Vec<Value>) -> Statement {
             args_len: args.len(),
             verifier_data_hash: EMPTY_HASH,
         },
-        args,
+        args.into_iter().map(Into::into).collect(),
     )
 }
 

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -159,26 +159,26 @@ The emitted podlang embeds `target` as a hex `Raw(0x00…)` literal.
 The example in the test `test_sdk_1` produces the following podlang code:
 
 ```
-use module 0x1127dce1866ccc4bb6a32782dec35754451ae33ac72e8daaa7e8454be8ac813d as tx
-use intro Vdf(count, input, output) from 0x92586a223c74ba4083d5c5d5b10f9c0a227b91fb2baa2272ffb99faca7adb993
-use intro LtEqU256(lhs, rhs) from 0xd80d0ac8d9d02dc8e9fa3344936a8c9594b915b10a88a4981ceecc462ed03724
+use module 0x8dcb7d36f8cb0504e533f124246671b983a78072d1ec8e80604cf01a831327b8 as tx
+use intro Vdf(count, input, output) from 0xab82223f501b5056f458f063eb2fc073f8ac01f2ea178a3a2303394fec6828a0
+use intro LtEqU256(lhs, rhs) from 0xe0595e5c75467e5a27bd30fa48a45e1dcc66a327076e5ce7c02ce33dfe357311
 
-record FindLogOut = (_pad, log)
-record FindLogInitials = (_pad, log)
-record CraftWoodIn = (_pad, log)
-record CraftWoodOut = (_pad, wood)
-record CraftSticksIn = (_pad, wood)
-record CraftSticksOut = (_pad, stick_a, stick_b)
-record CraftSticksChain = (_pad, step_0, step_1)
-record CraftSticksInitials = (_pad, stick_a, stick_b)
-record CraftWoodPickIn = (_pad, wood, stick)
-record CraftWoodPickOut = (_pad, pick)
-record CraftWoodPickChain = (_pad, step_0, step_1)
-record CraftWoodPickInitials = (_pad, pick)
-record UseWoodPickIn = (_pad, wood_pick)
-record UseWoodPickOut = (_pad, wood_pick)
-record MineStoneWithWoodPickOut = (_pad, stone)
-record MineStoneWithWoodPickInitials = (_pad, stone)
+record FindLogOut = (log)
+record FindLogInitials = (log)
+record CraftWoodIn = (log)
+record CraftWoodOut = (wood)
+record CraftSticksIn = (wood)
+record CraftSticksOut = (stick_a, stick_b)
+record CraftSticksChain = (step_0, step_1)
+record CraftSticksInitials = (stick_a, stick_b)
+record CraftWoodPickIn = (wood, stick)
+record CraftWoodPickOut = (pick)
+record CraftWoodPickChain = (step_0, step_1)
+record CraftWoodPickInitials = (pick)
+record UseWoodPickIn = (wood_pick)
+record UseWoodPickOut = (wood_pick)
+record MineStoneWithWoodPickOut = (stone)
+record MineStoneWithWoodPickInitials = (stone)
 
 // Actions
 

--- a/sdk/src/fmt_podlang.rs
+++ b/sdk/src/fmt_podlang.rs
@@ -56,11 +56,6 @@ pub(crate) const fn output_max_ts(base_ts: usize, is_output: bool) -> usize {
     if is_output { base_ts + 1 } else { base_ts }
 }
 
-/// Slot 0 placeholder in every records-form schema (`<Action>In`,
-/// `<Action>Out`, `<Action>Chain`). Real entries start at slot 1.
-/// Works around pod2 issue #513.
-pub(crate) const PAD_ENTRY: &str = "_pad";
-
 /// An action's chain max_ts must be at least this for the SDK to pack
 /// intermediate chain states into a `<Action>Chain` record. Below the
 /// threshold, the per-step scalar wildcards (`chain1`, `chain2`, ...)
@@ -84,10 +79,10 @@ pub(crate) fn chain_schema_name(action_name: &str) -> String {
 /// this action's chain is packed. Returns `None` for endpoints
 /// (`ts=0=chain0`, `ts=max_ts=chain`) and for unpacked actions (whose
 /// intermediates are scalar `chain1`, `chain2`, ... wildcards). The
-/// record's array layout is `[_pad, step_0_value, step_1_value, ...]`,
-/// so the slot index equals `ts` and the step name is `step_{ts-1}`.
+/// record's array layout is `[step_0_value, step_1_value, ...]`, so the
+/// slot index is `ts - 1` and the step name is `step_{ts-1}`.
 pub(crate) fn chain_step_at(ts: usize, chain_max_ts: usize) -> Option<usize> {
-    (chain_packed(chain_max_ts) && ts > 0 && ts < chain_max_ts).then_some(ts)
+    (chain_packed(chain_max_ts) && ts > 0 && ts < chain_max_ts).then_some(ts - 1)
 }
 
 #[derive(Clone, Copy)]
@@ -131,7 +126,7 @@ impl<'a> fmt::Display for VarNameFmt<'a> {
         if self.name == "chain"
             && let Some(slot) = chain_step_at(self.ts, max_ts)
         {
-            return write!(f, "chain_steps.step_{}", slot - 1);
+            return write!(f, "chain_steps.step_{slot}");
         }
         write!(f, "{}", fmt_var_at(self.name, self.ts, max_ts))
     }
@@ -228,15 +223,9 @@ fn schema_name(action_name: &str, ns: impl Into<Collapse>) -> String {
 
 /// Emit `record <Action><Side> = (<entries>)` lines for any non-empty
 /// in/out schema across all actions, plus `<Action>Chain` records for
-/// actions whose chain has 2+ intermediate states. Each schema is
-/// prepended with `PAD_ENTRY` so real entries start at index 1.
+/// actions whose chain has 2+ intermediate states.
 fn fmt_record_decls(loader: &Loader, w: &mut dyn fmt::Write) -> fmt::Result {
-    let render = |entries: &[String]| {
-        std::iter::once(PAD_ENTRY.to_string())
-            .chain(entries.iter().cloned())
-            .collect::<Vec<_>>()
-            .join(", ")
-    };
+    let render = |entries: &[String]| entries.join(", ");
     for meta in &loader.actions_meta {
         if !meta.in_entries.is_empty() {
             let names: Vec<String> = meta.in_entries.iter().map(|e| e.varname.clone()).collect();

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -539,8 +539,7 @@ impl ActionHandle {
 
         // ---- Build in/out record arrays from the action's direct
         // Object insts. Each Object contributes one entry to its
-        // dispatch side's array (Mutate contributes to both). Slot 0
-        // is `_pad`; real entries start at slot 1 (see PAD_ENTRY).
+        // dispatch side's array (Mutate contributes to both).
         //
         // For Outputs, cache the identity-stamped dict once here so the
         // three consumers that need the post-identity form -- the
@@ -577,8 +576,8 @@ impl ActionHandle {
             }
             (raw, stamped)
         };
-        let mut in_dicts: Vec<Value> = vec![Value::from(0_i64)];
-        let mut out_dicts: Vec<Value> = vec![Value::from(0_i64)];
+        let mut in_dicts: Vec<Value> = Vec::new();
+        let mut out_dicts: Vec<Value> = Vec::new();
         {
             let ctx = self.0.borrow();
             for inst in &ctx.insts {
@@ -611,12 +610,9 @@ impl ActionHandle {
         let out_array = Array::new(out_dicts);
 
         // Build the `<Action>Initials` record value (the pre-identity Output
-        // dicts) when the action has one. Slot 0 is the `_pad` (see PAD_ENTRY).
-        let initials_array: Option<Array> = has_initials.then(|| {
-            let mut values: Vec<Value> = vec![Value::from(0_i64)];
-            values.extend(raw_outputs.iter().cloned().map(Value::from));
-            Array::new(values)
-        });
+        // dicts) when the action has one.
+        let initials_array: Option<Array> = has_initials
+            .then(|| Array::new(raw_outputs.iter().cloned().map(Value::from).collect()));
 
         // Resolve an Output's pre-identity dict to its slot in the
         // `<Action>Initials` record.
@@ -721,12 +717,14 @@ impl ActionHandle {
         // advances the parent chain by exactly 1, in inst-iteration
         // order). Drives chain anchoring and the chain_steps record.
         let chain_max_ts = meta.chain_max_ts;
-        // chain_step_values[0] is `_pad`; [1..chain_max_ts] hold per-ts
-        // chain hashes (the final ts is the public `chain` wildcard, not
-        // stored here). SubAction values come from `st_sub` (baked in at
-        // Rhai time); Object values are filled later by the event_sts
-        // loop, once `tx_builder.{insert,mutate,delete}` advances the chain.
-        let mut chain_step_values: Vec<Value> = vec![Value::from(0_i64); chain_max_ts.max(1)];
+        // chain_step_values[ts - 1] holds the per-ts chain hash for each
+        // intermediate ts in 1..chain_max_ts (the final ts is the public
+        // `chain` wildcard, not stored here). SubAction values come from
+        // `st_sub` (baked in at Rhai time); Object values are filled later
+        // by the event_sts loop, once `tx_builder.{insert,mutate,delete}`
+        // advances the chain.
+        let mut chain_step_values: Vec<Value> =
+            vec![Value::from(0_i64); chain_max_ts.saturating_sub(1)];
         let inst_chain_ts: Vec<Option<usize>> = {
             let ctx = self.0.borrow();
             let mut chain_ts: usize = 0;
@@ -1570,24 +1568,22 @@ impl ActionMeta {
         self.total_outputs.iter()
     }
 
-    /// Find this Object's `in` entry. Returns the 1-based slot in the
-    /// `<Action>In` record (slot 0 is `_pad`) and the entry shape.
+    /// Find this Object's `in` entry. Returns its slot in the
+    /// `<Action>In` record and the entry shape.
     pub(crate) fn in_entry(&self, varname: &str) -> Option<(usize, &EntryShape)> {
         self.in_entries
             .iter()
             .enumerate()
             .find(|(_, e)| e.varname == varname)
-            .map(|(p, e)| (p + 1, e))
     }
 
-    /// 1-based slot for `varname` in the `<Action>Initials` record
-    /// (slot 0 is `_pad`), if such a record exists for this action.
+    /// Slot for `varname` in the `<Action>Initials` record, if such a
+    /// record exists for this action.
     pub(crate) fn initials_slot(&self, varname: &str) -> Option<usize> {
         self.initials_entries
             .as_ref()?
             .iter()
             .position(|name| name == varname)
-            .map(|p| p + 1)
     }
 
     pub(crate) fn out_entry(&self, varname: &str) -> Option<(usize, &EntryShape)> {
@@ -1595,7 +1591,6 @@ impl ActionMeta {
             .iter()
             .enumerate()
             .find(|(_, e)| e.varname == varname)
-            .map(|(p, e)| (p + 1, e))
     }
 
     pub(crate) fn max_ts(&self, varname: &str) -> usize {

--- a/sdk/src/tests.rs
+++ b/sdk/src/tests.rs
@@ -243,7 +243,7 @@ fn test_sdk_2() {
         [plugin]
         name = "test"
         version = "0.1.0"
-        module_hash = "8e2445036c4681ec5cad4e0bb31aed7748cb114559f61e0006503758501a4119"
+        module_hash = "6d86a1d566857bec6774e9811de4df643ac6aabf56cce05eb81ee170132ce87b"
 
         [[classes]]
         name = "Log"

--- a/sdk/src/tests.rs
+++ b/sdk/src/tests.rs
@@ -243,7 +243,7 @@ fn test_sdk_2() {
         [plugin]
         name = "test"
         version = "0.1.0"
-        module_hash = "d5588dc1b89c1246900b6f1ed86a41e0a8b7059f7c514dc9ac21e4efef69c762"
+        module_hash = "8e2445036c4681ec5cad4e0bb31aed7748cb114559f61e0006503758501a4119"
 
         [[classes]]
         name = "Log"
@@ -309,8 +309,8 @@ fn test_records_form_just_output() {
         .load_module_from_src_actions(craft_src, &["JustOutput"])
         .unwrap();
 
-    let expected = r#"record JustOutputOut = (_pad, x)
-record JustOutputInitials = (_pad, x)
+    let expected = r#"record JustOutputOut = (x)
+record JustOutputInitials = (x)
 
 // Actions
 
@@ -360,9 +360,9 @@ fn test_records_form_input_output_update() {
         .load_module_from_src_actions(craft_src, &["LogToWood"])
         .unwrap();
 
-    let expected = r#"record LogToWoodIn = (_pad, log)
-record LogToWoodOut = (_pad, wood)
-record LogToWoodInitials = (_pad, wood)
+    let expected = r#"record LogToWoodIn = (log)
+record LogToWoodOut = (wood)
+record LogToWoodInitials = (wood)
 
 // Actions
 
@@ -484,8 +484,8 @@ fn test_records_form_mutate() {
         .load_module_from_src_actions(craft_src, &["UseFoo"])
         .unwrap();
 
-    let expected = r#"record UseFooIn = (_pad, foo)
-record UseFooOut = (_pad, foo)
+    let expected = r#"record UseFooIn = (foo)
+record UseFooOut = (foo)
 
 // Actions
 

--- a/synchronizer/src/app_db.rs
+++ b/synchronizer/src/app_db.rs
@@ -260,9 +260,8 @@ mod tests {
         let (app_db, _dir) = open_test_db();
         let mut created = app_db.open_created(EMPTY_HASH).unwrap();
         let obj_commitment = test_hash(9);
-        // The created set is 1-indexed (slot 0 is reserved empty).
-        created.insert(1, Value::from(obj_commitment)).unwrap();
-        app_db.created_index_put(obj_commitment, 1).unwrap();
+        created.insert(0, Value::from(obj_commitment)).unwrap();
+        app_db.created_index_put(obj_commitment, 0).unwrap();
 
         let roots = CanonicalRoots {
             created: created.commitment(),
@@ -277,7 +276,7 @@ mod tests {
         );
         let (present, witness) = app_db.prove_created(&roots, obj_commitment).unwrap();
         assert!(present);
-        assert_eq!(witness.map(|(index, _proof)| index), Some(1));
+        assert_eq!(witness.map(|(index, _proof)| index), Some(0));
 
         // A commitment never recorded in the cache is absent, and a cache hit
         // that the array root does not actually contain resolves to absent too.

--- a/synchronizer/src/head.rs
+++ b/synchronizer/src/head.rs
@@ -39,8 +39,7 @@ pub struct HeadMetadata {
     /// Execution block number associated with `current_gsr`.
     pub current_block_number: Option<u32>,
     /// Number of objects in the canonical global created set. The array is
-    /// 1-indexed (slot 0 stays empty), so the next array slot is
-    /// `created_count + 1`.
+    /// 0-indexed, so this doubles as the next array slot.
     pub created_count: u64,
     /// Number of spent nullifiers in the canonical state.
     pub nullifier_count: u64,

--- a/synchronizer/src/state_machine.rs
+++ b/synchronizer/src/state_machine.rs
@@ -164,13 +164,9 @@ impl StateMachine {
         }
 
         for obj in &payload.live {
-            // The array is 1-indexed: slot 0 is left empty so no real object is
-            // ever grounded at `ArrayContains(created, 0, ..)`. Index 0's
-            // RawValue is [0,0,0,0], the all-zeros shape that collides with
-            // `None` / `IndexKey(0)` in pod2's StatementArg encoding -- the same
-            // hazard StateRoot's `_pad` slot avoids. `created_count` stays the
-            // true object count; the array slot is `created_count + 1`.
-            let index = state.metadata.created_count as usize + 1;
+            // The created array is 0-indexed: the next object lands at slot
+            // `created_count`, which doubles as the true object count.
+            let index = state.metadata.created_count as usize;
             state.created.insert(index, Value::from(*obj))?;
             self.app_db.created_index_put(*obj, index as i64)?;
             state.metadata.created_count += 1;

--- a/txlib/README.md
+++ b/txlib/README.md
@@ -22,7 +22,7 @@ Before the system can answer that question, the prover first produces **action s
 
 ## The hash chain
 
-Every event in a transaction (insert, mutate, delete) is recorded as one step of a chained hash. For each event a small per-event hash is computed (insert: `H(0, new)`; mutate: `H(old, new)`; delete: `H(old, 0)`) and folded into the running chain (`chain = H(prev_chain, event_hash)`). The chain is the canonical, ordering-preserving commitment to "what happened, in what order".
+Every event in a transaction (insert, mutate, delete) is recorded as one step of a chained hash. For each event a small per-event hash is computed (insert: `H({}, new)`; mutate: `H(old, new)`; delete: `H(old, {})`, where `{}` is the empty value) and folded into the running chain (`chain = H(prev_chain, event_hash)`). The chain is the canonical, ordering-preserving commitment to "what happened, in what order".
 
 An **action's range** is the pair `(chain_start, chain_end)` that brackets the action's events. The first event in the action takes `chain_start` as its `prev_chain`; the last event produces `chain_end`. The action statement commits to its range publicly so other proofs can match against it.
 
@@ -75,4 +75,4 @@ Replay is structured as recursive OR-walking over the chain. Four layers, bottom
 
    The created set is grow-only and grounding runs against a possibly-stale state root, so a grounded input may already have been spent. The nullifier set, not grounding, is what rejects a re-spend.
 
-4. **`TxFinalized`.** The public entry point. It seeds the chain (`chain_start = H(live_set, 0)`), pins the initial `before_tx` schema (`nullifiers = {}`, `chain_start = chain_end = 0`, `live = inputs_set`) in a single `DictInsert` clause to remove malleability, and threads everything through one `ReplayActions` call. `TxFinalBindings` surfaces the final `nullifiers` and `live` sets as public args (factored out so `TxFinalized` stays within the clause limit), letting the synchronizer fold them into its global nullifier and created sets. Public outputs: `(state_root, tx_final, nullifiers, live)`.
+4. **`TxFinalized`.** The public entry point. It seeds the chain (`chain_start = H(live_set, {})`), pins the initial `before_tx` schema (`nullifiers = {}`, `chain_start = chain_end = {}`, `live = inputs_set`) in a single `DictInsert` clause to remove malleability, and threads everything through one `ReplayActions` call. `TxFinalBindings` surfaces the final `nullifiers` and `live` sets as public args (factored out so `TxFinalized` stays within the clause limit), letting the synchronizer fold them into its global nullifier and created sets. Public outputs: `(state_root, tx_final, nullifiers, live)`.

--- a/txlib/src/lib.rs
+++ b/txlib/src/lib.rs
@@ -77,8 +77,8 @@ impl StateRoot {
         }
     }
 
-    /// Padded-array view used as the canonical state root record. Slot
-    /// layout matches the `record StateRoot` declaration in txlib.podlang.
+    /// Array view used as the canonical state root record. Slot layout
+    /// matches the `record StateRoot` declaration in txlib.podlang.
     /// Predicates access fields via anchored-key syntax (e.g.
     /// `state_root.created`).
     pub fn array(&self) -> Array {
@@ -493,7 +493,7 @@ impl std::fmt::Display for TxBuilder {
 
 impl TxBuilder {
     /// Create a new transaction builder from grounded inputs.
-    /// Seeds `chain_start = H(inputs, 0)`.
+    /// Seeds `chain_start = H(inputs, {})`.
     pub fn new(
         ctx: &mut BuildContext,
         inputs: &[Dictionary],

--- a/txlib/src/lib.rs
+++ b/txlib/src/lib.rs
@@ -83,7 +83,6 @@ impl StateRoot {
     /// `state_root.created`).
     pub fn array(&self) -> Array {
         Array::new(vec![
-            Value::from(0_i64),
             Value::from(self.block_number),
             Value::from(self.created_root),
             Value::from(self.nullifiers_root),
@@ -97,12 +96,12 @@ impl StateRoot {
     }
 }
 
-/// Slot indices for the `StateRoot` record. Slot 0 is `_pad` (works
-/// around pod2 issue #513); real fields start at slot 1.
-pub const STATE_ROOT_BLOCK_NUMBER_SLOT: usize = 1;
-pub const STATE_ROOT_CREATED_SLOT: usize = 2;
-pub const STATE_ROOT_NULLIFIERS_SLOT: usize = 3;
-pub const STATE_ROOT_GSRS_SLOT: usize = 4;
+/// Slot indices for the `StateRoot` record, matching the field order in
+/// the `record StateRoot` declaration in txlib.podlang.
+pub const STATE_ROOT_BLOCK_NUMBER_SLOT: usize = 0;
+pub const STATE_ROOT_CREATED_SLOT: usize = 1;
+pub const STATE_ROOT_NULLIFIERS_SLOT: usize = 2;
+pub const STATE_ROOT_GSRS_SLOT: usize = 3;
 
 /// Proof-bearing grounding data required to build a new transaction.
 ///
@@ -875,8 +874,8 @@ impl TxBuilder {
                 st_hash,
             ))
             .unwrap();
-        // Pin the full schema of `before_tx` (nullifiers={}, chain_start=0,
-        // chain_end=0, live=inputs_set) in a single DictInsert clause. This
+        // Pin the full schema of `before_tx` (nullifiers={}, chain_start={},
+        // chain_end={}, live=inputs_set) in a single DictInsert clause. This
         // closes the malleability where the prover could otherwise witness
         // arbitrary chain_start/chain_end values that pass through ReplayActions
         // verbatim into tx_final.
@@ -1156,8 +1155,7 @@ mod tests {
             for obj in tx.live.iter() {
                 let obj = obj.expect("tx live entry should decode");
                 let commitment = Hash(obj.raw().0);
-                // 1-indexed: slot 0 stays empty so nothing grounds at index 0.
-                let index = self.created_index.len() as i64 + 1;
+                let index = self.created_index.len() as i64;
                 self.created.insert(index as usize, obj).unwrap();
                 self.created_index.insert(commitment, index);
             }

--- a/txlib/src/predicates/txlib.podlang
+++ b/txlib/src/predicates/txlib.podlang
@@ -43,7 +43,7 @@
 // the hash relationship but do not update live/nullifier sets --
 // that happens during replay.
 
-// Insert: chain = H(prev, H(0, new)). The `type` arg pins the
+// Insert: chain = H(prev, H({}, new)). The `type` arg pins the
 // inserted object's type field so ReplayInsert can dispatch the
 // guard without re-extracting it. The DictInsert clause stamps
 // `new.identity = commitment(initial)`: `initial` is the

--- a/txlib/src/predicates/txlib.podlang
+++ b/txlib/src/predicates/txlib.podlang
@@ -56,7 +56,7 @@
 TxInsert(chain, prev_chain, initial, new, type, private: event_hash) = AND(
   DictContains(new, "type", type)
   DictInsert(new, initial, "identity", initial)
-  HashOf(event_hash, 0, new)
+  HashOf(event_hash, {}, new)
   HashOf(chain, prev_chain, event_hash)
 )
 
@@ -73,11 +73,11 @@ TxMutate(chain, prev_chain, new, old, type, private: event_hash) = AND(
   HashOf(chain, prev_chain, event_hash)
 )
 
-// Delete: chain = H(prev, H(old, 0)). The `type` arg pins the
+// Delete: chain = H(prev, H(old, {})). The `type` arg pins the
 // deleted object's type field for guard dispatch.
 TxDelete(chain, prev_chain, old, type, private: event_hash) = AND(
   DictContains(old, "type", type)
-  HashOf(event_hash, old, 0)
+  HashOf(event_hash, old, {})
   HashOf(chain, prev_chain, event_hash)
 )
 
@@ -319,7 +319,7 @@ ReplayDelete(before_tx, after_tx, before_chain, after_chain,
 // global created-object set (every object state ever created, maintained
 // by the synchronizer).
 
-record StateRoot = (_pad, block_number, created, nullifiers, gsrs)
+record StateRoot = (block_number, created, nullifiers, gsrs)
 
 InputsGrounded(inputs, created) = OR(
   // Base case: empty inputs. `created` is intentionally unconstrained --
@@ -380,7 +380,7 @@ InputsGroundedRecursive(inputs, created,
 //
 // The DictInsert clause pins the full schema of `before_tx`:
 // `nullifiers = {}` prevents a tx from inheriting nullifiers it did
-// not emit itself, and `chain_start = chain_end = 0` removes the
+// not emit itself, and `chain_start = chain_end = {}` removes the
 // malleability that would otherwise let the prover witness arbitrary
 // values for those two fields (they pass through ReplayActions
 // verbatim into `tx_final`, since ReplayAction only updates the
@@ -393,8 +393,8 @@ TxFinalBindings(tx_final, nullifiers, live) = AND(
 TxFinalized(state_root StateRoot, tx_final, nullifiers, live,
      private: before_tx, chain_start, chain_final) = AND(
   InputsGrounded(before_tx.live, state_root.created)
-  HashOf(chain_start, before_tx.live, 0)
-  DictInsert(before_tx, {"nullifiers": {}, "chain_start": 0, "chain_end": 0}, "live", before_tx.live)
+  HashOf(chain_start, before_tx.live, {})
+  DictInsert(before_tx, {"nullifiers": {}, "chain_start": {}, "chain_end": {}}, "live", before_tx.live)
   TxFinalBindings(tx_final, nullifiers, live)
   ReplayActions(before_tx, tx_final, chain_start, chain_final)
 )


### PR DESCRIPTION
This bumps zk-craft to the latest POD2, and removes the array padding mitigation we were using for the "zero index" bug. It also tidies up a now-incorrect assumption that 0 == EMPTY_VALUE - this is no longer true, and so we should use the literal `{}` in Podlang to equate to EMPTY_VALUE. In addition, intro PODs use the correct integer encoding.

Closes #134
