### PR TITLE
Split txlib into two modules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,7 +98,7 @@ Use `just` (recipes in `justfile`):
 - **`driver/src/pexe_catalog.rs`** — concrete `ActionCatalog` impl that loads `.pexe` archives from `~/.dobj/actions/`.
 - **`sdk/src/lib.rs`** — Rhai engine setup, custom syntax for `var` and `unsafe { ... }` (search `register_custom_syntax`), host API registration (search `register_fn`). Entry: `Sdk::load_module_from_src_actions`.
 - **`txlib/src/lib.rs`** — `StateRoot` (typed record), `GroundingWitness`, `Tx`, `TxBuilder`. No `Object` struct: object state is a `pod2::Dictionary` whose `identity` field is the commitment of its initial form (`with_identity`), stable across mutations.
-- **`txlib/src/predicates/txlib.podlang`** — the transaction state machine. See "txlib and the SDK" below.
+- **`txlib/src/predicates/txlib.podlang`** — the transaction state machine (replay, grounding, `TxFinalized`). Imports **`tx_events.podlang`**, the frozen chain-primitive batch (`TxInsert`/`TxMutate`/`TxDelete`) whose id is pinned by a test. See "txlib and the SDK" below.
 - **`synchronizer/src/state_machine.rs`** — `MAX_GSR_AGE_BLOCKS = 300`. Pure derivation: takes a base head + recent GSRs + decoded blob bytes; returns a candidate head.
 - **`synchronizer/src/api.rs`** — Axum routes (`/v1/state/head`, `/v1/state/membership`, `/v1/state/object/contains`, `/v1/state/nullifier/contains`, `/v1/txlib/grounding-witness`, plus `/healthz`, `/sync-progress`).
 - **`common/src/shrink.rs`** — Plonky2 wrapper circuit that re-proves a MainPod in a smaller circuit so it fits in a blob.
@@ -113,11 +113,11 @@ Use `just` (recipes in `justfile`):
 
 ## txlib and the SDK
 
-txlib's proof machinery is consumed only through the SDK. Its plain types (`StateRoot`, `GroundingWitness`) are shared more widely (the synchronizer computes GSRs), but the predicate batch and `TxBuilder` are not: the SDK loads the batch (`txlib::predicates::module()`) alongside the plugin module, drives `TxBuilder`, and is the only code that names txlib predicates.
+txlib's proof machinery is consumed only through the SDK. Its plain types (`StateRoot`, `GroundingWitness`) are shared more widely (the synchronizer computes GSRs), but the predicate batches and `TxBuilder` are not: the SDK loads both batches (`txlib::predicates::events_module()` and `module()`) alongside the plugin module, drives `TxBuilder`, and is the only code that names txlib predicates.
 
-What an action script actually touches is small. Each recorded event emits one of three chain primitives -- `TxInsert`, `TxMutate`, `TxDelete` (rendered in `sdk/src/fmt_podlang.rs`) -- and the whole transaction is proved against the top-level `TxFinalized` rule. `TxMutate`'s shared `type` arg pins `old.type == new.type` implicitly and preserves the object's `identity` across the mutation.
+The predicates are split across two batches. `tx_events.podlang` holds the three chain primitives -- `TxInsert`, `TxMutate`, `TxDelete` -- the only txlib predicates an action script's rendered podlang ever references (via `tx::`, rendered in `sdk/src/fmt_podlang.rs`). Plugin module hashes bake in only this batch's id, so it is frozen: its id is pinned by `test_events_module_hash_pinned`, and editing it invalidates every plugin manifest and recorded proof. `TxMutate`'s shared `type` arg pins `old.type == new.type` implicitly and preserves the object's `identity` across the mutation.
 
-Everything between those is fixed scaffolding inside the batch that the SDK and `TxBuilder` compose automatically; you never write or reference it from a script. It is the replay walker (`ReplayActions` and friends) that re-walks the recorded event chain to update the live/nullifier sets, and grounding (`InputsGrounded`) that proves each input existed in a prior state root. Opened in `txlib.podlang`, the file reads bottom-up: chain primitives -> replay -> grounding -> `TxFinalized`.
+`txlib.podlang` (the batch from `module()`, which imports the events batch) is fixed scaffolding that the SDK and `TxBuilder` compose automatically; you never write or reference it from a script, and it can churn without touching plugin hashes. It is the replay walker (`ReplayActions` and friends) that re-walks the recorded event chain to update the live/nullifier sets, grounding (`InputsGrounded`) that proves each input existed in a prior state root, and the top-level `TxFinalized` rule the whole transaction is proved against. The file reads bottom-up: replay -> grounding -> `TxFinalized`.
 
 ## SDK essentials
 

--- a/pexe/src/inspect.rs
+++ b/pexe/src/inspect.rs
@@ -17,9 +17,10 @@ use sdk::{Dependency, Sdk, SdkModule, manifest::Manifest};
 
 use crate::{PluginSource, read_pexe_file, unpack};
 
-/// txlib's compiled predicate module. Building it isn't free, so we
-/// share one instance between the two event-hash statics below.
-static TXLIB_MODULE: LazyLock<pod2::lang::Module> = LazyLock::new(txlib::predicates::module);
+/// txlib's compiled chain-primitive module. Building it isn't free, so
+/// we share one instance between the two event-hash statics below.
+static TX_EVENTS_MODULE: LazyLock<pod2::lang::Module> =
+    LazyLock::new(txlib::predicates::events_module);
 
 /// Hashes of `Predicate::Custom(txlib::TxInsert)` and `TxMutate`. Used
 /// to identify txlib events regardless of which batch referenced them.
@@ -27,10 +28,10 @@ static TX_INSERT_HASH: LazyLock<Hash> = LazyLock::new(|| txlib_event_hash("TxIns
 static TX_MUTATE_HASH: LazyLock<Hash> = LazyLock::new(|| txlib_event_hash("TxMutate"));
 
 fn txlib_event_hash(name: &str) -> Hash {
-    let custom_ref = TXLIB_MODULE
+    let custom_ref = TX_EVENTS_MODULE
         .batch
         .predicate_ref_by_name(name)
-        .unwrap_or_else(|| panic!("txlib module is missing predicate {name}"));
+        .unwrap_or_else(|| panic!("tx_events module is missing predicate {name}"));
     Predicate::Custom(custom_ref).hash()
 }
 

--- a/plugins/craft-basics/manifest.toml
+++ b/plugins/craft-basics/manifest.toml
@@ -2,7 +2,7 @@
 name = "craft-basics"
 version = "0.1.0"
 # Rewritten by `cargo run -p pexe -- build plugins/craft-basics`.
-module_hash = "92eeef2a638c02fc9ba3de5ba17c70bf5168e47522d8055c3e4b9ebf9a46d8cd"
+module_hash = "1327998e7704f3868c069d7bdd527ffaf0d6ae7bc0bf97bde6935bb7272dce57"
 
 [[classes]]
 name = "Log"

--- a/plugins/episode-1/manifest.toml
+++ b/plugins/episode-1/manifest.toml
@@ -2,7 +2,7 @@
 name = "episode-1"
 version = "0.1.0"
 # Rewritten by `cargo run -p pexe -- build plugins/episode-1`.
-module_hash = "2d352db701ea02eed4ebed75c7cf1f5bc7b7ffe2dde2e6c63b54f8b58cafba69"
+module_hash = "827e81d712e9daec361cca12184e9e1fd6799aebf86e78ac6f3b09a44f74a107"
 
 # ── raw resources ────────────────────────────────────────────────────────────
 

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -159,7 +159,7 @@ The emitted podlang embeds `target` as a hex `Raw(0x00…)` literal.
 The example in the test `test_sdk_1` produces the following podlang code:
 
 ```
-use module 0x8dcb7d36f8cb0504e533f124246671b983a78072d1ec8e80604cf01a831327b8 as tx
+use module 0x845770b5494c1793e749c7110c0db3e0faefd0d675cd11f83901432dc08dccd2 as tx
 use intro Vdf(count, input, output) from 0xab82223f501b5056f458f063eb2fc073f8ac01f2ea178a3a2303394fec6828a0
 use intro LtEqU256(lhs, rhs) from 0xe0595e5c75467e5a27bd30fa48a45e1dcc66a327076e5ce7c02ce33dfe357311
 

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -1831,6 +1831,10 @@ pub struct ClassMeta {
 
 /// The Loader is used to store declarative module information at Load time.
 struct Loader {
+    // The frozen chain-primitive batch (TxInsert/TxMutate/TxDelete).
+    // The only txlib module the rendered plugin source imports, so
+    // plugin module hashes survive churn in the replay/finalize batch.
+    tx_events_mod: Arc<Module>,
     txlib_mod: Arc<Module>,
     dependencies: Vec<Dependency>,
     actions: Vec<ActionHandle>,
@@ -1868,11 +1872,12 @@ impl Loader {
     }
 
     fn new(actions: Vec<ActionHandle>) -> Result<Self> {
+        let tx_events_mod = Arc::new(txlib::predicates::events_module());
         let txlib_mod = Arc::new(txlib::predicates::module());
         let dependencies = vec![
             Dependency::Module {
                 name: "tx".to_string(),
-                hash: txlib_mod.id(),
+                hash: tx_events_mod.id(),
             },
             Dependency::Intro {
                 pred: "Vdf(count, input, output)".to_string(),
@@ -1890,6 +1895,7 @@ impl Loader {
         }
         let classes = Self::actions_to_classes(&actions_meta);
         Ok(Self {
+            tx_events_mod,
             txlib_mod,
             dependencies,
             actions,
@@ -1925,7 +1931,7 @@ impl Loader {
                 podlang_src.as_str(),
                 "root",
                 &params,
-                slice::from_ref(&self.txlib_mod),
+                slice::from_ref(&self.tx_events_mod),
             )
             .expect("compiles"),
         );
@@ -1940,6 +1946,7 @@ impl Loader {
             })
             .collect();
         SdkModule {
+            tx_events_mod: self.tx_events_mod,
             txlib_mod: self.txlib_mod,
             podlang_src,
             actions: self.actions_meta,
@@ -1956,6 +1963,7 @@ impl Loader {
 
 /// An SdkModule contains a loaded module and allows executing actions.
 pub struct SdkModule {
+    tx_events_mod: Arc<Module>,
     txlib_mod: Arc<Module>,
     podlang_src: String,
     actions: Vec<ActionMeta>,
@@ -2185,7 +2193,11 @@ impl Executor {
             (vd_set.clone(), Box::new(real_prover))
         };
         let params = Params::default();
-        let modules = vec![module.txlib_mod.clone(), module.module.clone()];
+        let modules = vec![
+            module.tx_events_mod.clone(),
+            module.txlib_mod.clone(),
+            module.module.clone(),
+        ];
         Self {
             mock,
             params,

--- a/sdk/src/tests.rs
+++ b/sdk/src/tests.rs
@@ -243,7 +243,7 @@ fn test_sdk_2() {
         [plugin]
         name = "test"
         version = "0.1.0"
-        module_hash = "6d86a1d566857bec6774e9811de4df643ac6aabf56cce05eb81ee170132ce87b"
+        module_hash = "c3ebd7d7efd444fa26be03f912fba53e7f8931ddcf49e1b973be18d800eec271"
 
         [[classes]]
         name = "Log"

--- a/txlib/README.md
+++ b/txlib/README.md
@@ -50,7 +50,7 @@ This is what ties the two halves together. The action statement commits to a ran
 
 Replay is structured as recursive OR-walking over the chain. Four layers, bottom up:
 
-1. **Chain primitives.** `TxInsert`, `TxMutate`, `TxDelete` each witness one hash-step and pin the affected object's `type`. These primitives are referenced both by application action predicates at record time and by replay at finalize time, so the chain-step hash work is proved exactly once.
+1. **Chain primitives.** `TxInsert`, `TxMutate`, `TxDelete` each witness one hash-step and pin the affected object's `type`. These primitives are referenced both by application action predicates at record time and by replay at finalize time, so the chain-step hash work is proved exactly once. They live in their own podlang module (`tx_events.podlang`, imported by `txlib.podlang`) so that their hashes -- which every plugin module and recorded transaction bakes in -- survive churn in the replay and finalize predicates.
 
 2. **Replay.** Conceptually, replay walks the event tree and applies each step's state change and guard dispatch. In pseudocode:
 

--- a/txlib/src/lib.rs
+++ b/txlib/src/lib.rs
@@ -1260,9 +1260,10 @@ mod tests {
     /// Tx 2: MineStone using the WoodPick (mutate pick + insert stone).
     #[test]
     fn test_mine_stone() {
+        let events = Arc::new(crate::predicates::events_module());
         let txlib = Arc::new(crate::predicates::module());
         let craft = Arc::new(crate::predicates::crafting_test_module());
-        let modules = vec![txlib.clone(), craft.clone()];
+        let modules = vec![events, txlib.clone(), craft.clone()];
 
         let is_wood_pick = Value::from(
             Predicate::Custom(craft.predicate_ref_by_name("IsWoodPick").unwrap()).hash(),
@@ -1398,9 +1399,10 @@ mod tests {
     /// Tx 3: CraftSticks (delete wood, insert two sticks).
     #[test]
     fn test_craft_sticks() {
+        let events = Arc::new(crate::predicates::events_module());
         let txlib = Arc::new(crate::predicates::module());
         let craft = Arc::new(crate::predicates::crafting_test_module());
-        let modules = vec![txlib.clone(), craft.clone()];
+        let modules = vec![events, txlib.clone(), craft.clone()];
 
         let is_log =
             Value::from(Predicate::Custom(craft.predicate_ref_by_name("IsLog").unwrap()).hash());
@@ -1609,9 +1611,10 @@ mod tests {
     /// one- and two-input tests never reach.
     #[test]
     fn test_grounds_three_inputs() {
+        let events = Arc::new(crate::predicates::events_module());
         let txlib = Arc::new(crate::predicates::module());
         let craft = Arc::new(crate::predicates::crafting_test_module());
-        let modules = vec![txlib.clone(), craft.clone()];
+        let modules = vec![events, txlib.clone(), craft.clone()];
 
         let is_log =
             Value::from(Predicate::Custom(craft.predicate_ref_by_name("IsLog").unwrap()).hash());

--- a/txlib/src/predicates/crafting_test.podlang
+++ b/txlib/src/predicates/crafting_test.podlang
@@ -4,7 +4,7 @@
   structural correctness of actions, replay, and guard dispatch.
 */
 
-use module 0xTXLIB_MODULE_HASH as tx
+use module 0xTX_EVENTS_MODULE_HASH as tx
 
 // ========================================================
 // Deletion Sub-Actions

--- a/txlib/src/predicates/mod.rs
+++ b/txlib/src/predicates/mod.rs
@@ -1,24 +1,38 @@
-#[cfg(test)]
 use std::sync::Arc;
 
 use pod2::lang::{self, load_module};
 
-#[cfg(test)]
-const TXLIB_HASH_PLACEHOLDER: &str = "0xTXLIB_MODULE_HASH";
+const TX_EVENTS_HASH_PLACEHOLDER: &str = "0xTX_EVENTS_MODULE_HASH";
 
 #[cfg(test)]
 /// Load the test crafting predicates (simplified, no VDF).
 pub fn crafting_test_module() -> lang::Module {
     let params = pod2::middleware::Params::default();
-    let txlib = Arc::new(module());
-    let txlib_hash = format!("{:#}", txlib.batch.id());
-    let source = include_str!("crafting_test.podlang").replace(TXLIB_HASH_PLACEHOLDER, &txlib_hash);
-    load_module(&source, "craft", &params, &[txlib]).expect("crafting_test.podlang compiles")
+    let events = Arc::new(events_module());
+    let events_hash = format!("{:#}", events.batch.id());
+    let source =
+        include_str!("crafting_test.podlang").replace(TX_EVENTS_HASH_PLACEHOLDER, &events_hash);
+    load_module(&source, "craft", &params, &[events]).expect("crafting_test.podlang compiles")
 }
 
+/// The chain-primitive event predicates (TxInsert/TxMutate/TxDelete).
+/// Kept in their own batch so action predicates and recorded
+/// transactions keep stable hashes across edits to the replay and
+/// finalize predicates in [`module`].
+pub fn events_module() -> lang::Module {
+    let params = pod2::middleware::Params::default();
+    load_module(include_str!("tx_events.podlang"), "txev", &params, &[])
+        .expect("tx_events.podlang compiles")
+}
+
+/// The replay/grounding/finalize predicates. Imports [`events_module`]
+/// for the chain primitives.
 pub fn module() -> lang::Module {
     let params = pod2::middleware::Params::default();
-    load_module(include_str!("txlib.podlang"), "tx", &params, &[]).expect("txlib.podlang compiles")
+    let events = Arc::new(events_module());
+    let events_hash = format!("{:#}", events.batch.id());
+    let source = include_str!("txlib.podlang").replace(TX_EVENTS_HASH_PLACEHOLDER, &events_hash);
+    load_module(&source, "tx", &params, &[events]).expect("txlib.podlang compiles")
 }
 
 #[cfg(test)]
@@ -49,15 +63,33 @@ mod tests {
         module.predicate_ref_by_name("IsStone").unwrap();
     }
 
+    // Every plugin module hash and every recorded transaction bakes in
+    // the events batch id. If this test fails, the change is
+    // interface-breaking: every plugin manifest must be regenerated and
+    // existing proofs/objects no longer verify. Only then update the
+    // pinned hash.
+    #[test]
+    fn test_events_module_hash_pinned() {
+        let module = events_module();
+        assert_eq!(
+            format!("{:#}", module.batch.id()),
+            "0x845770b5494c1793e749c7110c0db3e0faefd0d675cd11f83901432dc08dccd2",
+        );
+    }
+
+    #[test]
+    fn test_events_predicates_exist() {
+        let module = events_module();
+
+        module.predicate_ref_by_name("TxInsert").unwrap();
+        module.predicate_ref_by_name("TxMutate").unwrap();
+        module.predicate_ref_by_name("TxDelete").unwrap();
+    }
+
     #[test]
     fn test_predicates_exist() {
         let module = module();
         println!("txlib id: {:#}", module.batch.id());
-
-        // Chain primitives
-        module.predicate_ref_by_name("TxInsert").unwrap();
-        module.predicate_ref_by_name("TxMutate").unwrap();
-        module.predicate_ref_by_name("TxDelete").unwrap();
 
         // Replay structure
         module.predicate_ref_by_name("ReplayActions").unwrap();

--- a/txlib/src/predicates/tx_events.podlang
+++ b/txlib/src/predicates/tx_events.podlang
@@ -1,0 +1,56 @@
+/*
+  tx_events: the chain-primitive event predicates.
+
+  These three predicates are the stable interface between txlib and
+  every action predicate compiled by the SDK: each recorded event in
+  an action references one of them, so their hashes are baked into
+  every plugin module hash and every recorded transaction. They live
+  in their own module so that churn in the replay/finalize predicates
+  (txlib.podlang, which imports this module) does not change their
+  hashes. Edits here are interface-breaking: they invalidate every
+  plugin manifest and recorded proof, so the module's batch id is
+  pinned by a test in mod.rs.
+
+  Called by application action predicates (e.g. CraftWoodPick,
+  UseWoodPick) to record events into the hash chain. These prove
+  the hash relationship but do not update live/nullifier sets --
+  that happens during replay.
+*/
+
+// Insert: chain = H(prev, H({}, new)). The `type` arg pins the
+// inserted object's type field so ReplayInsert can dispatch the
+// guard without re-extracting it. The DictInsert clause stamps
+// `new.identity = commitment(initial)`: `initial` is the
+// pre-identity object dict the action constructed (script-driven
+// DictUpdates land on `initial`), and `new` is the materialized
+// post-identity dict the tx records in its `live` set. Exposing
+// `initial` as a public arg lets the calling action predicate
+// share its body wildcard with both the script's DictUpdate chain
+// and TxInsert's identity-derivation clause.
+TxInsert(chain, prev_chain, initial, new, type, private: event_hash) = AND(
+  DictContains(new, "type", type)
+  DictInsert(new, initial, "identity", initial)
+  HashOf(event_hash, {}, new)
+  HashOf(chain, prev_chain, event_hash)
+)
+
+// Mutate: chain = H(prev, H(old, new)). The shared `type` arg pins
+// both old and new to the same type, enforcing type preservation
+// implicitly (no separate Equal needed). The Equal clause pins
+// old.identity == new.identity so the stable per-instance identifier
+// set by TxInsert survives every mutation.
+TxMutate(chain, prev_chain, new, old, type, private: event_hash) = AND(
+  DictContains(new, "type", type)
+  DictContains(old, "type", type)
+  Equal(old.identity, new.identity)
+  HashOf(event_hash, old, new)
+  HashOf(chain, prev_chain, event_hash)
+)
+
+// Delete: chain = H(prev, H(old, {})). The `type` arg pins the
+// deleted object's type field for guard dispatch.
+TxDelete(chain, prev_chain, old, type, private: event_hash) = AND(
+  DictContains(old, "type", type)
+  HashOf(event_hash, old, {})
+  HashOf(chain, prev_chain, event_hash)
+)

--- a/txlib/src/predicates/txlib.podlang
+++ b/txlib/src/predicates/txlib.podlang
@@ -3,20 +3,18 @@
 
   See README.md for the conceptual overview (what a transaction is,
   what actions and classes are, how replay validates state changes).
-  This file is the implementation, organized in four layers, bottom-up:
+  The chain primitives (TxInsert/TxMutate/TxDelete) live in the
+  imported tx_events module so their hashes survive churn in this
+  file. This file is the rest, organized in three layers, bottom-up:
 
-  1. Chain Primitives -- hash chain steps for each event type.
-     Called by application action predicates (e.g. MineStone) to
-     record events. These are the building blocks.
-
-  2. Replay -- walks the recorded chain, verifying each event's
+  1. Replay -- walks the recorded chain, verifying each event's
      hash step, updating the live/nullifier sets, and calling the
      affected object's type guard to authorize the event.
 
-  3. InputsGrounded -- proves each input object is present in the
+  2. InputsGrounded -- proves each input object is present in the
      global created set carried by the state root.
 
-  4. TxFinalized -- the public entry point. Ties input grounding,
+  3. TxFinalized -- the public entry point. Ties input grounding,
      chain seeding, and full replay together. Exposes
      (state_root, tx_final, nullifiers, live) publicly.
 
@@ -34,52 +32,7 @@
   }
 */
 
-// ========================================================
-// Chain Primitives
-// ========================================================
-//
-// Called by application action predicates (e.g. CraftWoodPick,
-// UseWoodPick) to record events into the hash chain. These prove
-// the hash relationship but do not update live/nullifier sets --
-// that happens during replay.
-
-// Insert: chain = H(prev, H({}, new)). The `type` arg pins the
-// inserted object's type field so ReplayInsert can dispatch the
-// guard without re-extracting it. The DictInsert clause stamps
-// `new.identity = commitment(initial)`: `initial` is the
-// pre-identity object dict the action constructed (script-driven
-// DictUpdates land on `initial`), and `new` is the materialized
-// post-identity dict the tx records in its `live` set. Exposing
-// `initial` as a public arg lets the calling action predicate
-// share its body wildcard with both the script's DictUpdate chain
-// and TxInsert's identity-derivation clause.
-TxInsert(chain, prev_chain, initial, new, type, private: event_hash) = AND(
-  DictContains(new, "type", type)
-  DictInsert(new, initial, "identity", initial)
-  HashOf(event_hash, {}, new)
-  HashOf(chain, prev_chain, event_hash)
-)
-
-// Mutate: chain = H(prev, H(old, new)). The shared `type` arg pins
-// both old and new to the same type, enforcing type preservation
-// implicitly (no separate Equal needed). The Equal clause pins
-// old.identity == new.identity so the stable per-instance identifier
-// set by TxInsert survives every mutation.
-TxMutate(chain, prev_chain, new, old, type, private: event_hash) = AND(
-  DictContains(new, "type", type)
-  DictContains(old, "type", type)
-  Equal(old.identity, new.identity)
-  HashOf(event_hash, old, new)
-  HashOf(chain, prev_chain, event_hash)
-)
-
-// Delete: chain = H(prev, H(old, {})). The `type` arg pins the
-// deleted object's type field for guard dispatch.
-TxDelete(chain, prev_chain, old, type, private: event_hash) = AND(
-  DictContains(old, "type", type)
-  HashOf(event_hash, old, {})
-  HashOf(chain, prev_chain, event_hash)
-)
+use module 0xTX_EVENTS_MODULE_HASH as tx
 
 // ========================================================
 // Replay: Helpers
@@ -137,7 +90,7 @@ ReplayContents(before_tx, after_tx, before_chain, after_chain) = OR(
 // wrapping per-event predicate.
 ReplayContentsStepInsert(before_tx, after_tx, before_chain, after_chain,
     private: mid_tx, mid_chain, ins, guard) = AND(
-  TxInsert(mid_chain, before_chain, ins.initial, ins.new, guard)
+  tx::TxInsert(mid_chain, before_chain, ins.initial, ins.new, guard)
   SetInsert(ins.new_live, before_tx.live, ins.new)
   DictUpdate(mid_tx, before_tx, "live", ins.new_live)
   guard(ins.new, before_tx.chain_start, before_tx.chain_end)
@@ -146,7 +99,7 @@ ReplayContentsStepInsert(before_tx, after_tx, before_chain, after_chain,
 
 ReplayContentsStepMutate(before_tx, after_tx, before_chain, after_chain,
     private: mid_tx, mid_chain, pair, guard) = AND(
-  TxMutate(mid_chain, before_chain, pair.new, pair.old, guard)
+  tx::TxMutate(mid_chain, before_chain, pair.new, pair.old, guard)
   ReplayMutateEvent(before_tx, mid_tx, pair.old, pair.new)
   guard(pair.new, before_tx.chain_start, before_tx.chain_end)
   ReplayContents(mid_tx, after_tx, mid_chain, after_chain)
@@ -239,7 +192,7 @@ ReplayActionsStep(before_tx, after_tx, before_chain, after_chain,
 // materialization is what saves the three intermediate statements.
 ReplayActionInsert(before_tx, after_tx, before_chain, after_chain,
     private: new, new_live, guard, initial) = AND(
-  TxInsert(after_chain, before_chain, initial, new, guard)
+  tx::TxInsert(after_chain, before_chain, initial, new, guard)
   SetInsert(new_live, before_tx.live, new)
   DictUpdate(after_tx, before_tx, "live", new_live)
   guard(new, before_chain, after_chain)
@@ -255,7 +208,7 @@ ReplayActionInsert(before_tx, after_tx, before_chain, after_chain,
 // that it already built for the application's action predicate.
 ReplayInsert(before_tx, after_tx, before_chain, after_chain,
     private: new, new_live, guard, initial) = AND(
-  TxInsert(after_chain, before_chain, initial, new, guard)
+  tx::TxInsert(after_chain, before_chain, initial, new, guard)
   SetInsert(new_live, before_tx.live, new)
   DictUpdate(after_tx, before_tx, "live", new_live)
   guard(new, before_tx.chain_start, before_tx.chain_end)
@@ -291,7 +244,7 @@ ReplayMutateEvent(before_tx, after_tx, old, new,
 // TxMutate's shared `type` arg already pins old.type == new.type.
 ReplayMutate(before_tx, after_tx, before_chain, after_chain,
     private: old, new, guard) = AND(
-  TxMutate(after_chain, before_chain, new, old, guard)
+  tx::TxMutate(after_chain, before_chain, new, old, guard)
   ReplayMutateEvent(before_tx, after_tx, old, new)
   guard(new, before_tx.chain_start, before_tx.chain_end)
 )
@@ -304,7 +257,7 @@ ReplayMutate(before_tx, after_tx, before_chain, after_chain,
 // + nullifier accumulation + guard dispatch.
 ReplayDelete(before_tx, after_tx, before_chain, after_chain,
     private: old, guard, new_live, mid_tx) = AND(
-  TxDelete(after_chain, before_chain, old, guard)
+  tx::TxDelete(after_chain, before_chain, old, guard)
   SetDelete(new_live, before_tx.live, old)
   DictUpdate(mid_tx, before_tx, "live", new_live)
   ReplayNullify(mid_tx, after_tx, old)


### PR DESCRIPTION
To reduce instances of compatibility breakage, this splits the "events" predicates out of the main txlib. Because these are the only predicates that will be called directly from pexe actions, we reduce the risk of a change in txlib causing pexe file hashes to change.

This does not mean that txlib changes cause no issues: if the TxFinalized hash changes then synchronizers will need to know about the new hash, for example. However, fixing a small number of synchronizer instances is easier than fixing many distributed pexe files and object files whose contents refer to those pexe file hashes.