### PR TITLE
preload proof artifacts

### DIFF
--- a/common/src/shrink.rs
+++ b/common/src/shrink.rs
@@ -196,20 +196,3 @@ pub fn cache_get_shrunk_main_pod_circuit_data(
     })
     .expect("cache ok")
 }
-
-/// Warm pod2's recursive MainPod circuit disk cache.
-///
-/// The first proof a process generates pulls the recursive MainPod circuit data
-/// from `~/.cache/pod2/`, building it on a miss -- a one-time cost of minutes.
-/// Both `Prover::prove` and `build_relayer_payload`'s shrink depend on it.
-/// Constructing `ShrunkMainPodSetup` reads the rec-main-pod common and verifier
-/// data, which (in pod2) forces that shared circuit data to be built and
-/// cached, so a later proof finds it ready. Idempotent: a warm cache just loads
-/// and returns.
-pub fn warm_prover_circuits() {
-    let start = Instant::now();
-    info!("preparing recursive MainPod circuit (first cold build can take several minutes)...");
-    // Construct and drop -- the side effect is the cached circuit build.
-    let _ = ShrunkMainPodSetup::new(&Params::default());
-    info!(elapsed = ?start.elapsed(), "recursive MainPod circuit ready");
-}

--- a/common/src/shrink.rs
+++ b/common/src/shrink.rs
@@ -196,3 +196,20 @@ pub fn cache_get_shrunk_main_pod_circuit_data(
     })
     .expect("cache ok")
 }
+
+/// Warm pod2's recursive MainPod circuit disk cache.
+///
+/// The first proof a process generates pulls the recursive MainPod circuit data
+/// from `~/.cache/pod2/`, building it on a miss -- a one-time cost of minutes.
+/// Both `Prover::prove` and `build_relayer_payload`'s shrink depend on it.
+/// Constructing `ShrunkMainPodSetup` reads the rec-main-pod common and verifier
+/// data, which (in pod2) forces that shared circuit data to be built and
+/// cached, so a later proof finds it ready. Idempotent: a warm cache just loads
+/// and returns.
+pub fn warm_prover_circuits() {
+    let start = Instant::now();
+    info!("preparing recursive MainPod circuit (first cold build can take several minutes)...");
+    // Construct and drop -- the side effect is the cached circuit build.
+    let _ = ShrunkMainPodSetup::new(&Params::default());
+    info!(elapsed = ?start.elapsed(), "recursive MainPod circuit ready");
+}

--- a/dobjd/src/main.rs
+++ b/dobjd/src/main.rs
@@ -42,18 +42,18 @@ async fn main() -> Result<()> {
     let mcp_addr = format!("127.0.0.1:{mcp_port}");
     let mcp_listener = tokio::net::TcpListener::bind(&mcp_addr).await?;
 
-    // Build the proving circuits (recursive MainPod, empty pod, and the VDF +
+    // Load the proving circuits (recursive MainPod, empty pod, and the VDF +
     // lt_eq_u256 intro pods) before accepting requests, so the first action
-    // doesn't pay the one-time build. Ports are already bound, so a port
-    // conflict still fails fast ahead of this. On a warm cache it's mostly fast
-    // reads. Runs on the blocking pool since circuit construction is CPU-bound
-    // and synchronous. A failure is fatal: a circuit that can't build now would
+    // doesn't pay to build them. Ports are already bound, so a port conflict
+    // still fails fast ahead of this. This only touches circuit data (no
+    // proving), so on a warm cache it's fast reads. Runs on the blocking pool
+    // since circuit construction is CPU-bound and synchronous. A failure is
+    // fatal (the warm panics internally): a circuit that can't build now would
     // fail every action, so refuse to start rather than serve a daemon that
-    // cannot prove. The `??` propagates both a panic (JoinError) and the
-    // warm-up's own error.
+    // cannot prove.
     tokio::task::spawn_blocking(driver::warm_proving_circuits)
         .await
-        .map_err(|err| anyhow!("circuit warm-up task panicked: {err}"))??;
+        .map_err(|err| anyhow!("circuit warm-up task panicked: {err}"))?;
 
     // Both ports are ours. Spawn the MCP server; share `Arc<Driver>` and the
     // broadcast hub so MCP, the desktop, and the website drive one process.

--- a/dobjd/src/main.rs
+++ b/dobjd/src/main.rs
@@ -47,13 +47,13 @@ async fn main() -> Result<()> {
     // doesn't pay the one-time build. Ports are already bound, so a port
     // conflict still fails fast ahead of this. On a warm cache it's mostly fast
     // reads. Runs on the blocking pool since circuit construction is CPU-bound
-    // and synchronous. Best-effort: if it fails, start anyway and let the first
-    // action build whatever is missing on demand.
-    if let Err(err) = tokio::task::spawn_blocking(driver::warm_proving_circuits).await {
-        tracing::warn!(
-            "circuit warm-up did not finish cleanly: {err}; the first action will build any missing circuits on demand"
-        );
-    }
+    // and synchronous. A failure is fatal: a circuit that can't build now would
+    // fail every action, so refuse to start rather than serve a daemon that
+    // cannot prove. The `??` propagates both a panic (JoinError) and the
+    // warm-up's own error.
+    tokio::task::spawn_blocking(driver::warm_proving_circuits)
+        .await
+        .map_err(|err| anyhow!("circuit warm-up task panicked: {err}"))??;
 
     // Both ports are ours. Spawn the MCP server; share `Arc<Driver>` and the
     // broadcast hub so MCP, the desktop, and the website drive one process.

--- a/dobjd/src/main.rs
+++ b/dobjd/src/main.rs
@@ -42,6 +42,15 @@ async fn main() -> Result<()> {
     let mcp_addr = format!("127.0.0.1:{mcp_port}");
     let mcp_listener = tokio::net::TcpListener::bind(&mcp_addr).await?;
 
+    // Build the proving circuit cache before accepting any requests, so the
+    // first action doesn't pay the one-time (multi-minute) build. Ports are
+    // already bound, so a port conflict still fails fast ahead of this. On a
+    // warm cache it's a fast read. Runs on the blocking pool since circuit
+    // construction is CPU-bound and synchronous.
+    tokio::task::spawn_blocking(common::shrink::warm_prover_circuits)
+        .await
+        .map_err(|err| anyhow!("circuit warm-up task failed: {err}"))?;
+
     // Both ports are ours. Spawn the MCP server; share `Arc<Driver>` and the
     // broadcast hub so MCP, the desktop, and the website drive one process.
     let mcp_event_tx = event_tx.clone();

--- a/dobjd/src/main.rs
+++ b/dobjd/src/main.rs
@@ -42,14 +42,18 @@ async fn main() -> Result<()> {
     let mcp_addr = format!("127.0.0.1:{mcp_port}");
     let mcp_listener = tokio::net::TcpListener::bind(&mcp_addr).await?;
 
-    // Build the proving circuit cache before accepting any requests, so the
-    // first action doesn't pay the one-time (multi-minute) build. Ports are
-    // already bound, so a port conflict still fails fast ahead of this. On a
-    // warm cache it's a fast read. Runs on the blocking pool since circuit
-    // construction is CPU-bound and synchronous.
-    tokio::task::spawn_blocking(common::shrink::warm_prover_circuits)
-        .await
-        .map_err(|err| anyhow!("circuit warm-up task failed: {err}"))?;
+    // Build the proving circuits (recursive MainPod, empty pod, and the VDF +
+    // lt_eq_u256 intro pods) before accepting requests, so the first action
+    // doesn't pay the one-time build. Ports are already bound, so a port
+    // conflict still fails fast ahead of this. On a warm cache it's mostly fast
+    // reads. Runs on the blocking pool since circuit construction is CPU-bound
+    // and synchronous. Best-effort: if it fails, start anyway and let the first
+    // action build whatever is missing on demand.
+    if let Err(err) = tokio::task::spawn_blocking(driver::warm_proving_circuits).await {
+        tracing::warn!(
+            "circuit warm-up did not finish cleanly: {err}; the first action will build any missing circuits on demand"
+        );
+    }
 
     // Both ports are ours. Spawn the MCP server; share `Arc<Driver>` and the
     // broadcast hub so MCP, the desktop, and the website drive one process.

--- a/dobjd/src/progress.rs
+++ b/dobjd/src/progress.rs
@@ -48,6 +48,9 @@ impl SseProgressReporter {
 
 impl ExecutionReporter for SseProgressReporter {
     fn on_step(&self, phase: ExecutionPhase, message: &str, ctx: &ExecutionStepContext) {
+        // Mirror the SSE step to the daemon's own logs/terminal so progress is
+        // visible without an SSE subscriber.
+        tracing::info!(run_id = %self.run_id, ?phase, "{message}");
         let progress = match phase {
             ExecutionPhase::GenerateProof => RunActionProgress {
                 run_id: self.run_id.clone(),
@@ -103,6 +106,7 @@ impl ExecutionReporter for SseProgressReporter {
                 None => return,
             },
         };
+        tracing::info!(run_id = %self.run_id, ?phase, "{}", progress.message);
         self.send(progress);
     }
 }

--- a/driver/src/driver.rs
+++ b/driver/src/driver.rs
@@ -66,7 +66,13 @@ pub struct DriverDeps {
 impl DriverDeps {
     /// Build deps with a catalog loaded from `paths.actions_dir`.
     pub fn load(paths: &DriverPaths) -> Result<Self> {
+        let start = std::time::Instant::now();
+        log::info!(
+            "loading action catalog from {}...",
+            paths.actions_dir.display()
+        );
         let catalog = PexeCatalog::load(&paths.actions_dir)?;
+        log::info!("action catalog loaded in {:?}", start.elapsed());
         if catalog.plugin_count() == 0 {
             log::warn!(
                 "no .pexe plugins installed in {}; run `just install-plugins`",

--- a/driver/src/lib.rs
+++ b/driver/src/lib.rs
@@ -9,6 +9,7 @@ pub mod paths;
 mod pexe_catalog;
 mod settings;
 mod types;
+mod warm;
 
 #[cfg(test)]
 mod tests;
@@ -26,3 +27,4 @@ pub use crate::types::{
     ActionQuery, DriverPaths, ExecuteActionInput, ExecuteActionResult, ExecutionReporter,
     ExecutionStepContext, NoopExecutionReporter, ObjectQuery,
 };
+pub use crate::warm::warm_proving_circuits;

--- a/driver/src/warm.rs
+++ b/driver/src/warm.rs
@@ -6,14 +6,15 @@
 use common::shrink::ShrunkMainPodSetup;
 use lt_eq_u256_pod::LtEqU256Pod;
 use pod2::backends::plonky2::basetypes::DEFAULT_VD_SET;
-use pod2::backends::plonky2::emptypod::cache_get_standard_empty_pod_circuit_data;
+use pod2::backends::plonky2::emptypod::EmptyPod;
 use pod2::middleware::{Params, RawValue};
 use vdfpod::VdfPod;
 
 /// Build every proving circuit the first action would otherwise build lazily,
 /// so the first `execute` is fast. On a cold start the first proof builds:
 /// - the recursive MainPod circuit (pod2's disk cache, the dominant artifact),
-/// - pod2's standard empty pod circuit (recursion padding the prover inserts),
+/// - pod2's empty pod (the proved instance the prover inserts as recursion
+///   padding, plus its circuit),
 /// - the VDF intro pod circuit, including its in-memory `VDF_RECURSIVE_CIRCUIT`
 ///   -- only generating a proof forces that one to build, so we prove a minimal
 ///   input (the VDF requires at least 2 iterations), and
@@ -37,10 +38,12 @@ pub fn warm_proving_circuits() {
     log::info!("warming recursive MainPod circuit (first cold build can take minutes)...");
     let _ = ShrunkMainPodSetup::new(&params);
 
-    // Empty pod: the prover pads recursive slots with it, so proving builds it
-    // on a cold cache even though no action references it directly.
-    log::info!("warming empty pod circuit...");
-    let _ = cache_get_standard_empty_pod_circuit_data();
+    // Empty pod: the prover pads recursive slots with a proved empty pod keyed
+    // by vd_set. `new_boxed` caches that instance ("empty_pod") and, building
+    // it, the empty pod circuit ("standard_empty_pod_circuit_data") -- so this
+    // one call covers both empty pod caches the first proof would build.
+    log::info!("warming empty pod...");
+    let _ = EmptyPod::new_boxed(vd_set.clone());
 
     log::info!("warming VDF intro pod circuit...");
     if let Err(err) = VdfPod::new_boxed(&params, vd_set.clone(), 2, RawValue::from(0_i64)) {

--- a/driver/src/warm.rs
+++ b/driver/src/warm.rs
@@ -1,65 +1,46 @@
 //! Startup warm-up of the proving circuits.
 //!
-//! Building proofs lazily builds several circuits on the first action. This
-//! module forces those builds up front so `dobjd` can do them at boot instead.
+//! Generating a proof lazily builds (or loads) several circuits on the first
+//! action. This module forces those circuit builds/loads up front so `dobjd`
+//! does them at boot instead -- touching circuit data only, never proving.
 
-use anyhow::{Context, Result};
 use common::shrink::ShrunkMainPodSetup;
-use lt_eq_u256_pod::LtEqU256Pod;
-use pod2::backends::plonky2::basetypes::DEFAULT_VD_SET;
-use pod2::backends::plonky2::emptypod::EmptyPod;
-use pod2::middleware::{Params, RawValue};
-use vdfpod::VdfPod;
+use lt_eq_u256_pod::STANDARD_LT_EQ_U256_VD_HASH;
+use pod2::backends::plonky2::emptypod::cache_get_standard_empty_pod_circuit_data;
+use pod2::middleware::Params;
+use vdfpod::STANDARD_VDF_VD_HASH;
 
-/// Build every proving circuit the first action would otherwise build lazily,
-/// so the first `execute` is fast. On a cold start the first proof builds:
+/// Load (building on a cold cache) the proving circuits the first action would
+/// otherwise build lazily, so the first `execute` doesn't pay for them. This
+/// only touches circuit data -- it does not generate proofs:
 /// - the recursive MainPod circuit (pod2's disk cache, the dominant artifact),
-/// - pod2's empty pod (the proved instance the prover inserts as recursion
-///   padding, plus its circuit),
-/// - the VDF intro pod circuit, including its in-memory `VDF_RECURSIVE_CIRCUIT`
-///   -- only generating a proof forces that one to build, so we prove a minimal
-///   input (the VDF requires at least 2 iterations), and
-/// - the lt_eq_u256 intro pod circuit.
+/// - pod2's empty pod circuit,
+/// - the VDF intro pod circuit (forcing `STANDARD_VDF_VD_HASH` loads it), and
+/// - the lt_eq_u256 intro pod circuit (via `STANDARD_LT_EQ_U256_VD_HASH`).
 ///
-/// A failure propagates rather than being swallowed: a circuit that cannot build
-/// at startup would fail every action too, so the caller should refuse to start
-/// rather than serve a daemon that cannot prove. (`ShrunkMainPodSetup::new` and
-/// `EmptyPod::new_boxed` return their value directly and panic internally on a
-/// build/cache failure; that panic is as fatal as the `?`s below.) Idempotent:
-/// already-built circuits load from the disk cache -- though the VDF recursive
-/// circuit is in-memory, so it is rebuilt once per process regardless.
-pub fn warm_proving_circuits() -> Result<()> {
+/// Every step panics internally on a build/cache failure; the caller treats that
+/// panic as fatal, since a circuit that can't build now would fail every action.
+/// Idempotent: a warm disk cache makes each step a fast read.
+pub fn warm_proving_circuits() {
     let start = std::time::Instant::now();
     let params = Params::default();
-    let vd_set = DEFAULT_VD_SET.clone();
     log::info!("warming proving circuits at startup...");
 
-    // Recursive MainPod circuit. Constructing ShrunkMainPodSetup reads pod2's
-    // rec-main-pod common+verifier data, which forces that shared circuit data
-    // (the one `Prover::prove` uses) to be built and cached.
+    // Constructing ShrunkMainPodSetup reads pod2's rec-main-pod common+verifier
+    // data, forcing that shared circuit (the one `Prover::prove` uses) to build.
     log::info!("warming recursive MainPod circuit (first cold build can take minutes)...");
     let _ = ShrunkMainPodSetup::new(&params);
 
-    // Empty pod: the prover pads recursive slots with a proved empty pod keyed
-    // by vd_set. `new_boxed` caches that instance ("empty_pod") and, building
-    // it, the empty pod circuit ("standard_empty_pod_circuit_data").
-    log::info!("warming empty pod...");
-    let _ = EmptyPod::new_boxed(vd_set.clone());
+    log::info!("warming empty pod circuit...");
+    let _ = cache_get_standard_empty_pod_circuit_data();
 
+    // Forcing each intro pod's verifier-data hash drives its circuit data to
+    // load/build, without constructing a pod (which would prove).
     log::info!("warming VDF intro pod circuit...");
-    VdfPod::new_boxed(&params, vd_set.clone(), 2, RawValue::from(0_i64))
-        .context("warming VDF intro pod circuit")?;
+    let _ = *STANDARD_VDF_VD_HASH;
 
-    // lt_eq_u256 requires lhs <= rhs; equal inputs satisfy the precheck.
     log::info!("warming lt_eq_u256 intro pod circuit...");
-    LtEqU256Pod::new_boxed(
-        &params,
-        vd_set,
-        RawValue::from(0_i64),
-        RawValue::from(0_i64),
-    )
-    .context("warming lt_eq_u256 intro pod circuit")?;
+    let _ = *STANDARD_LT_EQ_U256_VD_HASH;
 
     log::info!("proving circuits ready (warmed in {:?})", start.elapsed());
-    Ok(())
 }

--- a/driver/src/warm.rs
+++ b/driver/src/warm.rs
@@ -3,6 +3,7 @@
 //! Building proofs lazily builds several circuits on the first action. This
 //! module forces those builds up front so `dobjd` can do them at boot instead.
 
+use anyhow::{Context, Result};
 use common::shrink::ShrunkMainPodSetup;
 use lt_eq_u256_pod::LtEqU256Pod;
 use pod2::backends::plonky2::basetypes::DEFAULT_VD_SET;
@@ -20,12 +21,14 @@ use vdfpod::VdfPod;
 ///   input (the VDF requires at least 2 iterations), and
 /// - the lt_eq_u256 intro pod circuit.
 ///
-/// Each step is best-effort: a failure is logged and warming continues, so a
-/// warm-up problem never blocks startup -- the first action just builds
-/// whatever is missing, as before. Idempotent: already-built circuits load from
-/// the disk cache (the VDF recursive circuit is in-memory, so it is rebuilt once
-/// per process regardless).
-pub fn warm_proving_circuits() {
+/// A failure propagates rather than being swallowed: a circuit that cannot build
+/// at startup would fail every action too, so the caller should refuse to start
+/// rather than serve a daemon that cannot prove. (`ShrunkMainPodSetup::new` and
+/// `EmptyPod::new_boxed` return their value directly and panic internally on a
+/// build/cache failure; that panic is as fatal as the `?`s below.) Idempotent:
+/// already-built circuits load from the disk cache -- though the VDF recursive
+/// circuit is in-memory, so it is rebuilt once per process regardless.
+pub fn warm_proving_circuits() -> Result<()> {
     let start = std::time::Instant::now();
     let params = Params::default();
     let vd_set = DEFAULT_VD_SET.clone();
@@ -33,33 +36,30 @@ pub fn warm_proving_circuits() {
 
     // Recursive MainPod circuit. Constructing ShrunkMainPodSetup reads pod2's
     // rec-main-pod common+verifier data, which forces that shared circuit data
-    // (the one `Prover::prove` uses) to be built and cached; the value is
-    // dropped -- the populated cache is the point.
+    // (the one `Prover::prove` uses) to be built and cached.
     log::info!("warming recursive MainPod circuit (first cold build can take minutes)...");
     let _ = ShrunkMainPodSetup::new(&params);
 
     // Empty pod: the prover pads recursive slots with a proved empty pod keyed
     // by vd_set. `new_boxed` caches that instance ("empty_pod") and, building
-    // it, the empty pod circuit ("standard_empty_pod_circuit_data") -- so this
-    // one call covers both empty pod caches the first proof would build.
+    // it, the empty pod circuit ("standard_empty_pod_circuit_data").
     log::info!("warming empty pod...");
     let _ = EmptyPod::new_boxed(vd_set.clone());
 
     log::info!("warming VDF intro pod circuit...");
-    if let Err(err) = VdfPod::new_boxed(&params, vd_set.clone(), 2, RawValue::from(0_i64)) {
-        log::warn!("VDF circuit warm-up failed (first action will build it): {err:#}");
-    }
+    VdfPod::new_boxed(&params, vd_set.clone(), 2, RawValue::from(0_i64))
+        .context("warming VDF intro pod circuit")?;
 
     // lt_eq_u256 requires lhs <= rhs; equal inputs satisfy the precheck.
     log::info!("warming lt_eq_u256 intro pod circuit...");
-    if let Err(err) = LtEqU256Pod::new_boxed(
+    LtEqU256Pod::new_boxed(
         &params,
         vd_set,
         RawValue::from(0_i64),
         RawValue::from(0_i64),
-    ) {
-        log::warn!("lt_eq_u256 circuit warm-up failed (first action will build it): {err:#}");
-    }
+    )
+    .context("warming lt_eq_u256 intro pod circuit")?;
 
     log::info!("proving circuits ready (warmed in {:?})", start.elapsed());
+    Ok(())
 }

--- a/driver/src/warm.rs
+++ b/driver/src/warm.rs
@@ -1,0 +1,62 @@
+//! Startup warm-up of the proving circuits.
+//!
+//! Building proofs lazily builds several circuits on the first action. This
+//! module forces those builds up front so `dobjd` can do them at boot instead.
+
+use common::shrink::ShrunkMainPodSetup;
+use lt_eq_u256_pod::LtEqU256Pod;
+use pod2::backends::plonky2::basetypes::DEFAULT_VD_SET;
+use pod2::backends::plonky2::emptypod::cache_get_standard_empty_pod_circuit_data;
+use pod2::middleware::{Params, RawValue};
+use vdfpod::VdfPod;
+
+/// Build every proving circuit the first action would otherwise build lazily,
+/// so the first `execute` is fast. On a cold start the first proof builds:
+/// - the recursive MainPod circuit (pod2's disk cache, the dominant artifact),
+/// - pod2's standard empty pod circuit (recursion padding the prover inserts),
+/// - the VDF intro pod circuit, including its in-memory `VDF_RECURSIVE_CIRCUIT`
+///   -- only generating a proof forces that one to build, so we prove a minimal
+///   input (the VDF requires at least 2 iterations), and
+/// - the lt_eq_u256 intro pod circuit.
+///
+/// Each step is best-effort: a failure is logged and warming continues, so a
+/// warm-up problem never blocks startup -- the first action just builds
+/// whatever is missing, as before. Idempotent: already-built circuits load from
+/// the disk cache (the VDF recursive circuit is in-memory, so it is rebuilt once
+/// per process regardless).
+pub fn warm_proving_circuits() {
+    let start = std::time::Instant::now();
+    let params = Params::default();
+    let vd_set = DEFAULT_VD_SET.clone();
+    log::info!("warming proving circuits at startup...");
+
+    // Recursive MainPod circuit. Constructing ShrunkMainPodSetup reads pod2's
+    // rec-main-pod common+verifier data, which forces that shared circuit data
+    // (the one `Prover::prove` uses) to be built and cached; the value is
+    // dropped -- the populated cache is the point.
+    log::info!("warming recursive MainPod circuit (first cold build can take minutes)...");
+    let _ = ShrunkMainPodSetup::new(&params);
+
+    // Empty pod: the prover pads recursive slots with it, so proving builds it
+    // on a cold cache even though no action references it directly.
+    log::info!("warming empty pod circuit...");
+    let _ = cache_get_standard_empty_pod_circuit_data();
+
+    log::info!("warming VDF intro pod circuit...");
+    if let Err(err) = VdfPod::new_boxed(&params, vd_set.clone(), 2, RawValue::from(0_i64)) {
+        log::warn!("VDF circuit warm-up failed (first action will build it): {err:#}");
+    }
+
+    // lt_eq_u256 requires lhs <= rhs; equal inputs satisfy the precheck.
+    log::info!("warming lt_eq_u256 intro pod circuit...");
+    if let Err(err) = LtEqU256Pod::new_boxed(
+        &params,
+        vd_set,
+        RawValue::from(0_i64),
+        RawValue::from(0_i64),
+    ) {
+        log::warn!("lt_eq_u256 circuit warm-up failed (first action will build it): {err:#}");
+    }
+
+    log::info!("proving circuits ready (warmed in {:?})", start.elapsed());
+}

--- a/driver/src/warm.rs
+++ b/driver/src/warm.rs
@@ -1,25 +1,26 @@
 //! Startup warm-up of the proving circuits.
 //!
-//! Generating a proof lazily builds (or loads) several circuits on the first
-//! action. This module forces those circuit builds/loads up front so `dobjd`
-//! does them at boot instead -- touching circuit data only, never proving.
+//! Generating a proof lazily builds (or loads) several artifacts on the first
+//! action. This module forces those builds/loads up front so `dobjd` does them
+//! at boot instead.
 
 use common::shrink::ShrunkMainPodSetup;
 use lt_eq_u256_pod::STANDARD_LT_EQ_U256_VD_HASH;
-use pod2::backends::plonky2::emptypod::cache_get_standard_empty_pod_circuit_data;
+use pod2::backends::plonky2::basetypes::DEFAULT_VD_SET;
+use pod2::backends::plonky2::emptypod::EmptyPod;
+use pod2::backends::plonky2::mainpod::cache_get_rec_main_pod_common_hash;
 use pod2::middleware::Params;
 use vdfpod::STANDARD_VDF_VD_HASH;
 
-/// Load (building on a cold cache) the proving circuits the first action would
-/// otherwise build lazily, so the first `execute` doesn't pay for them. This
-/// only touches circuit data -- it does not generate proofs:
-/// - the recursive MainPod circuit (pod2's disk cache, the dominant artifact),
-/// - pod2's empty pod circuit,
-/// - the VDF intro pod circuit (forcing `STANDARD_VDF_VD_HASH` loads it), and
-/// - the lt_eq_u256 intro pod circuit (via `STANDARD_LT_EQ_U256_VD_HASH`).
+/// Load (building on a cold cache) the proving artifacts the first action would
+/// otherwise build lazily, so the first `execute` doesn't pay for them:
+/// - the recursive MainPod circuit and its common hash,
+/// - the VDF and lt_eq_u256 intro pod circuits (via their verifier-data hashes),
+/// - the empty pod: both its circuit and the proved *instance* the prover
+///   inserts as recursion padding.
 ///
 /// Every step panics internally on a build/cache failure; the caller treats that
-/// panic as fatal, since a circuit that can't build now would fail every action.
+/// as fatal, since an artifact that can't build now would fail every action.
 /// Idempotent: a warm disk cache makes each step a fast read.
 pub fn warm_proving_circuits() {
     let start = std::time::Instant::now();
@@ -31,8 +32,17 @@ pub fn warm_proving_circuits() {
     log::info!("warming recursive MainPod circuit (first cold build can take minutes)...");
     let _ = ShrunkMainPodSetup::new(&params);
 
-    log::info!("warming empty pod circuit...");
-    let _ = cache_get_standard_empty_pod_circuit_data();
+    // The intro pods stamp this onto every pod they build (VdfPod::new /
+    // LtEqU256Pod::new); a cheap hash of the rec-main-pod common circuit, but a
+    // disk cache the first action would otherwise write.
+    log::info!("warming rec MainPod common hash...");
+    let _ = cache_get_rec_main_pod_common_hash(&params);
+
+    // Empty pod: new_boxed proves+caches the instance the prover pads recursive
+    // slots with (keyed by vd_set), and building it also builds the empty pod
+    // circuit -- so this covers both empty pod caches the first proof would hit.
+    log::info!("warming empty pod (circuit + instance)...");
+    let _ = EmptyPod::new_boxed(DEFAULT_VD_SET.clone());
 
     // Forcing each intro pod's verifier-data hash drives its circuit data to
     // load/build, without constructing a pod (which would prove).

--- a/justfile
+++ b/justfile
@@ -46,6 +46,23 @@ dev: ensure-db ensure-plugins ensure-mcp
 dev-remote: ensure-remote-settings ensure-plugins ensure-mcp
     mprocs --config mprocs.remote.yaml
 
+# Block (up to ~5 min) until an HTTP endpoint responds, then return. mprocs
+# uses this to launch synchronizer -> relayer -> dobjd -> web -> desktop in
+# order, each gated on the previous one's health, so they don't race to
+# cold-build the shared proving-circuit cache on first run.
+wait-health URL:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    echo "waiting for {{URL}} ..."
+    for _ in $(seq 1 600); do
+        if curl -sf "{{URL}}" >/dev/null 2>&1; then
+            echo "{{URL}} is up"
+            exit 0
+        fi
+        sleep 0.5
+    done
+    echo "timed out waiting for {{URL}}; starting anyway"
+
 # Idempotently point ~/.dobj/settings.json at the hosted synchronizer + relayer
 ensure-remote-settings:
     @mkdir -p ~/.dobj

--- a/mprocs.remote.yaml
+++ b/mprocs.remote.yaml
@@ -1,7 +1,11 @@
+# dev-remote uses the hosted synchronizer + relayer, so dobjd is the only local
+# prover (no cross-process cache race). Still launch dobjd -> web -> desktop in
+# order so the UI doesn't flash connection errors while dobjd warms, and the
+# desktop shell opens only after its Vite server on :1420 is up.
 procs:
   dobjd:
     shell: just dobjd
   web:
-    shell: just web
+    shell: just wait-health http://127.0.0.1:7717/healthz && just web
   desktop:
-    shell: just desktop-shell
+    shell: just wait-health http://localhost:1420 && just desktop-shell

--- a/mprocs.yaml
+++ b/mprocs.yaml
@@ -1,11 +1,16 @@
+# Launch order: synchronizer -> relayer -> dobjd -> web -> desktop. Each proc
+# waits for the previous one's health endpoint before starting, so they don't
+# race to cold-build the shared proving-circuit cache (and the desktop shell
+# opens only once its Vite server on :1420 is up). Ports are the service
+# defaults (synchronizer :3000, relayer :3200, dobjd :7717).
 procs:
   synchronizer:
     shell: just sync
   relayer:
-    shell: just relayer
+    shell: just wait-health http://127.0.0.1:3000/healthz && just relayer
   dobjd:
-    shell: just dobjd
+    shell: just wait-health http://127.0.0.1:3200/healthz && just dobjd
   web:
-    shell: just web
+    shell: just wait-health http://127.0.0.1:7717/healthz && just web
   desktop:
-    shell: just desktop-shell
+    shell: just wait-health http://localhost:1420 && just desktop-shell

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -2267,8 +2267,11 @@ impl Executor {
         // to mask them from the relayer / synchronizer's `ProofParser`,
         // which expects a single public statement.
         log::info!("proving tx_pod for action {}", action);
+        let start = std::time::Instant::now();
         let tx_pod = prove(bld.builder, &*self.prover);
         tx_pod.pod.verify().unwrap();
+        let duration = start.elapsed();
+        log::info!("proving tx_pod for action {} took {:?}", action, duration);
 
         let objs: Vec<SpendableObject> = outputs
             .into_iter()

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -2244,7 +2244,10 @@ impl Executor {
             outputs: Vec::new(),
         }));
         let action_handle = ActionHandle::new(action.to_string(), Some(exe_rc.clone()));
+        log::info!("executing action {}", action);
+        let start = std::time::Instant::now();
         action_handle.exe_action()?;
+        log::info!("executing action {} took {:?}", action, start.elapsed());
 
         // Release the handle's Rc clone so `exe_rc` has a unique
         // owner for the `try_unwrap` below.
@@ -2270,8 +2273,11 @@ impl Executor {
         let start = std::time::Instant::now();
         let tx_pod = prove(bld.builder, &*self.prover);
         tx_pod.pod.verify().unwrap();
-        let duration = start.elapsed();
-        log::info!("proving tx_pod for action {} took {:?}", action, duration);
+        log::info!(
+            "proving tx_pod for action {} took {:?}",
+            action,
+            start.elapsed()
+        );
 
         let objs: Vec<SpendableObject> = outputs
             .into_iter()


### PR DESCRIPTION
Fixes https://github.com/dobjlabs/zk-craft/issues/30, https://github.com/dobjlabs/zk-craft/issues/15

The synchronizer & relayer already pre-load proof artifacts on startup by calling `ProofParser::new()`. This PR makes the driver also pre-load all proof artifacts the actions will use.

I also added some more logs to see various timings.

The synchronizer, relayer, and dobjd now write similar pod2 caches so they sometimes crash if they are running in parallel. Also, the desktop app shows empty if the dobjd is not up yet. So, I updated the dev flow so it launches them one after another. In production, this is not an issue as users only run dobjd and synchronizer/relayer also have crash-recovery mechanisms. 