### PR TITLE
Batch relayer tx-hash lookups and add CORS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6603,6 +6603,7 @@ dependencies = [
  "sqlx",
  "tokio",
  "tower",
+ "tower-http",
  "tracing",
  "tracing-subscriber",
  "url",

--- a/driver/src/clients/relayer_client.rs
+++ b/driver/src/clients/relayer_client.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::time::{Duration, Instant};
 
 use anyhow::{Result, anyhow};
@@ -5,11 +6,16 @@ use base64::{Engine, engine::general_purpose::STANDARD};
 use common::blob::MAX_SIMPLE_BLOB_PAYLOAD_BYTES;
 use pod2::middleware::Hash;
 use wire_types::relayer::{
-    JobStatus, JobStatusResponse, LookupByTxFinalRequest, SubmitProofRequest, SubmitProofResponse,
+    JobStatus, JobStatusResponse, SubmitProofRequest, SubmitProofResponse,
+    TxHashesByTxFinalRequest, TxHashesByTxFinalResponse,
 };
 
 pub const RELAYER_POLL_TIMEOUT_SECS: u64 = 180;
 pub const RELAYER_POLL_INTERVAL_MS: u64 = 1500;
+
+/// Per-request cap on `tx_finals` sent to the relayer's `tx-hashes` endpoint.
+/// MUST stay at or below the server's `MAX_TX_HASH_QUERY_ITEMS`.
+const TX_HASH_BATCH_LIMIT: usize = 256;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RelayerConfirmation {
@@ -40,9 +46,14 @@ pub trait RelayerClient: Send + Sync {
         timeout_secs: u64,
         poll_interval_ms: u64,
     ) -> Result<RelayerConfirmation>;
-    /// Look up the current tx_hash for a job by its tx_final (proof commitment).
-    /// Returns `Ok(None)` if the relayer has no record for this tx_final.
-    fn lookup_tx_hash(&self, relayer_api_url: &str, tx_final: &Hash) -> Result<Option<String>>;
+    /// Resolve the current Ethereum tx hash for each given `tx_final` (proof
+    /// commitment), in one batched call. Commitments the relayer has no
+    /// broadcast hash for are omitted from the returned map.
+    fn lookup_tx_hashes(
+        &self,
+        relayer_api_url: &str,
+        tx_finals: &[Hash],
+    ) -> Result<HashMap<Hash, String>>;
 }
 
 #[derive(Debug, Default)]
@@ -200,38 +211,54 @@ impl RelayerClient for HttpRelayerClient {
         }
     }
 
-    fn lookup_tx_hash(&self, relayer_api_url: &str, tx_final: &Hash) -> Result<Option<String>> {
+    fn lookup_tx_hashes(
+        &self,
+        relayer_api_url: &str,
+        tx_finals: &[Hash],
+    ) -> Result<HashMap<Hash, String>> {
+        let mut resolved = HashMap::new();
+        if tx_finals.is_empty() {
+            return Ok(resolved);
+        }
+
         let endpoint = format!(
-            "{}/api/v1/proofs/by-tx-final",
+            "{}/api/v1/proofs/tx-hashes",
             relayer_api_url.trim_end_matches('/')
         );
-        let request = LookupByTxFinalRequest {
-            tx_final: *tx_final,
-        };
         let client = reqwest::blocking::Client::new();
-        let response = client
-            .post(&endpoint)
-            .json(&request)
-            .send()
-            .map_err(|err| anyhow!("failed to query relayer by tx_final at {endpoint}: {err}"))?;
 
-        if response.status() == reqwest::StatusCode::NOT_FOUND {
-            return Ok(None);
+        // Chunk so a large pending inventory still resolves in one
+        // `sync_inventory` call, just spread across a few HTTP requests.
+        for chunk in tx_finals.chunks(TX_HASH_BATCH_LIMIT) {
+            let request = TxHashesByTxFinalRequest {
+                tx_finals: chunk.to_vec(),
+            };
+            let response = client
+                .post(&endpoint)
+                .json(&request)
+                .send()
+                .map_err(|err| anyhow!("failed to query relayer tx hashes at {endpoint}: {err}"))?;
+
+            let status = response.status();
+            let body = response.text().unwrap_or_default();
+            if !status.is_success() {
+                return Err(anyhow!(
+                    "relayer tx-hash lookup failed with {} {}: {}",
+                    status.as_u16(),
+                    status,
+                    body
+                ));
+            }
+
+            let payload: TxHashesByTxFinalResponse =
+                serde_json::from_str(&body).map_err(|err| {
+                    anyhow!("failed to decode relayer tx-hash response: {err}; body={body}")
+                })?;
+            for entry in payload.results {
+                resolved.insert(entry.tx_final, entry.tx_hash);
+            }
         }
 
-        let status = response.status();
-        let body = response.text().unwrap_or_default();
-        if !status.is_success() {
-            return Err(anyhow!(
-                "relayer lookup by tx_final failed with {} {}: {}",
-                status.as_u16(),
-                status,
-                body
-            ));
-        }
-
-        let job: JobStatusResponse = serde_json::from_str(&body)
-            .map_err(|err| anyhow!("failed to decode relayer response: {err}; body={body}"))?;
-        Ok(job.tx_hash)
+        Ok(resolved)
     }
 }

--- a/driver/src/clients/synchronizer_client.rs
+++ b/driver/src/clients/synchronizer_client.rs
@@ -24,7 +24,7 @@ pub const SYNCHRONIZER_POLL_INTERVAL_MS: u64 = 1200;
 /// We chunk client-side at this value so inventories with hundreds of
 /// objects still reconcile in a single `sync_inventory` call (just spread
 /// across multiple HTTP requests).
-const MEMBERSHIP_BATCH_LIMIT: usize = 256;
+const HASH_BATCH_LIMIT: usize = 256;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SynchronizerHead {
@@ -152,7 +152,7 @@ impl SynchronizerClient for HttpSynchronizerClient {
         }
 
         // The synchronizer rejects bodies where `object_commitments.len() +
-        // nullifiers.len() > MEMBERSHIP_BATCH_LIMIT` with 400. Pack each
+        // nullifiers.len() > HASH_BATCH_LIMIT` with 400. Pack each
         // batch tightly: take as many object commitments as possible (up to
         // the limit), then fill the remainder with nullifiers. Continue until
         // both lists are drained. Sequential because reqwest::blocking
@@ -160,8 +160,8 @@ impl SynchronizerClient for HttpSynchronizerClient {
         let mut obj_cursor = 0usize;
         let mut null_cursor = 0usize;
         while obj_cursor < object_commitments.len() || null_cursor < nullifiers.len() {
-            let obj_take = (object_commitments.len() - obj_cursor).min(MEMBERSHIP_BATCH_LIMIT);
-            let remaining_capacity = MEMBERSHIP_BATCH_LIMIT - obj_take;
+            let obj_take = (object_commitments.len() - obj_cursor).min(HASH_BATCH_LIMIT);
+            let remaining_capacity = HASH_BATCH_LIMIT - obj_take;
             let null_take = (nullifiers.len() - null_cursor).min(remaining_capacity);
 
             let request = MembershipRequest {

--- a/driver/src/driver.rs
+++ b/driver/src/driver.rs
@@ -189,20 +189,28 @@ impl Driver {
             &membership.on_chain_nullifiers,
         )?;
 
-        // Resolve correct Ethereum tx hashes from the relayer for any
-        // objects whose hash may be stale due to fee-bump replacements.
+        // Resolve correct Ethereum tx hashes from the relayer for any objects
+        // whose hash may be stale due to fee-bump replacements. One batched
+        // lookup rather than a request per pending object; best-effort, so a
+        // relayer error leaves existing hashes untouched.
+        let pending_tx_finals: Vec<Hash> = entries
+            .iter()
+            .filter(|entry| entry.record.status == ObjectStatus::Pending)
+            .map(|entry| entry.record.tx_final)
+            .collect();
+        let current_hashes = self
+            .deps
+            .relayer
+            .lookup_tx_hashes(&settings.relayer_api_url, &pending_tx_finals)
+            .unwrap_or_default();
         for entry in entries.iter_mut() {
             if entry.record.status != ObjectStatus::Pending {
                 continue;
             }
-            let current_hash = self
-                .deps
-                .relayer
-                .lookup_tx_hash(&settings.relayer_api_url, &entry.record.tx_final);
-            if let Ok(Some(relayer_hash)) = current_hash
-                && entry.record.tx_hash.as_deref() != Some(&relayer_hash)
+            if let Some(relayer_hash) = current_hashes.get(&entry.record.tx_final)
+                && entry.record.tx_hash.as_deref() != Some(relayer_hash.as_str())
             {
-                entry.record.tx_hash = Some(relayer_hash);
+                entry.record.tx_hash = Some(relayer_hash.clone());
                 let _ = write_object_file(&self.paths, &entry.record, &entry.file_name);
             }
         }

--- a/driver/src/tests.rs
+++ b/driver/src/tests.rs
@@ -238,8 +238,12 @@ impl RelayerClient for MockRelayer {
         })
     }
 
-    fn lookup_tx_hash(&self, _relayer_api_url: &str, _tx_final: &Hash) -> Result<Option<String>> {
-        Ok(Some("0xtx".to_string()))
+    fn lookup_tx_hashes(
+        &self,
+        _relayer_api_url: &str,
+        tx_finals: &[Hash],
+    ) -> Result<HashMap<Hash, String>> {
+        Ok(tx_finals.iter().map(|h| (*h, "0xtx".to_string())).collect())
     }
 }
 

--- a/relayer/Cargo.toml
+++ b/relayer/Cargo.toml
@@ -13,6 +13,7 @@ serde_json = { workspace = true }
 hex = { workspace = true }
 alloy = { workspace = true  }
 axum = "0.8.6"
+tower-http = { version = "0.6", features = ["cors"] }
 tokio = { version = "1.48.0", features = ["macros", "rt-multi-thread", "net", "signal", "sync", "time"] }
 base64 = "0.22.1"
 uuid = { version = "1.18.1", features = ["v4", "serde"] }

--- a/relayer/README.md
+++ b/relayer/README.md
@@ -8,7 +8,7 @@ Service that accepts zk-craft proof payloads over HTTP and relays them to Ethere
 2. Verifies payload format/proof using shared parser logic from `common`.
 3. Persists relay jobs in Postgres with idempotency keyed by `tx_final`.
 4. Runs a single worker that submits blob transactions and polls receipts.
-5. Exposes job status (`GET /api/v1/proofs/{job_id}`), lookup by idempotency key (`POST /api/v1/proofs/by-tx-final`), and health (`GET /healthz`).
+5. Exposes job status (`GET /api/v1/proofs/{job_id}`), batch tx-hash resolution by `tx_final` (`POST /api/v1/proofs/tx-hashes`), and health (`GET /healthz`).
 
 ## Storage model
 
@@ -47,7 +47,7 @@ Indexes:
 - `GET /healthz` (no auth)
 - `POST /api/v1/proofs` (no auth)
 - `GET /api/v1/proofs/{job_id}` (no auth)
-- `POST /api/v1/proofs/by-tx-final` (no auth) — look up a job by its `tx_final`; JSON body `{ "tx_final": "<hash>" }`
+- `POST /api/v1/proofs/tx-hashes` (no auth) — resolve current Ethereum tx hashes for a batch of `tx_final`s (fee-bump-aware); JSON body `{ "tx_finals": ["<hash>", ...] }`, capped at 256 per request
 
 ## Required env vars
 

--- a/relayer/src/api.rs
+++ b/relayer/src/api.rs
@@ -13,8 +13,8 @@ use tokio::sync::watch;
 use tracing::{debug, error, info};
 use uuid::Uuid;
 use wire_types::relayer::{
-    HealthResponse, JobStatusResponse, LookupByTxFinalRequest, SubmitProofRequest,
-    SubmitProofResponse,
+    HealthResponse, JobStatusResponse, SubmitProofRequest, SubmitProofResponse, TxHashEntry,
+    TxHashesByTxFinalRequest, TxHashesByTxFinalResponse,
 };
 
 use common::{blob::MAX_SIMPLE_BLOB_PAYLOAD_BYTES, proof::BlobParser};
@@ -24,6 +24,10 @@ use crate::{
     model::{JobStatus, RelayJob},
     time_utils::now_ts,
 };
+
+/// Per-request cap on `tx_finals` accepted by `POST /api/v1/proofs/tx-hashes`.
+/// Clients chunk their lookups at or below this.
+const MAX_TX_HASH_QUERY_ITEMS: usize = 256;
 
 /// Shared API dependencies.
 #[derive(Clone)]
@@ -103,7 +107,7 @@ pub fn build_router(state: AppState) -> Router {
         .route("/healthz", get(healthz))
         .route("/api/v1/proofs", post(submit_proof))
         .route("/api/v1/proofs/{job_id}", get(get_proof))
-        .route("/api/v1/proofs/by-tx-final", post(get_proof_by_tx_final))
+        .route("/api/v1/proofs/tx-hashes", post(get_tx_hashes))
         .with_state(state)
 }
 
@@ -217,22 +221,31 @@ async fn get_proof(
     Ok(Json(to_status_response(job)))
 }
 
-async fn get_proof_by_tx_final(
+async fn get_tx_hashes(
     State(app_state): State<AppState>,
-    Json(body): Json<LookupByTxFinalRequest>,
-) -> Result<Json<JobStatusResponse>, ApiError> {
-    debug!(tx_final = %format_args!("{:#}", body.tx_final), "Handling relay job lookup by tx_final");
+    Json(body): Json<TxHashesByTxFinalRequest>,
+) -> Result<Json<TxHashesByTxFinalResponse>, ApiError> {
+    if body.tx_finals.len() > MAX_TX_HASH_QUERY_ITEMS {
+        return Err(ApiError::BadRequest(format!(
+            "tx_finals exceeds maximum item count: {} > {MAX_TX_HASH_QUERY_ITEMS}",
+            body.tx_finals.len()
+        )));
+    }
+    debug!(
+        count = body.tx_finals.len(),
+        "Handling relay tx-hash batch lookup"
+    );
 
-    let job = app_state
+    let results = app_state
         .db
-        .get_job_by_tx_final(&body.tx_final)
+        .tx_hashes_by_tx_finals(&body.tx_finals)
         .await
         .map_err(ApiError::Internal)?
-        .ok_or_else(|| {
-            ApiError::NotFound(format!("job not found for tx_final: {:#}", body.tx_final))
-        })?;
+        .into_iter()
+        .map(|(tx_final, tx_hash)| TxHashEntry { tx_final, tx_hash })
+        .collect();
 
-    Ok(Json(to_status_response(job)))
+    Ok(Json(TxHashesByTxFinalResponse { results }))
 }
 
 fn to_submit_response(job: RelayJob) -> SubmitProofResponse {

--- a/relayer/src/api.rs
+++ b/relayer/src/api.rs
@@ -108,6 +108,7 @@ pub fn build_router(state: AppState) -> Router {
         .route("/api/v1/proofs", post(submit_proof))
         .route("/api/v1/proofs/{job_id}", get(get_proof))
         .route("/api/v1/proofs/tx-hashes", post(get_tx_hashes))
+        .layer(tower_http::cors::CorsLayer::permissive())
         .with_state(state)
 }
 

--- a/relayer/src/db.rs
+++ b/relayer/src/db.rs
@@ -256,6 +256,31 @@ impl Db {
         row.map(row_to_job).transpose()
     }
 
+    /// Resolve the current Ethereum tx hash for each given `tx_final` that
+    /// exists and has been broadcast. Unknown or not-yet-broadcast commitments
+    /// are omitted from the result.
+    pub async fn tx_hashes_by_tx_finals(&self, tx_finals: &[Hash]) -> Result<Vec<(Hash, String)>> {
+        let keys: Vec<Vec<u8>> = tx_finals.iter().map(|h| hash_to_db_bytes(*h)).collect();
+        let rows = sqlx::query(
+            r#"
+            SELECT tx_final, tx_hash
+            FROM relay_jobs
+            WHERE tx_final = ANY($1::bytea[]) AND tx_hash IS NOT NULL
+            "#,
+        )
+        .bind(keys)
+        .fetch_all(&self.pool)
+        .await?;
+
+        rows.into_iter()
+            .map(|row| {
+                let tx_final = db_bytes_to_hash(&row.get::<Vec<u8>, _>("tx_final"))?;
+                let tx_hash: String = row.get("tx_hash");
+                Ok((tx_final, tx_hash))
+            })
+            .collect()
+    }
+
     /// Requeue in-flight states that can be left behind on crash/restart.
     pub async fn recover_inflight_jobs(&self, now: i64) -> Result<usize> {
         let result = sqlx::query(

--- a/wire-types/src/relayer.rs
+++ b/wire-types/src/relayer.rs
@@ -73,12 +73,33 @@ pub struct SubmitProofRequest {
     pub client_ref: Option<String>,
 }
 
-/// Request body for looking up a relay job by its proof idempotency key.
+/// Batch request to resolve current Ethereum tx hashes for a set of proof
+/// commitments (`tx_final`). Used to refresh hashes that may have changed via
+/// fee-bump replacement.
 #[cfg(feature = "chain")]
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct LookupByTxFinalRequest {
-    /// Proof commitment (`tx_final`) to look up.
+pub struct TxHashesByTxFinalRequest {
+    /// Proof commitments to resolve.
+    pub tx_finals: Vec<Hash>,
+}
+
+/// One resolved `(tx_final, current Ethereum tx hash)` pair.
+#[cfg(feature = "chain")]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TxHashEntry {
+    /// Proof commitment the job is keyed by.
     pub tx_final: Hash,
+    /// Current Ethereum tx hash the relayer has broadcast for it.
+    pub tx_hash: String,
+}
+
+/// Batch response: one entry per requested `tx_final` that has a known,
+/// broadcast tx hash. Unknown or not-yet-broadcast commitments are omitted.
+#[cfg(feature = "chain")]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TxHashesByTxFinalResponse {
+    /// Resolved hashes, in no particular order.
+    pub results: Vec<TxHashEntry>,
 }
 
 /// Submit response returns the created/existing job identity and key metadata.


### PR DESCRIPTION
Replaces the relayer's per-pending-object tx-hash lookup with a single batched `POST /api/v1/proofs/tx-hashes` endpoint (chunked at 256, server-capped), so `sync_inventory` makes one request instead of one per object. Adds permissive CORS to the relayer, matching the synchronizer.