### PR TITLE
Rename state types: StateRoot→StateHeader, GSR→"state root", drop Canonical prefix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ The workspace is declared in `Cargo.toml:2-18`. Crate-by-crate:
 | `app-gui/src` (TS)               | React/Vite frontend. Component-based: `features/{actions,inventory,context,proof-runner,settings}`.   |
 | `driver`                         | Headless Rust orchestration library. **The core.** Owns `~/.dobj/`, runs actions end-to-end.          |
 | `sdk`                            | Rhai engine + two-phase Loader/Executor that compiles plugin scripts into pod2 modules.               |
-| `txlib`                          | Transaction state machine: `StateRoot`, `GroundingWitness`, `Tx`, `TxBuilder` + `TxFinalized` rule.   |
+| `txlib`                          | Transaction state machine: `StateHeader`, `GroundingWitness`, `Tx`, `TxBuilder` + `TxFinalized` rule.   |
 | `synchronizer`                   | Long-running service: ingests Ethereum blobs, maintains canonical Merkle state, serves HTTP queries.  |
 | `relayer`                        | HTTP service that wraps proofs as EIP-4844 blob txs and submits them.                                 |
 | `common`                         | Cross-crate types: blob payload encoding, plonky2 proof shrink wrapper, `BlobParser`.                 |
@@ -84,7 +84,7 @@ Use `just` (recipes in `justfile`):
                          relayer  ────────► Ethereum L1 (EIP-4844 blob)
                                                 ▲
                                                 │
-                                           synchronizer (ingests blobs, builds GSRs)
+                                           synchronizer (ingests blobs, builds state roots)
 ```
 
 `dobjd` is the **single owner of `Arc<Driver>`** in the running system. Desktop, browser, MCP, and CLI all talk to it over HTTP/SSE — there is no in-process driver inside the Tauri shell anymore.
@@ -97,9 +97,9 @@ Use `just` (recipes in `justfile`):
 - **`driver/src/execute.rs`** — the proof-and-commit pipeline.
 - **`driver/src/pexe_catalog.rs`** — concrete `ActionCatalog` impl that loads `.pexe` archives from `~/.dobj/actions/`.
 - **`sdk/src/lib.rs`** — Rhai engine setup, custom syntax for `var` and `unsafe { ... }` (search `register_custom_syntax`), host API registration (search `register_fn`). Entry: `Sdk::load_module_from_src_actions`.
-- **`txlib/src/lib.rs`** — `StateRoot` (typed record), `GroundingWitness`, `Tx`, `TxBuilder`. No `Object` struct: object state is a `pod2::Dictionary` whose `identity` field is the commitment of its initial form (`with_identity`), stable across mutations.
+- **`txlib/src/lib.rs`** — `StateHeader` (typed record), `GroundingWitness`, `Tx`, `TxBuilder`. No `Object` struct: object state is a `pod2::Dictionary` whose `identity` field is the commitment of its initial form (`with_identity`), stable across mutations.
 - **`txlib/src/predicates/txlib.podlang`** — the transaction state machine (replay, grounding, `TxFinalized`). Imports **`tx_events.podlang`**, the frozen chain-primitive batch (`TxInsert`/`TxMutate`/`TxDelete`) whose id is pinned by a test. See "txlib and the SDK" below.
-- **`synchronizer/src/state_machine.rs`** — `MAX_GSR_AGE_BLOCKS = 300`. Pure derivation: takes a base head + recent GSRs + decoded blob bytes; returns a candidate head.
+- **`synchronizer/src/state_machine.rs`** — `MAX_STATE_ROOT_AGE_BLOCKS = 300`. Pure derivation: takes a base head + recent state roots + decoded blob bytes; returns a candidate head.
 - **`synchronizer/src/api.rs`** — Axum routes (`/v1/state/head`, `/v1/state/membership`, `/v1/state/object/contains`, `/v1/state/nullifier/contains`, `/v1/txlib/grounding-witness`, plus `/healthz`, `/sync-progress`).
 - **`common/src/shrink.rs`** — Plonky2 wrapper circuit that re-proves a MainPod in a smaller circuit so it fits in a blob.
 - **`common/src/payload.rs`** — blob payload encoding (`PAYLOAD_MAGIC`, proof type, `tx_final`, state root, nullifiers, and the `live` object commitments).
@@ -113,7 +113,7 @@ Use `just` (recipes in `justfile`):
 
 ## txlib and the SDK
 
-txlib's proof machinery is consumed only through the SDK. Its plain types (`StateRoot`, `GroundingWitness`) are shared more widely (the synchronizer computes GSRs), but the predicate batches and `TxBuilder` are not: the SDK loads both batches (`txlib::predicates::events_module()` and `module()`) alongside the plugin module, drives `TxBuilder`, and is the only code that names txlib predicates.
+txlib's proof machinery is consumed only through the SDK. Its plain types (`StateHeader`, `GroundingWitness`) are shared more widely (the synchronizer computes state roots), but the predicate batches and `TxBuilder` are not: the SDK loads both batches (`txlib::predicates::events_module()` and `module()`) alongside the plugin module, drives `TxBuilder`, and is the only code that names txlib predicates.
 
 The predicates are split across two batches. `tx_events.podlang` holds the three chain primitives -- `TxInsert`, `TxMutate`, `TxDelete` -- the only txlib predicates an action script's rendered podlang ever references (via `tx::`, rendered in `sdk/src/fmt_podlang.rs`). Plugin module hashes bake in only this batch's id, so it is frozen: its id is pinned by `test_events_module_hash_pinned`, and editing it invalidates every plugin manifest and recorded proof. `TxMutate`'s shared `type` arg pins `old.type == new.type` implicitly and preserves the object's `identity` across the mutation.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,50 +12,51 @@ This file focuses on navigating the code, building/testing, and gotchas.
 
 The workspace is declared in `Cargo.toml:2-18`. Crate-by-crate:
 
-| Crate                            | Role                                                                                                  |
-| -------------------------------- | ----------------------------------------------------------------------------------------------------- |
-| `dobjd`                          | **The daemon.** Headless HTTP server on `:7717` wrapping the driver. Every client talks to it.        |
-| `cli`                            | `dobj` CLI binary. Thin HTTP/SSE client of dobjd. No `Driver` of its own.                             |
-| `app-gui/src-tauri`              | Tauri 2 shell. Holds **no** driver state — webview talks to dobjd over HTTP. Native conveniences only.|
-| `app-gui/src` (TS)               | React/Vite frontend. Component-based: `features/{actions,inventory,context,proof-runner,settings}`.   |
-| `driver`                         | Headless Rust orchestration library. **The core.** Owns `~/.dobj/`, runs actions end-to-end.          |
-| `sdk`                            | Rhai engine + two-phase Loader/Executor that compiles plugin scripts into pod2 modules.               |
-| `txlib`                          | Transaction state machine: `StateHeader`, `GroundingWitness`, `Tx`, `TxBuilder` + `TxFinalized` rule.   |
-| `synchronizer`                   | Long-running service: ingests Ethereum blobs, maintains canonical Merkle state, serves HTTP queries.  |
-| `relayer`                        | HTTP service that wraps proofs as EIP-4844 blob txs and submits them.                                 |
-| `common`                         | Cross-crate types: blob payload encoding, plonky2 proof shrink wrapper, `BlobParser`.                 |
-| `wire-types`                     | Pure-data types crossing process boundaries (HTTP/MCP/SSE/CLI). Dependency-light — no pod2/plonky2.   |
-| `pod2utils`                      | Macros (`st_custom!`, `dict!`, `set!`, `op!`, …) and `BuildContext` for loading podlang modules.      |
-| `pexe`                           | `.pexe` plugin archive format (zip of `manifest.toml` + `plugin.rhai`) and the `pexe` CLI.            |
-| `mcp` (crate name `craft-mcp`)   | MCP server exposing driver as tools to AI agents. Embedded by dobjd on the adjacent port.             |
-| `intro_pods/vdfpod`              | VDF intro pod (PoW gating via iterated hashing).                                                      |
-| `intro_pods/lt_eq_u256_pod`      | 256-bit `<=` intro pod (PoW difficulty checks).                                                       |
-| `plugins/*`                      | Example plugin sources: `craft-basics` (Log, Wood, Stick, Stone, WoodPick, StonePick + 9 actions) and `episode-1`. |
+| Crate                          | Role                                                                                                               |
+| ------------------------------ | ------------------------------------------------------------------------------------------------------------------ |
+| `dobjd`                        | **The daemon.** Headless HTTP server on `:7717` wrapping the driver. Every client talks to it.                     |
+| `cli`                          | `dobj` CLI binary. Thin HTTP/SSE client of dobjd. No `Driver` of its own.                                          |
+| `app-gui/src-tauri`            | Tauri 2 shell. Holds **no** driver state — webview talks to dobjd over HTTP. Native conveniences only.             |
+| `app-gui/src` (TS)             | React/Vite frontend. Component-based: `features/{actions,inventory,context,proof-runner,settings}`.                |
+| `driver`                       | Headless Rust orchestration library. **The core.** Owns `~/.dobj/`, runs actions end-to-end.                       |
+| `sdk`                          | Rhai engine + two-phase Loader/Executor that compiles plugin scripts into pod2 modules.                            |
+| `txlib`                        | Transaction state machine: `StateHeader`, `GroundingWitness`, `Tx`, `TxBuilder` + `TxFinalized` rule.              |
+| `synchronizer`                 | Long-running service: ingests Ethereum blobs, maintains Merkle state, serves HTTP queries.                         |
+| `relayer`                      | HTTP service that wraps proofs as EIP-4844 blob txs and submits them.                                              |
+| `common`                       | Cross-crate types: blob payload encoding, plonky2 proof shrink wrapper, `BlobParser`.                              |
+| `wire-types`                   | Pure-data types crossing process boundaries (HTTP/MCP/SSE/CLI). Dependency-light — no pod2/plonky2.                |
+| `pod2utils`                    | Macros (`st_custom!`, `dict!`, `set!`, `op!`, …) and `BuildContext` for loading podlang modules.                   |
+| `pexe`                         | `.pexe` plugin archive format (zip of `manifest.toml` + `plugin.rhai`) and the `pexe` CLI.                         |
+| `mcp` (crate name `craft-mcp`) | MCP server exposing driver as tools to AI agents. Embedded by dobjd on the adjacent port.                          |
+| `intro_pods/vdfpod`            | VDF intro pod (PoW gating via iterated hashing).                                                                   |
+| `intro_pods/lt_eq_u256_pod`    | 256-bit `<=` intro pod (PoW difficulty checks).                                                                    |
+| `plugins/*`                    | Example plugin sources: `craft-basics` (Log, Wood, Stick, Stone, WoodPick, StonePick + 9 actions) and `episode-1`. |
 
 ## Build / test / dev
 
 Use `just` (recipes in `justfile`):
 
-| Recipe                    | What it does                                                                                  |
-| ------------------------- | --------------------------------------------------------------------------------------------- |
-| `just dev`                | Brings up synchronizer + relayer + **dobjd** + Vite + Tauri shell via `mprocs.yaml`. Depends on `ensure-plugins` + `ensure-mcp`. Open `http://localhost:1420` in a browser or use the desktop window. |
-| `just sync`               | Runs the synchronizer (loads `synchronizer/.env`).                                            |
-| `just relayer`            | Runs the relayer (loads `relayer/.env`).                                                      |
-| `just dobjd`              | Runs the headless HTTP daemon. Default port `7717` (override via `DOBJD_PORT`).               |
-| `just desktop`            | Standalone Tauri window — Tauri spawns its own Vite on `:1420`.                               |
-| `just desktop-shell`      | Tauri shell pointing at an already-running Vite (used inside `just dev`). Skips `beforeDevCommand`. |
-| `just web`                | Vite dev server alone on `:1420`. Talks to `dobjd` at `:7717`.                                |
-| `just ensure-plugins`     | Installs `craft-basics.pexe` to `~/.dobj/actions/` if none present.                           |
-| `just ensure-mcp`         | Registers/refreshes the bitcraft MCP at `http://127.0.0.1:7718/mcp` with Claude Code, project scope. Idempotent; no-op if the `claude` CLI is missing. |
-| `just install-plugins`    | Builds + installs all `plugins/*` via the `pexe` CLI.                                         |
-| `just pack-plugins`       | Builds plugins to `target/pexe/*.pexe` (no install).                                          |
-| `just reset`              | Stops the dobj daemon, wipes `data/` + `~/.dobj/`, drops the `synchronizer` + `relayer` DBs, and removes the bitcraft MCP registration. |
-| `just test`               | `cargo test --workspace --release`.                                                           |
-| `just test-ignored`       | Runs `--ignored` tests with `--nocapture`.                                                    |
-| `just test-e2e`           | Runs `synchronizer::test_e2e_real_proof` (slow, full real-proof flow).                       |
-| `just build`              | `cargo build --workspace`.                                                                    |
+| Recipe                 | What it does                                                                                                                                                                                          |
+| ---------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `just dev`             | Brings up synchronizer + relayer + **dobjd** + Vite + Tauri shell via `mprocs.yaml`. Depends on `ensure-plugins` + `ensure-mcp`. Open `http://localhost:1420` in a browser or use the desktop window. |
+| `just sync`            | Runs the synchronizer (loads `synchronizer/.env`).                                                                                                                                                    |
+| `just relayer`         | Runs the relayer (loads `relayer/.env`).                                                                                                                                                              |
+| `just dobjd`           | Runs the headless HTTP daemon. Default port `7717` (override via `DOBJD_PORT`).                                                                                                                       |
+| `just desktop`         | Standalone Tauri window — Tauri spawns its own Vite on `:1420`.                                                                                                                                       |
+| `just desktop-shell`   | Tauri shell pointing at an already-running Vite (used inside `just dev`). Skips `beforeDevCommand`.                                                                                                   |
+| `just web`             | Vite dev server alone on `:1420`. Talks to `dobjd` at `:7717`.                                                                                                                                        |
+| `just ensure-plugins`  | Installs `craft-basics.pexe` to `~/.dobj/actions/` if none present.                                                                                                                                   |
+| `just ensure-mcp`      | Registers/refreshes the bitcraft MCP at `http://127.0.0.1:7718/mcp` with Claude Code, project scope. Idempotent; no-op if the `claude` CLI is missing.                                                |
+| `just install-plugins` | Builds + installs all `plugins/*` via the `pexe` CLI.                                                                                                                                                 |
+| `just pack-plugins`    | Builds plugins to `target/pexe/*.pexe` (no install).                                                                                                                                                  |
+| `just reset`           | Stops the dobj daemon, wipes `data/` + `~/.dobj/`, drops the `synchronizer` + `relayer` DBs, and removes the bitcraft MCP registration.                                                               |
+| `just test`            | `cargo test --workspace --release`.                                                                                                                                                                   |
+| `just test-ignored`    | Runs `--ignored` tests with `--nocapture`.                                                                                                                                                            |
+| `just test-e2e`        | Runs `synchronizer::test_e2e_real_proof` (slow, full real-proof flow).                                                                                                                                |
+| `just build`           | `cargo build --workspace`.                                                                                                                                                                            |
 
 **Infrastructure required for `just dev`:**
+
 - Postgres on `localhost:5432` (user `postgres`). Synchronizer + relayer create their own DBs.
 - An Ethereum beacon + execution endpoint (configure in `synchronizer/.env`, `relayer/.env`).
 - RocksDB stores under `data/` and `~/.dobj/` are created on first run.
@@ -129,19 +130,21 @@ Action scripts are Rhai files; the SDK registers a host API and runs each action
 The driver does not cache compiled modules between calls — every `Driver::execute` re-parses the script.
 
 **Rhai custom syntax** (search `register_custom_syntax` in `sdk/src/lib.rs`):
+
 - `var <ident> = <expr>` — declare a wildcard. Operations on it generate constraining statements.
 - `let <ident> = <expr>` — plain Rhai, literal known at both phases. No statements emitted.
 - `unsafe { <expr> }` — compute a wildcard value without emitting constraints. Pair with an explicit `action.st_*` call afterward, or a malicious prover can put anything there.
 
 **Host API** (registered via `register_fn` in `sdk/src/lib.rs`):
+
 - On `action`: `input(class)`, `output(class)`, `mutate(class)`, `subaction(name)`, `random()`, `st_gt(a,b)`, `st_sum_of(a,b,c)`, `intro_vdf(iters, obj)`, `intro_lt_eq_u256(obj, target)`, `pow_obj_grind(obj, target)`, `top_limb_u256(n)`.
 - On object handles: `set([[k,v],...])` (initializer for literals), `update(k,v)` (writes a witness-derived value), `get(k)`, indexer `obj.<field>`.
 
-**Constraint:** the event tree must be the same shape every run. Branching that emits *different events* on different inputs is unsupported. Branching on wildcard values inside `unsafe { ... }` is fine.
+**Constraint:** the event tree must be the same shape every run. Branching that emits _different events_ on different inputs is unsupported. Branching on wildcard values inside `unsafe { ... }` is fine.
 
 **Records-form rendering** (`sdk/src/fmt_podlang.rs`): to keep predicate arity small, the formatter coalesces all same-role objects of an action into one record arg instead of N loose wildcards. The public records are `in <Action>In` / `out <Action>Out` (one entry per input/output object; a Mutate contributes to both); the private `<Action>Initials` record holds one entry per output object's pre-identity (script-final) dict. The related `chain_steps`/`<Action>Chain` packing does the same for intermediate chain states, but only past a threshold (`CHAIN_PACK_MIN_TS = 3`); the in/out/initials records have no threshold and are the canonical form.
 
-**`Side` vs `Collapse`** (same file): these are two distinct axes, do not conflate them. `Side { In, Out }` is the strictly-binary public I/O role — it drives `dispatch_side` and the public signature. `Collapse { Side(Side), Initials }` is the record namespace a *collapsed* object dict pins to when rendered (`in.<name>` / `out.<name>` / `initials.<name>`) or anchored; it is what `collapsed_at` / `collapses_at` return. `Initials` lives only on `Collapse` (private-only, never a public record arg or a dispatch target) and is deliberately **not** a `Side`.
+**`Side` vs `Collapse`** (same file): these are two distinct axes, do not conflate them. `Side { In, Out }` is the strictly-binary public I/O role — it drives `dispatch_side` and the public signature. `Collapse { Side(Side), Initials }` is the record namespace a _collapsed_ object dict pins to when rendered (`in.<name>` / `out.<name>` / `initials.<name>`) or anchored; it is what `collapsed_at` / `collapses_at` return. `Initials` lives only on `Collapse` (private-only, never a public record arg or a dispatch target) and is deliberately **not** a `Side`.
 
 ## Coding style
 
@@ -150,12 +153,14 @@ ASCII only in code and comments: no em-dashes or other non-ASCII characters.
 ### Naming
 
 Name things for what they mean, not for abstract or mathematical placeholders -- at every level:
+
 - Variables and fields: descriptive over terse, even where it reads long, and even where an algorithm's paper uses a single letter. This is industrial code, not a transliteration of the math (`num_statements`, not `n`; `used_in_link`, not `u`).
 - Types: when the same tuple of scalars keeps travelling together in one role -- across a body, its callers, a loop, or a parameter list -- make it a struct. The type name says what the value is; the field names say what each component means.
 
 ### Comments
 
 While coding, write a comment only if all three hold:
+
 - its subject is present in this unit -- the signature, a parameter, a local, a value's range here, a branch's precondition;
 - it does not transcribe another unit's mechanism, name a specific that will rot (a fixture, a sibling function, a field elsewhere), or lean on what you'd have to leave the repo to check (a prior version, a use case, our conversation);
 - it carries something an intelligent reader could not easily infer from this unit -- not control flow, not types, not return values, not general knowledge, not a paraphrase of the line beside it.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ A single **driver daemon** (`dobjd`) on the user's machine owns
   stdio transport to dobjd's HTTP MCP server. Claude Code connects to
   `http://127.0.0.1:7718/mcp` directly via `claude mcp add`.
 - **Hosted synchronizer + relayer** — public endpoints the daemon points
-  at by default. The synchronizer maintains the canonical Merkle trees
+  at by default. The synchronizer maintains the Merkle trees
   of transactions + nullifiers; the relayer submits proof payloads as
   EIP-4844 blobs. Both are independent Rust services
   ([synchronizer/](synchronizer), [relayer/](relayer)) that can also
@@ -86,13 +86,13 @@ just dev
 
 `just dev` brings up five panes via mprocs:
 
-| Pane           | Purpose                                                    |
-| -------------- | ---------------------------------------------------------- |
-| `synchronizer` | rebuilds canonical state from chain data (Postgres-backed) |
-| `relayer`      | submits proof payloads as EIP-4844 blobs                   |
-| `dobjd`        | the driver daemon — HTTP on `:7717`, MCP on `:7718`        |
-| `web`          | Vite on `:1420`, hot-reload for the React app              |
-| `desktop`      | Tauri shell pointing at the standalone Vite                |
+| Pane           | Purpose                                             |
+| -------------- | --------------------------------------------------- |
+| `synchronizer` | rebuilds state from chain data (Postgres-backed)    |
+| `relayer`      | submits proof payloads as EIP-4844 blobs            |
+| `dobjd`        | the driver daemon — HTTP on `:7717`, MCP on `:7718` |
+| `web`          | Vite on `:1420`, hot-reload for the React app       |
+| `desktop`      | Tauri shell pointing at the standalone Vite         |
 
 The desktop window opens automatically. Open `http://localhost:1420` in
 any browser to use the website client. MCP-aware agents can connect via
@@ -103,19 +103,19 @@ Run individual pieces standalone with `just sync`, `just relayer`,
 
 ## Workspace map
 
-| Crate                                                                       | Role                                                                                                                           |
-| --------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| [`driver/`](driver)                                                         | the canonical Rust library — opens `~/.dobj/`, runs actions, queries inventory. Single entry point for any in-process consumer |
-| [`dobjd/`](dobjd)                                                           | HTTP + MCP daemon wrapping the driver. Long-running, owns the broadcast hub                                                    |
-| [`cli/`](cli)                                                               | terminal CLI client for dobjd (binary: `dobj`)                                                                                 |
-| [`mcp/`](mcp)                                                               | MCP server library + `bitcraft-mcp-proxy` stdio bridge                                                                         |
-| [`app-gui/`](app-gui)                                                       | React frontend + thin Tauri shell. Fetches from dobjd over HTTP/SSE                                                            |
-| [`synchronizer/`](synchronizer), [`relayer/`](relayer)                      | chain-side services (Postgres-backed)                                                                                          |
-| [`txlib/`](txlib)                                                           | transaction builder — event hash chain, `TxFinalized` predicate, nullifier derivation                                          |
-| [`sdk/`](sdk)                                                               | higher-level helpers used inside plugin actions                                                                                |
-| [`pexe/`](pexe)                                                             | plugin packager — bundles `manifest.toml` + `plugin.rhai` into `.pexe` archives                                                |
-| [`plugins/craft-basics/`](plugins/craft-basics)                             | the bundled crafting plugin (Log, Wood, Stone, sticks, picks…)                                                                 |
-| [`common/`](common), [`pod2utils/`](pod2utils), [`intro_pods/`](intro_pods) | shared utilities + intro proof-of-work / VDF pods                                                                              |
+| Crate                                                                       | Role                                                                                                                      |
+| --------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| [`driver/`](driver)                                                         | the core Rust library — opens `~/.dobj/`, runs actions, queries inventory. Single entry point for any in-process consumer |
+| [`dobjd/`](dobjd)                                                           | HTTP + MCP daemon wrapping the driver. Long-running, owns the broadcast hub                                               |
+| [`cli/`](cli)                                                               | terminal CLI client for dobjd (binary: `dobj`)                                                                            |
+| [`mcp/`](mcp)                                                               | MCP server library + `bitcraft-mcp-proxy` stdio bridge                                                                    |
+| [`app-gui/`](app-gui)                                                       | React frontend + thin Tauri shell. Fetches from dobjd over HTTP/SSE                                                       |
+| [`synchronizer/`](synchronizer), [`relayer/`](relayer)                      | chain-side services (Postgres-backed)                                                                                     |
+| [`txlib/`](txlib)                                                           | transaction builder — event hash chain, `TxFinalized` predicate, nullifier derivation                                     |
+| [`sdk/`](sdk)                                                               | higher-level helpers used inside plugin actions                                                                           |
+| [`pexe/`](pexe)                                                             | plugin packager — bundles `manifest.toml` + `plugin.rhai` into `.pexe` archives                                           |
+| [`plugins/craft-basics/`](plugins/craft-basics)                             | the bundled crafting plugin (Log, Wood, Stone, sticks, picks…)                                                            |
+| [`common/`](common), [`pod2utils/`](pod2utils), [`intro_pods/`](intro_pods) | shared utilities + intro proof-of-work / VDF pods                                                                         |
 
 Built on **pod2** (0xPARC's predicate-of-data system) using `plonky2` —
 proofs are constant-size regardless of input count.

--- a/app-gui/README.md
+++ b/app-gui/README.md
@@ -33,7 +33,7 @@ Frontend panels (`src/features/`):
 - `InventoryPanel` — local live/nullified objects, drag source, `+ Import .dobj` button
 - `ActionGrid` — action catalog + search/filter
 - `ContextPanel` — selected object/action details, input binding, run button
-- `ProofRunnerPanel` — proof-run status, CPU stats, global state root
+- `ProofRunnerPanel` — proof-run status, CPU stats, state root
 - `SettingsModal` — synchronizer/relayer URL editor
 
 State: Zustand store at `src/shared/state/store.ts` (`useStore`).
@@ -49,7 +49,7 @@ provides things the browser fundamentally can't do.
 | ------------------------------------ | ------------------------------------------ |
 | `loadInventory`                      | `GET /inventory`                           |
 | `loadActions`                        | `GET /actions`                             |
-| `getGlobalStateRoot`                 | `GET /state-root`                          |
+| `getStateRoot`                       | `GET /state-root`                          |
 | `getObjectsDir`                      | `GET /objects/dir`                         |
 | `getAppSettings` / `saveAppSettings` | `GET` / `PUT /settings`                    |
 | `importObject`                       | `POST /objects/import`                     |
@@ -86,7 +86,7 @@ desktop's progress UI in real time.
 ## Polling
 
 - **CPU sample**: 1s, via `sample_app_cpu` (desktop only — browser shows zeros)
-- **Global state root**: 4s, via `GET /state-root`
+- **state root**: 4s, via `GET /state-root`
 
 ## Run
 

--- a/app-gui/src/App.tsx
+++ b/app-gui/src/App.tsx
@@ -5,7 +5,7 @@ import { InventoryPanel } from "./features/inventory/InventoryPanel";
 import { ProofRunnerPanel } from "./features/proof-runner/ProofRunnerPanel";
 import { SettingsModal } from "./features/settings/SettingsModal";
 import {
-  getGlobalStateRoot,
+  getStateRoot,
   getObjectsDir,
   listenOpenSettings,
   listenRunActionProgress,
@@ -42,7 +42,7 @@ function App() {
   const clearSelection = useStore((state) => state.clearSelection);
   const toggleNullified = useStore((state) => state.toggleNullified);
   const recordCpuSample = useStore((state) => state.recordCpuSample);
-  const setGlobalStateRoot = useStore((state) => state.setGlobalStateRoot);
+  const setStateRoot = useStore((state) => state.setStateRoot);
   const applyRunActionProgress = useStore(
     (state) => state.applyRunActionProgress,
   );
@@ -105,7 +105,10 @@ function App() {
         if (cancelled) return;
         hydrateData().catch((error) => {
           if (!cancelled) {
-            console.error("Failed to refresh GUI after action progress:", error);
+            console.error(
+              "Failed to refresh GUI after action progress:",
+              error,
+            );
           }
         });
       }, 120);
@@ -178,13 +181,13 @@ function App() {
     let cancelled = false;
     const poll = async () => {
       try {
-        const root = await getGlobalStateRoot();
+        const root = await getStateRoot();
         if (!cancelled) {
-          setGlobalStateRoot(root);
+          setStateRoot(root);
         }
       } catch (error) {
         if (!cancelled) {
-          console.error("Failed to fetch global state root:", error);
+          console.error("Failed to fetch state root:", error);
         }
       }
     };
@@ -198,7 +201,7 @@ function App() {
       cancelled = true;
       window.clearInterval(interval);
     };
-  }, [setGlobalStateRoot]);
+  }, [setStateRoot]);
 
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {

--- a/app-gui/src/features/proof-runner/ProofRunnerPanel.tsx
+++ b/app-gui/src/features/proof-runner/ProofRunnerPanel.tsx
@@ -34,9 +34,9 @@ export function ProofRunnerPanel() {
     }
   }, [runActive, proof.action]);
 
-  const globalRootRaw = proof.stats.globalStateRoot?.trim() ?? "";
-  const globalRootDisplay = globalRootRaw
-    ? truncateDisplayHash(globalRootRaw)
+  const stateRootRaw = proof.stats.stateRoot?.trim() ?? "";
+  const globalRootDisplay = stateRootRaw
+    ? truncateDisplayHash(stateRootRaw)
     : "0x----...----";
 
   const formatCpuDuration = (totalSecs: number) => {
@@ -127,7 +127,7 @@ export function ProofRunnerPanel() {
               <span className="root-dot live" />
               <span className="root-label">Global Valid State Roots</span>
             </span>
-            <span className="root-hash" title={globalRootRaw || undefined}>
+            <span className="root-hash" title={stateRootRaw || undefined}>
               {globalRootDisplay}
             </span>
           </div>
@@ -136,7 +136,7 @@ export function ProofRunnerPanel() {
               <span className="root-dot nullified" />
               <span className="root-label">Global Nullified State Roots</span>
             </span>
-            <span className="root-hash" title={globalRootRaw || undefined}>
+            <span className="root-hash" title={stateRootRaw || undefined}>
               {globalRootDisplay}
             </span>
           </div>

--- a/app-gui/src/shared/api/tauriClient.ts
+++ b/app-gui/src/shared/api/tauriClient.ts
@@ -113,7 +113,7 @@ export function loadActions(): Promise<ActionPayload[]> {
   return dobjdFetch("/actions").then(httpJson<ActionPayload[]>);
 }
 
-export function getGlobalStateRoot(): Promise<string> {
+export function getStateRoot(): Promise<string> {
   return dobjdFetch("/state-root").then(httpJson<string>);
 }
 

--- a/app-gui/src/shared/state/store.ts
+++ b/app-gui/src/shared/state/store.ts
@@ -25,7 +25,7 @@ interface ProofStep {
 interface ProofStats {
   cpuHistory: number[];
   totalCpuSecs: number;
-  globalStateRoot: string | null;
+  stateRoot: string | null;
 }
 
 interface ProofSummary {
@@ -71,7 +71,7 @@ export interface AppState {
   clearSelection: () => void;
   toggleNullified: () => void;
   recordCpuSample: (usagePct: number, totalCpuSecs: number) => void;
-  setGlobalStateRoot: (hash: string | null) => void;
+  setStateRoot: (hash: string | null) => void;
   applyRunActionProgress: (event: RunActionProgress) => void;
   initProofPanel: (input: {
     runId: string;
@@ -119,7 +119,7 @@ export const useStore = create<AppState>((set, get) => ({
     stats: {
       cpuHistory: Array.from({ length: 24 }, () => 0),
       totalCpuSecs: 0,
-      globalStateRoot: null,
+      stateRoot: null,
     },
   },
   hydrateData: async () => {
@@ -210,10 +210,10 @@ export const useStore = create<AppState>((set, get) => ({
         },
       };
     }),
-  setGlobalStateRoot: (hash) =>
+  setStateRoot: (hash) =>
     set((prev) => {
       const nextHash = hash?.trim() || null;
-      if (prev.proof.stats.globalStateRoot === nextHash) {
+      if (prev.proof.stats.stateRoot === nextHash) {
         return prev;
       }
       return {
@@ -222,7 +222,7 @@ export const useStore = create<AppState>((set, get) => ({
           ...prev.proof,
           stats: {
             ...prev.proof.stats,
-            globalStateRoot: nextHash,
+            stateRoot: nextHash,
           },
         },
       };

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -72,7 +72,7 @@ enum Cmd {
         #[arg(value_name = "PLUGIN::ACTION")]
         qualified_id: String,
     },
-    /// Print the current global state root.
+    /// Print the current state root.
     StateRoot,
     /// Print the local objects directory path (`~/.dobj/objects/`).
     ObjectsDir,

--- a/common/src/payload.rs
+++ b/common/src/payload.rs
@@ -64,7 +64,7 @@ pub struct Payload {
     pub proof: PayloadProof,
     /// Commitment of the finalized transaction dictionary `{live, nullifiers, chain_start, chain_end}`.
     pub tx_final: Hash,
-    pub state_root_hash: Hash,
+    pub state_root: Hash,
     pub nullifiers: Vec<Hash>,
     /// Commitments of the objects this tx leaves live. The synchronizer
     /// inserts each into its global created set, rejecting any that already
@@ -85,7 +85,7 @@ impl Payload {
             .expect("vec write");
         self.proof.write_bytes(&mut buffer);
         write_elems(&mut buffer, &self.tx_final.0);
-        write_elems(&mut buffer, &self.state_root_hash.0);
+        write_elems(&mut buffer, &self.state_root.0);
         write_hashes(&mut buffer, &self.nullifiers);
         write_hashes(&mut buffer, &self.live);
         buffer
@@ -105,13 +105,13 @@ impl Payload {
         let (proof, len) = PayloadProof::from_bytes(bytes, common_data)?;
         bytes = &bytes[len..];
         let tx_final = Hash(read_elems(&mut bytes)?);
-        let state_root_hash = Hash(read_elems(&mut bytes)?);
+        let state_root = Hash(read_elems(&mut bytes)?);
         let nullifiers = read_hashes(&mut bytes)?;
         let live = read_hashes(&mut bytes)?;
         Ok(Self {
             proof,
             tx_final,
-            state_root_hash,
+            state_root,
             nullifiers,
             live,
         })
@@ -215,7 +215,7 @@ mod tests {
         let vds_root = vd_set.root();
 
         let input = r#"
-        TxnFinalized(state_root_hash, tx_final, nullifiers, live) = AND(
+        TxnFinalized(state_root, tx_final, nullifiers, live) = AND(
             Equal(0, 0)
         )
         "#;
@@ -272,7 +272,7 @@ mod tests {
             Payload {
                 proof: PayloadProof::Plonky2(Box::new(shrunk_main_pod_proof.clone())),
                 tx_final: Hash(tx_final.raw().0),
-                state_root_hash: Hash(state_root.raw().0),
+                state_root: Hash(state_root.raw().0),
                 nullifiers: nullifiers.clone(),
                 live: live.clone(),
             }
@@ -294,7 +294,7 @@ mod tests {
         let st = Statement::Custom(
             pred,
             vec![
-                Value::from(payload.state_root_hash).into(),
+                Value::from(payload.state_root).into(),
                 Value::from(payload.tx_final).into(),
                 nullifiers_set.into(),
                 live_set.into(),

--- a/common/src/proof.rs
+++ b/common/src/proof.rs
@@ -37,7 +37,7 @@ pub trait BlobParser: Send + Sync {
 // MockBlobParser
 // ---------------------------------------------------------------------------
 
-/// Mock parser: accepts JSON `{ "tx_final": "0x...", "nullifiers": [...], "live": [...], "state_root_hash": "0x..." }`
+/// Mock parser: accepts JSON `{ "tx_final": "0x...", "nullifiers": [...], "live": [...], "state_root": "0x..." }`
 /// Hash bytes serialized as lowercase hex strings.
 /// Returns a `Payload` with a dummy empty `PayloadProof` since no real proof
 /// is needed for mock testing.
@@ -50,7 +50,7 @@ struct MockProofJson {
     tx_final: String,
     nullifiers: Vec<String>,
     live: Vec<String>,
-    state_root_hash: String,
+    state_root: String,
 }
 
 #[cfg(any(test, feature = "test-utils"))]
@@ -72,11 +72,11 @@ impl BlobParser for MockBlobParser {
             .iter()
             .map(|s| decode_hash_hex(s))
             .collect::<Result<Vec<_>>>()?;
-        let state_root_hash = decode_hash_hex(&json.state_root_hash)?;
+        let state_root = decode_hash_hex(&json.state_root)?;
         Ok(Some(Payload {
             proof: PayloadProof::empty_for_test(),
             tx_final,
-            state_root_hash,
+            state_root,
             nullifiers,
             live,
         }))
@@ -158,7 +158,7 @@ impl BlobParser for ProofParser {
         let statement = Statement::Custom(
             self.txn_finalized_pred.clone(),
             vec![
-                Value::from(payload.state_root_hash).into(),
+                Value::from(payload.state_root).into(),
                 Value::from(payload.tx_final).into(),
                 Value::from(hashes_to_set(&payload.nullifiers)).into(),
                 Value::from(hashes_to_set(&payload.live)).into(),
@@ -199,7 +199,7 @@ mod tests {
         let sr_hex = format!("0x{}", hash_to_hex(&state_root));
 
         let json = format!(
-            r#"{{"tx_final":"{}","nullifiers":["{}"],"live":[],"state_root_hash":"{}"}}"#,
+            r#"{{"tx_final":"{}","nullifiers":["{}"],"live":[],"state_root":"{}"}}"#,
             tx_hex, null_hex, sr_hex
         );
 
@@ -209,7 +209,7 @@ mod tests {
         assert_eq!(payload.tx_final, tx_final);
         assert_eq!(payload.nullifiers.len(), 1);
         assert_eq!(payload.nullifiers[0], nullifier);
-        assert_eq!(payload.state_root_hash, state_root);
+        assert_eq!(payload.state_root, state_root);
     }
 
     #[test]
@@ -227,7 +227,7 @@ mod tests {
         let tx_hex = hash_to_hex(&tx_final); // no "0x" prefix
 
         let json = format!(
-            r#"{{"tx_final":"{}","nullifiers":[],"live":[],"state_root_hash":"{}"}}"#,
+            r#"{{"tx_final":"{}","nullifiers":[],"live":[],"state_root":"{}"}}"#,
             tx_hex, tx_hex
         );
 

--- a/common/src/test_state.rs
+++ b/common/src/test_state.rs
@@ -38,7 +38,7 @@ impl TestState {
         }
     }
 
-    /// `(created_root, nullifiers_root, state_history_root)`.
+    /// `(created_root, nullifiers_root, prior_state_history_root)`.
     pub fn roots(&self) -> (Hash, Hash, Hash) {
         (
             self.created.commitment(),
@@ -49,7 +49,7 @@ impl TestState {
 
     /// Build a grounding witness proving each input object commitment is a
     /// member of the global created set. `build` assembles the crate's witness
-    /// type from `(block_number, created_root, nullifiers_root, state_history_root,
+    /// type from `(block_number, created_root, nullifiers_root, prior_state_history_root,
     /// per-object (index, proof) keyed by commitment)`.
     pub fn build_grounding_witness<W>(
         &self,
@@ -60,12 +60,12 @@ impl TestState {
             .iter()
             .map(|commitment| (*commitment, self.created_membership_proof(*commitment)))
             .collect::<HashMap<_, _>>();
-        let (created_root, nullifiers_root, state_history_root) = self.roots();
+        let (created_root, nullifiers_root, prior_state_history_root) = self.roots();
         build(
             self.block_number,
             created_root,
             nullifiers_root,
-            state_history_root,
+            prior_state_history_root,
             created_proofs,
         )
     }

--- a/common/src/test_state.rs
+++ b/common/src/test_state.rs
@@ -10,7 +10,7 @@ use pod2::{
 
 /// Reusable committed-state helper for proof-heavy tests across crates. Holds
 /// a grow-only global created-object set (an array, plus a reverse index for
-/// proofs), a nullifier set, and a GSR history array, and hands out the Merkle
+/// proofs), a nullifier set, and a state root history array, and hands out the Merkle
 /// proofs grounding needs.
 #[derive(Clone, Debug)]
 pub struct TestState {
@@ -18,7 +18,7 @@ pub struct TestState {
     created: Array,
     created_index: HashMap<Hash, i64>,
     nullifiers: Set,
-    gsrs: Array,
+    state_history: Array,
 }
 
 impl Default for TestState {
@@ -34,22 +34,22 @@ impl TestState {
             created: Array::new(Vec::<Value>::new()),
             created_index: HashMap::new(),
             nullifiers: Set::new(HashSet::<Value>::new()),
-            gsrs: Array::new(Vec::<Value>::new()),
+            state_history: Array::new(Vec::<Value>::new()),
         }
     }
 
-    /// `(created_root, nullifiers_root, gsrs_root)`.
+    /// `(created_root, nullifiers_root, state_history_root)`.
     pub fn roots(&self) -> (Hash, Hash, Hash) {
         (
             self.created.commitment(),
             self.nullifiers.commitment(),
-            self.gsrs.commitment(),
+            self.state_history.commitment(),
         )
     }
 
     /// Build a grounding witness proving each input object commitment is a
     /// member of the global created set. `build` assembles the crate's witness
-    /// type from `(block_number, created_root, nullifiers_root, gsrs_root,
+    /// type from `(block_number, created_root, nullifiers_root, state_history_root,
     /// per-object (index, proof) keyed by commitment)`.
     pub fn build_grounding_witness<W>(
         &self,
@@ -60,12 +60,12 @@ impl TestState {
             .iter()
             .map(|commitment| (*commitment, self.created_membership_proof(*commitment)))
             .collect::<HashMap<_, _>>();
-        let (created_root, nullifiers_root, gsrs_root) = self.roots();
+        let (created_root, nullifiers_root, state_history_root) = self.roots();
         build(
             self.block_number,
             created_root,
             nullifiers_root,
-            gsrs_root,
+            state_history_root,
             created_proofs,
         )
     }
@@ -84,12 +84,15 @@ impl TestState {
         (index, proof)
     }
 
-    pub fn prior_state_root_membership(&self, prior_state_root_hash: Hash) -> (usize, MerkleProof) {
-        let target = Value::from(prior_state_root_hash);
-        for entry in self.gsrs.iter() {
-            let (index, value) = entry.expect("gsr entry should decode");
+    pub fn prior_state_root_membership(&self, prior_state_root: Hash) -> (usize, MerkleProof) {
+        let target = Value::from(prior_state_root);
+        for entry in self.state_history.iter() {
+            let (index, value) = entry.expect("state root entry should decode");
             if value == target {
-                let (_, proof) = self.gsrs.prove(index).expect("gsr proof should build");
+                let (_, proof) = self
+                    .state_history
+                    .prove(index)
+                    .expect("state root proof should build");
                 return (index, proof);
             }
         }

--- a/driver/src/clients/synchronizer_client.rs
+++ b/driver/src/clients/synchronizer_client.rs
@@ -106,7 +106,7 @@ impl SynchronizerClient for HttpSynchronizerClient {
             payload.block_number,
             payload.created_root,
             payload.nullifiers_root,
-            payload.state_history_root,
+            payload.prior_state_history_root,
         );
         let remote_state_root = payload.state_root;
         let derived_state_root = state_header.hash();

--- a/driver/src/clients/synchronizer_client.rs
+++ b/driver/src/clients/synchronizer_client.rs
@@ -33,7 +33,7 @@ pub struct SynchronizerHead {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SynchronizerMembership {
-    /// Object commitments present in the canonical global created set.
+    /// Object commitments present in the global created set.
     pub created_objects: HashSet<Hash>,
     pub on_chain_nullifiers: HashSet<Hash>,
 }
@@ -52,8 +52,8 @@ pub trait SynchronizerClient: Send + Sync {
         nullifiers: &[Hash],
     ) -> Result<SynchronizerMembership>;
     /// Wait until a transaction has landed: every object commitment it produces
-    /// is in the canonical created set and every nullifier it emits is in the
-    /// canonical nullifier set. Returns the resulting head once the whole union
+    /// is in the created set and every nullifier it emits is in the
+    /// nullifier set. Returns the resulting head once the whole union
     /// is present, or errors on timeout.
     fn wait_for_tx(
         &self,
@@ -79,7 +79,7 @@ impl SynchronizerClient for HttpSynchronizerClient {
         )?;
         let current_state_root = payload
             .current_state_root
-            .ok_or_else(|| anyhow!("synchronizer has no canonical grounded state yet"))?;
+            .ok_or_else(|| anyhow!("synchronizer has no grounded state yet"))?;
         Ok(SynchronizerHead { current_state_root })
     }
 

--- a/driver/src/clients/synchronizer_client.rs
+++ b/driver/src/clients/synchronizer_client.rs
@@ -6,7 +6,7 @@ use std::{
 use anyhow::{Result, anyhow};
 use pod2::middleware::Hash;
 use serde::de::DeserializeOwned;
-use txlib::{GroundingWitness, StateRoot};
+use txlib::{GroundingWitness, StateHeader};
 use wire_types::synchronizer::{
     GroundingWitnessRequest, GroundingWitnessResponse, MembershipRequest, MembershipResponse,
     StateHeadResponse,
@@ -28,7 +28,7 @@ const HASH_BATCH_LIMIT: usize = 256;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SynchronizerHead {
-    pub current_gsr: Hash,
+    pub current_state_root: Hash,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -77,10 +77,10 @@ impl SynchronizerClient for HttpSynchronizerClient {
             &endpoint,
             "synchronizer head response",
         )?;
-        let current_gsr = payload
-            .current_gsr
+        let current_state_root = payload
+            .current_state_root
             .ok_or_else(|| anyhow!("synchronizer has no canonical grounded state yet"))?;
-        Ok(SynchronizerHead { current_gsr })
+        Ok(SynchronizerHead { current_state_root })
     }
 
     fn fetch_grounding_witness(
@@ -102,17 +102,17 @@ impl SynchronizerClient for HttpSynchronizerClient {
             "synchronizer grounding witness response",
         )?;
 
-        let state_root = StateRoot::new(
+        let state_header = StateHeader::new(
             payload.block_number,
             payload.created_root,
             payload.nullifiers_root,
-            payload.gsrs_root,
+            payload.state_history_root,
         );
-        let remote_state_root_hash = payload.state_root_hash;
-        let derived_state_root_hash = state_root.hash();
-        if remote_state_root_hash != derived_state_root_hash {
+        let remote_state_root = payload.state_root;
+        let derived_state_root = state_header.hash();
+        if remote_state_root != derived_state_root {
             return Err(anyhow!(
-                "synchronizer grounding witness hash mismatch: remote={remote_state_root_hash:#} derived={derived_state_root_hash:#}"
+                "synchronizer grounding witness hash mismatch: remote={remote_state_root:#} derived={derived_state_root:#}"
             ));
         }
 
@@ -127,7 +127,7 @@ impl SynchronizerClient for HttpSynchronizerClient {
             }),
         )?;
 
-        Ok(GroundingWitness::new(state_root, created_proofs))
+        Ok(GroundingWitness::new(state_header, created_proofs))
     }
 
     fn fetch_membership_with_nullifiers(

--- a/driver/src/driver.rs
+++ b/driver/src/driver.rs
@@ -354,7 +354,7 @@ impl Driver {
     /// (e.g. a file from outside `~/.dobj/`) — into local inventory.
     ///
     /// `dobj_json` is the raw JSON contents of a `.dobj` file. The object is
-    /// filed under a canonical name derived from its commitment — the file's
+    /// filed under a name derived from its commitment — the file's
     /// own `id` and filename are not trusted.
     ///
     /// Validation:
@@ -364,7 +364,7 @@ impl Driver {
     /// - the object must not already be in inventory (live or nullified);
     /// - the object's nullifier must not already be spent on-chain.
     ///
-    /// Status is decided by grounding: `Live` if the source tx is canonical,
+    /// Status is decided by grounding: `Live` if the source tx is committed,
     /// otherwise `Unknown` (a later `sync_inventory` promotes it). If the
     /// synchronizer is unreachable the object is imported as `Unknown` rather
     /// than failing, so the flow still works offline.
@@ -424,7 +424,7 @@ impl Driver {
 
         // 4. Grounding decides status. A nullifier already on-chain means the
         //    object has been spent — reject it. Otherwise Live if the object's
-        //    commitment is in the canonical created set, else Unknown. Tolerate
+        //    commitment is in the created set, else Unknown. Tolerate
         //    an unreachable synchronizer by importing as Unknown.
         let settings = self.load_settings()?;
         let commitment = record.obj.commitment();
@@ -521,7 +521,7 @@ impl Driver {
             .deps
             .payload_builder
             .build_payload(&old_root_hash, &spendable_outputs)?;
-        // A tx has landed once the union of its effects is canonical: every
+        // A tx has landed once the union of its effects is committed: every
         // produced object commitment in the created set and every nullifier in
         // the nullifier set. Collect both for the confirmation poll below.
         let output_commitments: Vec<Hash> = spendable_outputs

--- a/driver/src/driver.rs
+++ b/driver/src/driver.rs
@@ -37,7 +37,7 @@ use wire_types::{
 pub trait PayloadBuilder: Send + Sync {
     fn build_payload(
         &self,
-        old_state_root_hash: &Hash,
+        old_state_root: &Hash,
         action_output: &SpendableObjects,
     ) -> Result<Vec<u8>>;
 }
@@ -48,10 +48,10 @@ struct DefaultPayloadBuilder;
 impl PayloadBuilder for DefaultPayloadBuilder {
     fn build_payload(
         &self,
-        old_state_root_hash: &Hash,
+        old_state_root: &Hash,
         action_output: &SpendableObjects,
     ) -> Result<Vec<u8>> {
-        build_relayer_payload(old_state_root_hash, action_output)
+        build_relayer_payload(old_state_root, action_output)
     }
 }
 
@@ -347,7 +347,7 @@ impl Driver {
             .deps
             .synchronizer
             .fetch_head(&settings.synchronizer_api_url)?;
-        Ok(head.current_gsr)
+        Ok(head.current_state_root)
     }
 
     /// Import an external `.dobj` object — one not produced by this driver
@@ -496,7 +496,7 @@ impl Driver {
             .deps
             .synchronizer
             .fetch_grounding_witness(&settings.synchronizer_api_url, &input_commitments)?;
-        let old_root_hash = grounding_witness.state_root.hash();
+        let old_root_hash = grounding_witness.state_header.hash();
         let old_root = old_root_hash;
 
         reporter.on_step(ExecutionPhase::GenerateProof, "Generating proof", &no_ctx);
@@ -664,7 +664,7 @@ impl Driver {
 
         let result = ExecuteActionResult {
             old_root,
-            new_root: sync_head.current_gsr,
+            new_root: sync_head.current_state_root,
             output_files: saved.output_files.clone(),
             nullified_files: saved.nullified_files.clone(),
             relayer_job_id: confirmation.job_id,

--- a/driver/src/driver.rs
+++ b/driver/src/driver.rs
@@ -496,8 +496,7 @@ impl Driver {
             .deps
             .synchronizer
             .fetch_grounding_witness(&settings.synchronizer_api_url, &input_commitments)?;
-        let old_root_hash = grounding_witness.state_header.hash();
-        let old_root = old_root_hash;
+        let old_root = grounding_witness.state_header.hash();
 
         reporter.on_step(ExecutionPhase::GenerateProof, "Generating proof", &no_ctx);
         let execution_inputs = resolved_inputs
@@ -520,7 +519,7 @@ impl Driver {
         let payload_bytes = self
             .deps
             .payload_builder
-            .build_payload(&old_root_hash, &spendable_outputs)?;
+            .build_payload(&old_root, &spendable_outputs)?;
         // A tx has landed once the union of its effects is committed: every
         // produced object commitment in the created set and every nullifier in
         // the nullifier set. Collect both for the confirmation poll below.

--- a/driver/src/execute.rs
+++ b/driver/src/execute.rs
@@ -79,7 +79,7 @@ pub(crate) fn reconcile_objects(
     }
 
     // Third pass: mark non-nullified objects as Live when their commitment
-    // is present in the canonical global created set.
+    // is present in the created set.
     for entry in objects.iter_mut() {
         if entry.record.is_nullified() || entry.record.status == ObjectStatus::Live {
             continue;

--- a/driver/src/execute.rs
+++ b/driver/src/execute.rs
@@ -280,7 +280,7 @@ pub(crate) fn update_output_files(
 }
 
 pub(crate) fn build_relayer_payload(
-    old_state_root_hash: &Hash,
+    old_state_root: &Hash,
     action_output: &SpendableObjects,
 ) -> Result<Vec<u8>> {
     let params = Params::default();
@@ -296,7 +296,7 @@ pub(crate) fn build_relayer_payload(
     let payload = Payload {
         proof: PayloadProof::Plonky2(Box::new(compressed)),
         tx_final,
-        state_root_hash: *old_state_root_hash,
+        state_root: *old_state_root,
         nullifiers,
         live,
     };

--- a/driver/src/object_store.rs
+++ b/driver/src/object_store.rs
@@ -173,7 +173,7 @@ mod tests {
     use std::collections::HashMap;
 
     use tempfile::tempdir;
-    use txlib::{GroundingWitness, StateRoot};
+    use txlib::{GroundingWitness, StateHeader};
 
     use crate::catalog::ActionCatalog;
     use crate::paths::default_paths;
@@ -193,7 +193,7 @@ mod tests {
 
     fn dummy_grounding_witness() -> GroundingWitness {
         GroundingWitness::new(
-            StateRoot::new(
+            StateHeader::new(
                 1,
                 pod2::middleware::EMPTY_HASH,
                 pod2::middleware::EMPTY_HASH,

--- a/driver/src/pexe_catalog.rs
+++ b/driver/src/pexe_catalog.rs
@@ -754,7 +754,7 @@ description = "consume a Foo to make a Bar"
 
     fn dummy_grounding_witness() -> txlib::GroundingWitness {
         txlib::GroundingWitness::new(
-            txlib::StateRoot::new(
+            txlib::StateHeader::new(
                 1,
                 pod2::middleware::EMPTY_HASH,
                 pod2::middleware::EMPTY_HASH,

--- a/driver/src/tests.rs
+++ b/driver/src/tests.rs
@@ -6,7 +6,7 @@ use common::test_state::TestState;
 use pod2::middleware::Hash;
 use sdk::SpendableObjects;
 use tempfile::tempdir;
-use txlib::{GroundingWitness, StateRoot};
+use txlib::{GroundingWitness, StateHeader};
 
 use crate::catalog::ActionCatalog;
 use crate::clients::{
@@ -40,7 +40,7 @@ fn make_catalog() -> PexeCatalog {
 
 fn dummy_grounding_witness() -> GroundingWitness {
     GroundingWitness::new(
-        StateRoot::new(
+        StateHeader::new(
             1,
             pod2::middleware::EMPTY_HASH,
             pod2::middleware::EMPTY_HASH,
@@ -61,9 +61,14 @@ fn apply_tx(state: &mut TestState, tx: &txlib::Tx) {
     );
 }
 
-fn state_root(state: &TestState) -> StateRoot {
-    let (created_root, nullifiers_root, gsrs_root) = state.roots();
-    StateRoot::new(state.block_number, created_root, nullifiers_root, gsrs_root)
+fn state_header(state: &TestState) -> StateHeader {
+    let (created_root, nullifiers_root, state_history_root) = state.roots();
+    StateHeader::new(
+        state.block_number,
+        created_root,
+        nullifiers_root,
+        state_history_root,
+    )
 }
 
 fn craft_basics(name: &str) -> QualifiedName {
@@ -111,7 +116,7 @@ struct MockPayloadBuilder;
 impl PayloadBuilder for MockPayloadBuilder {
     fn build_payload(
         &self,
-        _old_state_root_hash: &Hash,
+        _old_state_root: &Hash,
         _action_output: &SpendableObjects,
     ) -> Result<Vec<u8>> {
         Ok(vec![1, 2, 3])
@@ -130,7 +135,7 @@ struct MockSynchronizer {
 impl SynchronizerClient for MockSynchronizer {
     fn fetch_head(&self, _sync_api_url: &str) -> Result<SynchronizerHead> {
         Ok(SynchronizerHead {
-            current_gsr: state_root(&self.state).hash(),
+            current_state_root: state_header(&self.state).hash(),
         })
     }
 
@@ -145,7 +150,7 @@ impl SynchronizerClient for MockSynchronizer {
             .map(|commitment| (commitment, self.state.created_membership_proof(commitment)))
             .collect::<HashMap<_, _>>();
         Ok(GroundingWitness::new(
-            state_root(&self.state),
+            state_header(&self.state),
             created_proofs,
         ))
     }
@@ -177,7 +182,7 @@ impl SynchronizerClient for MockSynchronizer {
             return Err(anyhow!("synchronizer timeout"));
         }
         Ok(SynchronizerHead {
-            current_gsr: state_root(&self.state).hash(),
+            current_state_root: state_header(&self.state).hash(),
         })
     }
 }
@@ -202,7 +207,7 @@ impl RelayerClient for MockRelayer {
             job_id: "job-1".to_string(),
             status: wire_types::relayer::JobStatus::Queued,
             tx_final: Default::default(),
-            state_root_hash: Default::default(),
+            state_root: Default::default(),
             attempt_count: 0,
             created_at: 0,
         })

--- a/driver/src/tests.rs
+++ b/driver/src/tests.rs
@@ -62,12 +62,12 @@ fn apply_tx(state: &mut TestState, tx: &txlib::Tx) {
 }
 
 fn state_header(state: &TestState) -> StateHeader {
-    let (created_root, nullifiers_root, state_history_root) = state.roots();
+    let (created_root, nullifiers_root, prior_state_history_root) = state.roots();
     StateHeader::new(
         state.block_number,
         created_root,
         nullifiers_root,
-        state_history_root,
+        prior_state_history_root,
     )
 }
 

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -61,7 +61,7 @@ production implementation lives in
 | `list_inventory`                   | All objects with types, fields, liveness status               |
 | `list_actions`                     | Available crafting actions with input/output classes          |
 | `list_classes`                     | All object classes with live counts and related actions       |
-| `get_state_root`                   | Current global state root from the synchronizer               |
+| `get_state_root`                   | Current state root from the synchronizer                      |
 | `inspect_object`                   | Full object detail: fields, class, liveness, predicate        |
 | `import_object_file`               | Adopt an external `.dobj` from a local path into inventory    |
 | `inspect_class`                    | Class predicate definition and related actions                |

--- a/mcp/docs/instructions.md
+++ b/mcp/docs/instructions.md
@@ -47,7 +47,7 @@ grounded in a recent state root (within ~300 blocks / ~1 hour). The
 - `inspect_object(file_name)` — full detail on one object: fields, status, predicate source
 - `inspect_class(class_name)` — predicate definition + which actions produce/consume the class
 - `check_feasibility(action_id)` — does the user's inventory have what this action needs?
-- `get_state_root` — current canonical state root from the synchronizer
+- `get_state_root` — current state root from the synchronizer
 - `read_doc(name)` — reference docs (`podlang-reference`, `object-lifecycle`, `txlib.podlang`,
   `time.podlang`, `generated.podlang`, or `list` to enumerate)
 

--- a/mcp/docs/instructions.md
+++ b/mcp/docs/instructions.md
@@ -32,10 +32,10 @@ prevents double-spending. An object is "live" if its nullifier has not
 been published. Dead objects remain in inventory for reference but
 cannot be used as inputs.
 
-**State root.** A Global State Root (GSR) is a hash of all published
+**State root.** A state root is a hash of all published
 transactions and nullifiers at a given Ethereum block. Actions must be
-grounded in a recent GSR (within ~300 blocks / ~1 hour). The
-`get_state_root` tool returns the current GSR.
+grounded in a recent state root (within ~300 blocks / ~1 hour). The
+`get_state_root` tool returns the current state root.
 
 ## Tools
 
@@ -47,7 +47,7 @@ grounded in a recent GSR (within ~300 blocks / ~1 hour). The
 - `inspect_object(file_name)` — full detail on one object: fields, status, predicate source
 - `inspect_class(class_name)` — predicate definition + which actions produce/consume the class
 - `check_feasibility(action_id)` — does the user's inventory have what this action needs?
-- `get_state_root` — current canonical GSR from the synchronizer
+- `get_state_root` — current canonical state root from the synchronizer
 - `read_doc(name)` — reference docs (`podlang-reference`, `object-lifecycle`, `txlib.podlang`,
   `time.podlang`, `generated.podlang`, or `list` to enumerate)
 

--- a/mcp/docs/object-lifecycle.md
+++ b/mcp/docs/object-lifecycle.md
@@ -52,7 +52,7 @@ Once published, any attempt to use the same object in another action will fail b
 
 ## 6. State root grounding
 
-Every action must reference a recent Global State Root (GSR) — a hash of all published transactions and nullifiers. This ensures the action's inputs were live at a known point in time. The synchronizer rejects actions grounded in a GSR more than ~300 blocks (~1 hour) old.
+Every action must reference a recent state root — a hash of all published transactions and nullifiers. This ensures the action's inputs were live at a known point in time. The synchronizer rejects actions grounded in a state root more than ~300 blocks (~1 hour) old.
 
 ## Summary of what changes after each action
 

--- a/mcp/docs/podlang-reference.md
+++ b/mcp/docs/podlang-reference.md
@@ -143,7 +143,7 @@ Imports a predicate group (identified by its Merkle root hash) and gives it a lo
 use module 0xHASH as txlib
 
 MyPred(...) = AND(
-  txlib::StateRoot(...)
+  txlib::StateHeader(...)
 )
 ```
 

--- a/mcp/src/resources.rs
+++ b/mcp/src/resources.rs
@@ -19,7 +19,7 @@ pub fn list() -> Vec<Resource> {
         Annotated::new(
             RawResource::new(TXLIB_PREDICATES_URI, "txlib.podlang")
                 .with_description(
-                    "Core transaction-model predicates: StateRoot, TxInit, \
+                    "Core transaction-model predicates: StateHeader, TxInit, \
                      TxInsert, TxMutate, TxDelete, TxFinalized, and \
                      nullifier logic. This is the foundation all actions build on.",
                 )

--- a/mcp/src/server.rs
+++ b/mcp/src/server.rs
@@ -117,7 +117,7 @@ impl<T: CraftOps> CraftMcpService<T> {
             .map_err(|e| e.to_string())
     }
 
-    #[tool(description = "Get the current global state root hash from the synchronizer")]
+    #[tool(description = "Get the current state root hash from the synchronizer")]
     fn get_state_root(&self) -> Result<Json<StateRootResponse>, String> {
         self.ops
             .get_state_root()

--- a/mcp/src/types.rs
+++ b/mcp/src/types.rs
@@ -46,7 +46,7 @@ pub struct ClassList {
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct StateRootResponse {
-    /// The current global state root hash.
+    /// The current state root hash.
     pub state_root: String,
 }
 

--- a/pexe/src/fixtures.rs
+++ b/pexe/src/fixtures.rs
@@ -12,7 +12,7 @@ use anyhow::{Result, anyhow};
 use pod2::middleware::{EMPTY_HASH, EMPTY_VALUE, Hash, StrKey, Value, containers::Array};
 use pod2utils::{dict, rand_raw_value};
 use sdk::{SdkModule, SpendableObject};
-use txlib::{GroundingWitness, StateRoot, with_identity};
+use txlib::{GroundingWitness, StateHeader, with_identity};
 
 use crate::inspect::derive_class_signature;
 
@@ -117,7 +117,7 @@ pub fn build_synthetic_state(
         indices.insert(commitment, index);
     }
 
-    let state_root = StateRoot::new(1, created.commitment(), EMPTY_HASH, EMPTY_HASH);
+    let state_header = StateHeader::new(1, created.commitment(), EMPTY_HASH, EMPTY_HASH);
 
     let mut created_proofs: HashMap<Hash, _> = HashMap::with_capacity(objs.len());
     for obj in objs {
@@ -129,7 +129,7 @@ pub fn build_synthetic_state(
         created_proofs.insert(commitment, (index, proof));
     }
 
-    let grounding_witness = Arc::new(GroundingWitness::new(state_root, created_proofs));
+    let grounding_witness = Arc::new(GroundingWitness::new(state_header, created_proofs));
 
     let spendable: Vec<SpendableObject> = objs
         .iter()

--- a/relayer/src/api.rs
+++ b/relayer/src/api.rs
@@ -153,7 +153,7 @@ async fn submit_proof(
         status: JobStatus::Queued,
         payload_bytes,
         tx_final: payload.tx_final,
-        state_root_hash: payload.state_root_hash,
+        state_root: payload.state_root,
         client_ref: req.client_ref,
         attempt_count: 0,
         tx_hash: None,
@@ -254,7 +254,7 @@ fn to_submit_response(job: RelayJob) -> SubmitProofResponse {
         job_id: job.job_id,
         status: job.status,
         tx_final: job.tx_final,
-        state_root_hash: job.state_root_hash,
+        state_root: job.state_root,
         attempt_count: job.attempt_count,
         created_at: job.created_at,
     }
@@ -271,7 +271,7 @@ fn to_status_response(job: RelayJob) -> JobStatusResponse {
         updated_at: job.updated_at,
         created_at: job.created_at,
         tx_final: job.tx_final,
-        state_root_hash: job.state_root_hash,
+        state_root: job.state_root,
     }
 }
 
@@ -307,7 +307,7 @@ mod tests {
                 ParseMode::Valid => Ok(Some(Payload {
                     proof: PayloadProof::empty_for_test(),
                     tx_final: EMPTY_HASH,
-                    state_root_hash: EMPTY_HASH,
+                    state_root: EMPTY_HASH,
                     nullifiers: vec![],
                     live: vec![],
                 })),
@@ -514,7 +514,7 @@ mod tests {
         assert_eq!(first.job_id, second.job_id);
         assert_eq!(first.tx_final, second.tx_final);
         assert!(second_json.get("tx_final").is_some());
-        assert!(second_json.get("state_root_hash").is_some());
+        assert!(second_json.get("state_root").is_some());
         assert!(second_json.get("attempt_count").is_some());
         assert!(second_json.get("txFinal").is_none());
 

--- a/relayer/src/db.rs
+++ b/relayer/src/db.rs
@@ -44,7 +44,7 @@ impl Db {
                 status TEXT NOT NULL CHECK (status IN ('queued','sending','submitted','confirmed','failed')),
                 payload_bytes BYTEA NOT NULL,
                 tx_final BYTEA NOT NULL UNIQUE,
-                state_root_hash BYTEA NOT NULL,
+                state_root BYTEA NOT NULL,
                 client_ref TEXT NULL,
                 attempt_count INTEGER NOT NULL,
                 tx_hash TEXT NULL,
@@ -87,7 +87,7 @@ impl Db {
                 status,
                 payload_bytes,
                 tx_final,
-                state_root_hash,
+                state_root,
                 client_ref,
                 attempt_count,
                 tx_hash,
@@ -110,7 +110,7 @@ impl Db {
         .bind(job.status.as_str())
         .bind(&job.payload_bytes)
         .bind(hash_to_db_bytes(job.tx_final))
-        .bind(hash_to_db_bytes(job.state_root_hash))
+        .bind(hash_to_db_bytes(job.state_root))
         .bind(job.client_ref.clone())
         .bind(job.attempt_count as i32)
         .bind(job.tx_hash.clone())
@@ -148,7 +148,7 @@ impl Db {
             SET status = $2,
                 payload_bytes = $3,
                 tx_final = $4,
-                state_root_hash = $5,
+                state_root = $5,
                 client_ref = $6,
                 attempt_count = $7,
                 tx_hash = $8,
@@ -168,7 +168,7 @@ impl Db {
         .bind(job.status.as_str())
         .bind(&job.payload_bytes)
         .bind(hash_to_db_bytes(job.tx_final))
-        .bind(hash_to_db_bytes(job.state_root_hash))
+        .bind(hash_to_db_bytes(job.state_root))
         .bind(job.client_ref.clone())
         .bind(job.attempt_count as i32)
         .bind(job.tx_hash.clone())
@@ -200,7 +200,7 @@ impl Db {
                    status,
                    payload_bytes,
                    tx_final,
-                   state_root_hash,
+                   state_root,
                    client_ref,
                    attempt_count,
                    tx_hash,
@@ -232,7 +232,7 @@ impl Db {
                    status,
                    payload_bytes,
                    tx_final,
-                   state_root_hash,
+                   state_root,
                    client_ref,
                    attempt_count,
                    tx_hash,
@@ -307,7 +307,7 @@ impl Db {
                    status,
                    payload_bytes,
                    tx_final,
-                   state_root_hash,
+                   state_root,
                    client_ref,
                    attempt_count,
                    tx_hash,
@@ -357,7 +357,7 @@ fn row_to_job(row: sqlx::postgres::PgRow) -> Result<RelayJob> {
         status,
         payload_bytes: row.get("payload_bytes"),
         tx_final: db_bytes_to_hash(&row.get::<Vec<u8>, _>("tx_final"))?,
-        state_root_hash: db_bytes_to_hash(&row.get::<Vec<u8>, _>("state_root_hash"))?,
+        state_root: db_bytes_to_hash(&row.get::<Vec<u8>, _>("state_root"))?,
         client_ref: row.get("client_ref"),
         attempt_count,
         tx_hash: row.get("tx_hash"),
@@ -398,7 +398,7 @@ mod tests {
             status,
             payload_bytes: vec![1, 2, 3],
             tx_final,
-            state_root_hash: Hash::default(),
+            state_root: Hash::default(),
             client_ref: None,
             attempt_count: 0,
             tx_hash: None,

--- a/relayer/src/model.rs
+++ b/relayer/src/model.rs
@@ -15,7 +15,7 @@ pub struct RelayJob {
     /// Idempotency key derived from proof payload.
     pub tx_final: Hash,
     /// State root hash claimed by the payload.
-    pub state_root_hash: Hash,
+    pub state_root: Hash,
     /// Optional caller-provided trace string for observability.
     pub client_ref: Option<String>,
     /// Total submission attempts made so far.

--- a/relayer/src/worker.rs
+++ b/relayer/src/worker.rs
@@ -124,7 +124,7 @@ async fn send_queued_job(
         attempt = job.attempt_count,
         payload_bytes = job.payload_bytes.len(),
         tx_final = %format_args!("{:#}", job.tx_final),
-        state_root_hash = %format_args!("{:#}", job.state_root_hash),
+        state_root = %format_args!("{:#}", job.state_root),
         nonce,
         "Submitting relay payload to Ethereum"
     );
@@ -627,7 +627,7 @@ mod tests {
             status,
             payload_bytes: vec![1, 2, 3],
             tx_final: Default::default(),
-            state_root_hash: Default::default(),
+            state_root: Default::default(),
             client_ref: None,
             attempt_count: 0,
             tx_hash: None,

--- a/sdk/src/tests.rs
+++ b/sdk/src/tests.rs
@@ -13,13 +13,13 @@ fn apply_tx(state: &mut TestState, tx: &Tx) {
 fn grounding_witness(state: &TestState, input_commitments: &[Hash]) -> Arc<GroundingWitness> {
     state.build_grounding_witness(
         input_commitments,
-        |block_number, created_root, nullifiers_root, state_history_root, created_proofs| {
+        |block_number, created_root, nullifiers_root, prior_state_history_root, created_proofs| {
             Arc::new(GroundingWitness::new(
                 StateHeader::new(
                     block_number,
                     created_root,
                     nullifiers_root,
-                    state_history_root,
+                    prior_state_history_root,
                 ),
                 created_proofs,
             ))

--- a/sdk/src/tests.rs
+++ b/sdk/src/tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 use common::test_state::TestState;
-use txlib::StateRoot;
+use txlib::StateHeader;
 
 fn apply_tx(state: &mut TestState, tx: &Tx) {
     state.apply_tx(
@@ -13,9 +13,14 @@ fn apply_tx(state: &mut TestState, tx: &Tx) {
 fn grounding_witness(state: &TestState, input_commitments: &[Hash]) -> Arc<GroundingWitness> {
     state.build_grounding_witness(
         input_commitments,
-        |block_number, created_root, nullifiers_root, gsrs_root, created_proofs| {
+        |block_number, created_root, nullifiers_root, state_history_root, created_proofs| {
             Arc::new(GroundingWitness::new(
-                StateRoot::new(block_number, created_root, nullifiers_root, gsrs_root),
+                StateHeader::new(
+                    block_number,
+                    created_root,
+                    nullifiers_root,
+                    state_history_root,
+                ),
                 created_proofs,
             ))
         },

--- a/synchronizer/README.md
+++ b/synchronizer/README.md
@@ -194,7 +194,7 @@ Reorg rollback does not modify RocksDB. The surviving Postgres `StateHead` deter
     - `blockNumber`
     - `createdRoot`
     - `nullifiersRoot`
-    - `stateHistoryRoot`
+    - `priorStateHistoryRoot`
     - `createdProofs` (array of `{ commitment, present, index, proof }`)
 
 Membership and grounding-witness requests read the state head and the

--- a/synchronizer/README.md
+++ b/synchronizer/README.md
@@ -76,7 +76,7 @@ Important: RocksDB is not the source of truth. It is an append-only backing stor
 
 Postgres stores the synchronization state:
 
-- `canonical_slots`
+- `state_slots`
   - one row per slot
   - on first initialization, the first row is a bootstrap row at `start_slot - 1`
   - that bootstrap row uses the real beacon/execution metadata when `start_slot - 1` had a block
@@ -93,7 +93,7 @@ Postgres stores the synchronization state:
     cross-checks it against the created array at the queried root
 
 Postgres is the sole source of `StateHead`. The highest committed
-`canonical_slots.slot` is the current state head.
+`state_slots.slot` is the current state head.
 
 ## Slot derivation rules
 
@@ -142,7 +142,7 @@ Because the Merkle nodes were already materialized during derivation, there is n
 On reorg:
 
 - the synchronizer finds the last common ancestor slot
-- deletes `canonical_slots` rows after the keep-point, and the `created_index`
+- deletes `state_slots` rows after the keep-point, and the `created_index`
   rows those slots added, in one transaction
 - resumes syncing from the first divergent slot
 

--- a/synchronizer/README.md
+++ b/synchronizer/README.md
@@ -1,6 +1,6 @@
 # Synchronizer
 
-Service that tracks Digital Object blob transactions on Ethereum, derives canonical app state, persists persistent-container data in RocksDB, stores canonical heads in Postgres, and serves proof-backed query APIs over HTTP.
+Service that tracks Digital Object blob transactions on Ethereum, derives app state, persists persistent-container data in RocksDB, stores state heads in Postgres, and serves proof-backed query APIs over HTTP.
 
 ## What it does
 
@@ -8,15 +8,15 @@ Service that tracks Digital Object blob transactions on Ethereum, derives canoni
 2. Starts:
    - a sync loop that processes beacon slots in order
    - an HTTP API server
-3. For each canonical slot, it:
+3. For each slot, it:
    - reads the beacon block header/block
    - finds blob txs sent to `TO_ADDRESS`
    - fetches matching blob sidecars
    - parses and verifies `TxFinalized` payloads
    - prefetches the payloads' created-object commitments from the Postgres created index
-   - opens the current Merkle containers from the canonical `StateHead`
+   - opens the current Merkle containers from the `StateHead`
    - derives the next `StateHead`
-4. Publishes the new canonical slot/head and its created-index rows in one Postgres transaction, and serves state/proof APIs for clients like `app-gui`.
+4. Publishes the new slot/head and its created-index rows in one Postgres transaction, and serves state/proof APIs for clients like `app-gui`.
 
 ## State model
 
@@ -25,16 +25,16 @@ The synchronizer splits state into two layers:
 - RocksDB stores the content-addressed POD2 Merkle backing store
   - persistent Merkle nodes
   - persistent POD2 values
-- Postgres stores the canonical control plane
-  - canonical slot metadata
-  - the canonical `StateHead` for each slot
+- Postgres stores the control plane
+  - slot metadata
+  - the `StateHead` for each slot
   - the created index: object commitment -> position in the created array
 
-There is no canonical head stored in RocksDB, and no resident in-memory head/cache. Every slot derivation and API read loads the current canonical head from Postgres, then reopens the needed persistent containers from RocksDB by root.
+There is no state head stored in RocksDB, and no resident in-memory head/cache. Every slot derivation and API read loads the current state head from Postgres, then reopens the needed persistent containers from RocksDB by root.
 
 ### `StateHead`
 
-`StateHead` is the compact committed app-state snapshot stored on canonical slot rows. It is split into:
+`StateHead` is the compact committed app-state snapshot stored on slot rows. It is split into:
 
 - `StateRoots`
   - `created`
@@ -70,37 +70,37 @@ The Merkle-backed containers are:
 
 The synchronizer reopens those containers from the roots stored in `StateRoots`.
 
-Important: RocksDB is not the source of canonical truth. It is an append-only backing store for Merkle data. Derivation may materialize nodes that never become canonical; those orphaned nodes are harmless and are ignored unless a future `StateHead` points at them.
+Important: RocksDB is not the source of truth. It is an append-only backing store for Merkle data. Derivation may materialize nodes that are never committed; those orphaned nodes are harmless and are ignored unless a future `StateHead` points at them.
 
-### Postgres (`SYNC_METADATA_DB_URL`) — canonical heads and sync metadata
+### Postgres (`SYNC_METADATA_DB_URL`) — state heads and sync metadata
 
-Postgres stores the canonical synchronization state:
+Postgres stores the synchronization state:
 
 - `canonical_slots`
-  - one row per canonical slot
+  - one row per slot
   - on first initialization, the first row is a bootstrap row at `start_slot - 1`
   - that bootstrap row uses the real beacon/execution metadata when `start_slot - 1` had a block
   - if `start_slot - 1` was an empty beacon slot, its block fields remain `NULL`
   - includes `block_root`, `parent_root`, `execution_block_number`, `current_state_root`, `is_empty`
-  - includes normalized `head_*` columns for the canonical `StateHead` at that slot
+  - includes normalized `head_*` columns for the `StateHead` at that slot
 - `created_index`
   - reverse index from object commitment to its position in the created array
   - one row per created object: `commitment` (primary key), `array_index`, `slot`
   - rows are inserted in the same transaction that commits their slot and
     deleted in the same transaction that rolls the slot back, so the index
-    never diverges from the canonical head
+    never diverges from the state head
   - reads treat the index as a hint: every membership and proof answer
     cross-checks it against the created array at the queried root
 
-Postgres is the sole source of canonical `StateHead`. The highest committed
-`canonical_slots.slot` is the current canonical head.
+Postgres is the sole source of `StateHead`. The highest committed
+`canonical_slots.slot` is the current state head.
 
 ## Slot derivation rules
 
 For each decoded blob payload, the synchronizer:
 
 - skips blobs that do not decode into a valid `TxFinalized` proof
-- rejects payloads whose `state_root_hash` is not in recent canonical state root history
+- rejects payloads whose `state_root_hash` is not in recent state root history
 - rejects payloads whose grounding state root is older than `MAX_STATE_ROOT_AGE_BLOCKS` (currently 300)
 - rejects creation collisions: a created-object commitment that repeats within
   the payload, repeats within the slot, or already exists in committed state
@@ -119,23 +119,23 @@ After processing all blobs in the slot, it computes the next state root from:
 
 Then it appends that new state root to the persistent state root history array and derives a new `StateHead`.
 
-Important: state root history advances for each canonical processed slot, even if that slot accepted zero app transactions.
+Important: state root history advances for each processed slot, even if that slot accepted zero app transactions.
 
 ## Publish, recovery, and reorgs
 
-### Canonical publish
+### Publish
 
-The synchronizer derives candidate state by mutating persistent containers in RocksDB. Once derivation succeeds, canonical publication is a single Postgres transaction:
+The synchronizer derives candidate state by mutating persistent containers in RocksDB. Once derivation succeeds, publication is a single Postgres transaction:
 
-1. Insert the canonical slot row, including the normalized `head_*` columns
+1. Insert the slot row, including the normalized `head_*` columns
 2. Insert one `created_index` row per object commitment the slot added
 
-Because the Merkle nodes were already materialized during derivation, there is no second canonical write to RocksDB.
+Because the Merkle nodes were already materialized during derivation, there is no second write to RocksDB.
 
 ### Crash semantics
 
-- If the process crashes before the Postgres commit, the old canonical head remains in force and any newly written RocksDB nodes are just orphaned.
-- If the process crashes after the Postgres commit, the published `StateHead` is already durable and sufficient to reopen the canonical containers.
+- If the process crashes before the Postgres commit, the old state head remains in force and any newly written RocksDB nodes are just orphaned.
+- If the process crashes after the Postgres commit, the published `StateHead` is already durable and sufficient to reopen the persistent containers.
 
 ### Reorg handling
 
@@ -146,7 +146,7 @@ On reorg:
   rows those slots added, in one transaction
 - resumes syncing from the first divergent slot
 
-Reorg rollback does not modify RocksDB. The surviving Postgres `StateHead` determines which Merkle roots are canonical after rewind.
+Reorg rollback does not modify RocksDB. The surviving Postgres `StateHead` determines which Merkle roots are current after rewind.
 
 ## API
 
@@ -167,7 +167,7 @@ Reorg rollback does not modify RocksDB. The surviving Postgres `StateHead` deter
   - request body:
     - `object_commitments` (array of hash strings)
     - `nullifiers` (array of hash strings)
-  - returns membership for both sets from one captured canonical head:
+  - returns membership for both sets from one captured state head:
     - `last_processed_slot`
     - `current_state_root`
     - `created_results` (array of `{ commitment, present }`)
@@ -197,7 +197,7 @@ Reorg rollback does not modify RocksDB. The surviving Postgres `StateHead` deter
     - `stateHistoryRoot`
     - `createdProofs` (array of `{ commitment, present, index, proof }`)
 
-Membership and grounding-witness requests read the canonical head and the
+Membership and grounding-witness requests read the state head and the
 created index from one `REPEATABLE READ` Postgres transaction, so the index
 entries always match the captured head's roots. The RocksDB reads then run
 against those pinned roots; Merkle nodes are content-addressed and immutable

--- a/synchronizer/README.md
+++ b/synchronizer/README.md
@@ -39,7 +39,7 @@ There is no state head stored in RocksDB, and no resident in-memory head/cache. 
 - `StateRoots`
   - `created`
   - `nullifiers`
-  - `state_history`
+  - `prior_state_history`
   - `next_state_history`
 - `StateMetadata`
   - `current_state_root`
@@ -48,7 +48,7 @@ There is no state head stored in RocksDB, and no resident in-memory head/cache. 
   - `nullifier_count`
   - `state_root_count`
 
-`StateRoots.state_history` is the prior-state root array root committed inside `txlib::StateHeader`.
+`StateRoots.prior_state_history` is the prior-state root array root committed inside `txlib::StateHeader`.
 `StateRoots.next_state_history` is the full state root-history root after appending `StateMetadata.current_state_root`.
 
 ## Storage model

--- a/synchronizer/README.md
+++ b/synchronizer/README.md
@@ -14,8 +14,8 @@ Service that tracks Digital Object blob transactions on Ethereum, derives canoni
    - fetches matching blob sidecars
    - parses and verifies `TxFinalized` payloads
    - prefetches the payloads' created-object commitments from the Postgres created index
-   - opens the current Merkle containers from the canonical `CanonicalHead`
-   - derives the next `CanonicalHead`
+   - opens the current Merkle containers from the canonical `StateHead`
+   - derives the next `StateHead`
 4. Publishes the new canonical slot/head and its created-index rows in one Postgres transaction, and serves state/proof APIs for clients like `app-gui`.
 
 ## State model
@@ -27,29 +27,29 @@ The synchronizer splits state into two layers:
   - persistent POD2 values
 - Postgres stores the canonical control plane
   - canonical slot metadata
-  - the canonical `CanonicalHead` for each slot
+  - the canonical `StateHead` for each slot
   - the created index: object commitment -> position in the created array
 
 There is no canonical head stored in RocksDB, and no resident in-memory head/cache. Every slot derivation and API read loads the current canonical head from Postgres, then reopens the needed persistent containers from RocksDB by root.
 
-### `CanonicalHead`
+### `StateHead`
 
-`CanonicalHead` is the compact committed app-state snapshot stored on canonical slot rows. It is split into:
+`StateHead` is the compact committed app-state snapshot stored on canonical slot rows. It is split into:
 
-- `CanonicalRoots`
+- `StateRoots`
   - `created`
   - `nullifiers`
-  - `state_root_gsrs`
-  - `gsr_history`
-- `HeadMetadata`
-  - `current_gsr`
+  - `state_history`
+  - `next_state_history`
+- `StateMetadata`
+  - `current_state_root`
   - `current_block_number`
   - `created_count`
   - `nullifier_count`
-  - `gsr_count`
+  - `state_root_count`
 
-`CanonicalRoots.state_root_gsrs` is the prior-GSR array root committed inside `txlib::StateRoot`.
-`CanonicalRoots.gsr_history` is the full GSR-history root after appending `HeadMetadata.current_gsr`.
+`StateRoots.state_history` is the prior-state root array root committed inside `txlib::StateHeader`.
+`StateRoots.next_state_history` is the full state root-history root after appending `StateMetadata.current_state_root`.
 
 ## Storage model
 
@@ -66,11 +66,11 @@ The Merkle-backed containers are:
 
 - created objects: persistent `Array` of object commitments (0-indexed)
 - nullifiers: persistent `Set`
-- GSR history: persistent `Array`
+- state root history: persistent `Array`
 
-The synchronizer reopens those containers from the roots stored in `CanonicalRoots`.
+The synchronizer reopens those containers from the roots stored in `StateRoots`.
 
-Important: RocksDB is not the source of canonical truth. It is an append-only backing store for Merkle data. Derivation may materialize nodes that never become canonical; those orphaned nodes are harmless and are ignored unless a future `CanonicalHead` points at them.
+Important: RocksDB is not the source of canonical truth. It is an append-only backing store for Merkle data. Derivation may materialize nodes that never become canonical; those orphaned nodes are harmless and are ignored unless a future `StateHead` points at them.
 
 ### Postgres (`SYNC_METADATA_DB_URL`) — canonical heads and sync metadata
 
@@ -81,8 +81,8 @@ Postgres stores the canonical synchronization state:
   - on first initialization, the first row is a bootstrap row at `start_slot - 1`
   - that bootstrap row uses the real beacon/execution metadata when `start_slot - 1` had a block
   - if `start_slot - 1` was an empty beacon slot, its block fields remain `NULL`
-  - includes `block_root`, `parent_root`, `execution_block_number`, `current_gsr`, `is_empty`
-  - includes normalized `head_*` columns for the canonical `CanonicalHead` at that slot
+  - includes `block_root`, `parent_root`, `execution_block_number`, `current_state_root`, `is_empty`
+  - includes normalized `head_*` columns for the canonical `StateHead` at that slot
 - `created_index`
   - reverse index from object commitment to its position in the created array
   - one row per created object: `commitment` (primary key), `array_index`, `slot`
@@ -92,7 +92,7 @@ Postgres stores the canonical synchronization state:
   - reads treat the index as a hint: every membership and proof answer
     cross-checks it against the created array at the queried root
 
-Postgres is the sole source of canonical `CanonicalHead`. The highest committed
+Postgres is the sole source of canonical `StateHead`. The highest committed
 `canonical_slots.slot` is the current canonical head.
 
 ## Slot derivation rules
@@ -100,8 +100,8 @@ Postgres is the sole source of canonical `CanonicalHead`. The highest committed
 For each decoded blob payload, the synchronizer:
 
 - skips blobs that do not decode into a valid `TxFinalized` proof
-- rejects payloads whose `state_root_hash` is not in recent canonical GSR history
-- rejects payloads whose grounding GSR is older than `MAX_GSR_AGE_BLOCKS` (currently 300)
+- rejects payloads whose `state_root_hash` is not in recent canonical state root history
+- rejects payloads whose grounding state root is older than `MAX_STATE_ROOT_AGE_BLOCKS` (currently 300)
 - rejects creation collisions: a created-object commitment that repeats within
   the payload, repeats within the slot, or already exists in committed state
   (prefetched from the created index and cross-checked against the created
@@ -110,16 +110,16 @@ For each decoded blob payload, the synchronizer:
 - appends accepted object commitments to the created array and inserts
   nullifiers into the persistent set
 
-After processing all blobs in the slot, it computes the next GSR from:
+After processing all blobs in the slot, it computes the next state root from:
 
 - current execution block number
 - created array root
 - nullifiers set root
-- prior GSR-array root
+- prior state root-array root
 
-Then it appends that new GSR to the persistent GSR history array and derives a new `CanonicalHead`.
+Then it appends that new state root to the persistent state root history array and derives a new `StateHead`.
 
-Important: GSR history advances for each canonical processed slot, even if that slot accepted zero app transactions.
+Important: state root history advances for each canonical processed slot, even if that slot accepted zero app transactions.
 
 ## Publish, recovery, and reorgs
 
@@ -135,7 +135,7 @@ Because the Merkle nodes were already materialized during derivation, there is n
 ### Crash semantics
 
 - If the process crashes before the Postgres commit, the old canonical head remains in force and any newly written RocksDB nodes are just orphaned.
-- If the process crashes after the Postgres commit, the published `CanonicalHead` is already durable and sufficient to reopen the canonical containers.
+- If the process crashes after the Postgres commit, the published `StateHead` is already durable and sufficient to reopen the canonical containers.
 
 ### Reorg handling
 
@@ -146,7 +146,7 @@ On reorg:
   rows those slots added, in one transaction
 - resumes syncing from the first divergent slot
 
-Reorg rollback does not modify RocksDB. The surviving Postgres `CanonicalHead` determines which Merkle roots are canonical after rewind.
+Reorg rollback does not modify RocksDB. The surviving Postgres `StateHead` determines which Merkle roots are canonical after rewind.
 
 ## API
 
@@ -158,18 +158,18 @@ Reorg rollback does not modify RocksDB. The surviving Postgres `CanonicalHead` d
   - returns:
     - `last_processed_slot`
     - `last_processed_block_number`
-    - `current_gsr`
+    - `current_state_root`
     - `current_block_number`
     - `created_count`
     - `nullifier_count`
-    - `gsr_count`
+    - `state_root_count`
 - `POST /v1/state/membership`
   - request body:
     - `object_commitments` (array of hash strings)
     - `nullifiers` (array of hash strings)
   - returns membership for both sets from one captured canonical head:
     - `last_processed_slot`
-    - `current_gsr`
+    - `current_state_root`
     - `created_results` (array of `{ commitment, present }`)
     - `nullifier_results` (array of `{ nullifier, present }`)
 - `POST /v1/state/object/contains`
@@ -177,24 +177,24 @@ Reorg rollback does not modify RocksDB. The surviving Postgres `CanonicalHead` d
     - `object_commitments` (array of hash strings)
   - returns:
     - `last_processed_slot`
-    - `current_gsr`
+    - `current_state_root`
     - `results` (array of `{ commitment, present }`)
 - `POST /v1/state/nullifier/contains`
   - request body:
     - `nullifiers` (array of hash strings)
   - returns:
     - `last_processed_slot`
-    - `current_gsr`
+    - `current_state_root`
     - `results` (array of `{ nullifier, present }`)
 - `POST /v1/txlib/grounding-witness`
   - request body:
     - `objectCommitments` (array of hash strings)
   - returns:
-    - `stateRootHash`
+    - `stateRoot`
     - `blockNumber`
     - `createdRoot`
     - `nullifiersRoot`
-    - `gsrsRoot`
+    - `stateHistoryRoot`
     - `createdProofs` (array of `{ commitment, present, index, proof }`)
 
 Membership and grounding-witness requests read the canonical head and the

--- a/synchronizer/src/api.rs
+++ b/synchronizer/src/api.rs
@@ -29,25 +29,25 @@ const MAX_HASH_QUERY_ITEMS: usize = 256;
 struct AppState {
     /// RocksDB-backed read path used for membership checks and Merkle proofs.
     app_db: AppDb,
-    /// Postgres-backed canonical head and sync-progress store.
+    /// Postgres-backed state head and sync-progress store.
     sync_db: Arc<SyncDb>,
 }
 
 /// Internal view of head/progress fields shaped for HTTP responses.
 struct HeadSnapshot {
-    /// Last canonical slot fully committed by the synchronizer.
+    /// Last slot fully committed by the synchronizer.
     last_processed_slot: u32,
     /// Execution block number associated with the last processed slot, if any.
     last_processed_block_number: Option<u32>,
-    /// Current canonical state root, if one exists.
+    /// Current state root, if one exists.
     current_state_root: Option<Hash>,
     /// Execution block number committed inside the current state root, if any.
     current_block_number: Option<i64>,
-    /// Number of objects in the canonical global created set.
+    /// Number of objects in the global created set.
     created_count: usize,
-    /// Number of spent nullifiers in canonical state.
+    /// Number of spent nullifiers in committed state.
     nullifier_count: usize,
-    /// Number of state root entries in canonical history.
+    /// Number of state root entries in chain history.
     state_root_count: usize,
 }
 
@@ -228,7 +228,7 @@ async fn post_grounding_witness(
     let state_header = head.current_state_header().ok_or_else(|| {
         (
             StatusCode::CONFLICT,
-            "synchronizer has no canonical grounded state yet".to_string(),
+            "synchronizer has no grounded state yet".to_string(),
         )
     })?;
     let state_root = head

--- a/synchronizer/src/api.rs
+++ b/synchronizer/src/api.rs
@@ -19,7 +19,7 @@ use wire_types::synchronizer::{
 
 use crate::{
     app_db::AppDb,
-    head::CanonicalRoots,
+    head::StateRoots,
     sync_db::{CurrentSnapshot, SyncDb},
 };
 
@@ -39,16 +39,16 @@ struct HeadSnapshot {
     last_processed_slot: u32,
     /// Execution block number associated with the last processed slot, if any.
     last_processed_block_number: Option<u32>,
-    /// Current canonical global state root, if one exists.
-    current_gsr: Option<Hash>,
+    /// Current canonical state root, if one exists.
+    current_state_root: Option<Hash>,
     /// Execution block number committed inside the current state root, if any.
     current_block_number: Option<i64>,
     /// Number of objects in the canonical global created set.
     created_count: usize,
     /// Number of spent nullifiers in canonical state.
     nullifier_count: usize,
-    /// Number of GSR entries in canonical history.
-    gsr_count: usize,
+    /// Number of state root entries in canonical history.
+    state_root_count: usize,
 }
 
 #[derive(Debug, Clone)]
@@ -141,11 +141,11 @@ async fn get_state_head(
     Ok(Json(StateHeadResponse {
         last_processed_slot: head.last_processed_slot,
         last_processed_block_number: head.last_processed_block_number,
-        current_gsr: head.current_gsr,
+        current_state_root: head.current_state_root,
         current_block_number: head.current_block_number,
         created_count: head.created_count,
         nullifier_count: head.nullifier_count,
-        gsr_count: head.gsr_count,
+        state_root_count: head.state_root_count,
     }))
 }
 
@@ -163,7 +163,7 @@ async fn post_state_object_contains(
 
     Ok(Json(ObjectContainsResponse {
         last_processed_slot: head.last_processed_slot,
-        current_gsr: head.current_gsr,
+        current_state_root: head.current_state_root,
         results: object_contains_entries(object_commitments, membership.created_present),
     }))
 }
@@ -182,7 +182,7 @@ async fn post_state_nullifier_contains(
 
     Ok(Json(NullifierContainsResponse {
         last_processed_slot: head.last_processed_slot,
-        current_gsr: head.current_gsr,
+        current_state_root: head.current_state_root,
         results: nullifier_contains_entries(nullifiers, membership.nullifier_present),
     }))
 }
@@ -200,7 +200,7 @@ async fn post_state_membership(
 
     Ok(Json(MembershipResponse {
         last_processed_slot: head.last_processed_slot,
-        current_gsr: head.current_gsr,
+        current_state_root: head.current_state_root,
         created_results: object_contains_entries(object_commitments, membership.created_present),
         nullifier_results: nullifier_contains_entries(nullifiers, membership.nullifier_present),
     }))
@@ -225,23 +225,23 @@ async fn post_grounding_witness(
     )
     .map_err(internal_error)?;
     let head = snapshot.head;
-    let state_root = head.current_state_root().ok_or_else(|| {
+    let state_header = head.current_state_header().ok_or_else(|| {
         (
             StatusCode::CONFLICT,
             "synchronizer has no canonical grounded state yet".to_string(),
         )
     })?;
-    let state_root_hash = head
+    let state_root = head
         .metadata
-        .current_gsr
-        .unwrap_or_else(|| state_root.hash());
+        .current_state_root
+        .unwrap_or_else(|| state_header.hash());
 
     Ok(Json(GroundingWitnessResponse {
-        state_root_hash,
-        block_number: state_root.block_number,
-        created_root: state_root.created_root,
-        nullifiers_root: state_root.nullifiers_root,
-        gsrs_root: state_root.gsrs_root,
+        state_root,
+        block_number: state_header.block_number,
+        created_root: state_header.created_root,
+        nullifiers_root: state_header.nullifiers_root,
+        state_history_root: state_header.state_history_root,
         created_proofs: witness
             .object_proofs
             .into_iter()
@@ -265,17 +265,17 @@ fn build_head_snapshot(snapshot: &CurrentSnapshot) -> HeadSnapshot {
     HeadSnapshot {
         last_processed_slot: snapshot.last_processed_slot,
         last_processed_block_number: snapshot.last_processed_block_number,
-        current_gsr: snapshot.head.metadata.current_gsr,
+        current_state_root: snapshot.head.metadata.current_state_root,
         current_block_number: snapshot.head.metadata.current_block_number.map(i64::from),
         created_count: snapshot.head.metadata.created_count as usize,
         nullifier_count: snapshot.head.metadata.nullifier_count as usize,
-        gsr_count: snapshot.head.metadata.gsr_count as usize,
+        state_root_count: snapshot.head.metadata.state_root_count as usize,
     }
 }
 
 fn membership_snapshot(
     app_db: &AppDb,
-    roots: &CanonicalRoots,
+    roots: &StateRoots,
     object_commitments: &[Hash],
     nullifiers: &[Hash],
     indices: &HashMap<Hash, i64>,
@@ -288,7 +288,7 @@ fn membership_snapshot(
 
 fn grounding_witness(
     app_db: &AppDb,
-    roots: &CanonicalRoots,
+    roots: &StateRoots,
     object_commitments: &[Hash],
     indices: &HashMap<Hash, i64>,
 ) -> anyhow::Result<GroundingWitnessSnapshot> {

--- a/synchronizer/src/api.rs
+++ b/synchronizer/src/api.rs
@@ -241,7 +241,7 @@ async fn post_grounding_witness(
         block_number: state_header.block_number,
         created_root: state_header.created_root,
         nullifiers_root: state_header.nullifiers_root,
-        state_history_root: state_header.state_history_root,
+        prior_state_history_root: state_header.prior_state_history_root,
         created_proofs: witness
             .object_proofs
             .into_iter()

--- a/synchronizer/src/app_db.rs
+++ b/synchronizer/src/app_db.rs
@@ -11,7 +11,7 @@ use pod2::{
 };
 use rocksdb::{Options, TransactionDB, TransactionDBOptions};
 
-use crate::head::CanonicalRoots;
+use crate::head::StateRoots;
 
 fn node_key(hash: Hash) -> Vec<u8> {
     let mut k = Vec::with_capacity(34);
@@ -67,7 +67,7 @@ impl AppDb {
         Ok(Set::from_db(root, self.db_box())?)
     }
 
-    pub fn open_gsr_history(&self, root: Hash) -> Result<Array> {
+    pub fn open_next_state_history(&self, root: Hash) -> Result<Array> {
         Ok(Array::from_db(root, self.db_box())?)
     }
 
@@ -78,7 +78,7 @@ impl AppDb {
     /// whole batch.
     pub fn prove_created_for(
         &self,
-        roots: &CanonicalRoots,
+        roots: &StateRoots,
         obj_commitments: &[Hash],
         indices: &HashMap<Hash, i64>,
     ) -> Result<Vec<Option<(i64, MerkleProof)>>> {
@@ -104,7 +104,7 @@ impl AppDb {
     /// index against the authoritative root.
     pub fn created_exists_for(
         &self,
-        roots: &CanonicalRoots,
+        roots: &StateRoots,
         obj_commitments: &[Hash],
         indices: &HashMap<Hash, i64>,
     ) -> Result<Vec<bool>> {
@@ -120,7 +120,7 @@ impl AppDb {
 
     pub fn nullifier_exists_batch(
         &self,
-        roots: &CanonicalRoots,
+        roots: &StateRoots,
         nullifiers: &[Hash],
     ) -> Result<Vec<bool>> {
         let nullifier_set = self.open_nullifiers(roots.nullifiers)?;
@@ -231,9 +231,9 @@ mod tests {
         let obj_commitment = test_hash(9);
         created.insert(0, Value::from(obj_commitment)).unwrap();
 
-        let roots = CanonicalRoots {
+        let roots = StateRoots {
             created: created.commitment(),
-            ..CanonicalRoots::empty()
+            ..StateRoots::empty()
         };
         let indices = HashMap::from([(obj_commitment, 0i64)]);
 
@@ -258,7 +258,7 @@ mod tests {
                 .unwrap(),
             vec![false]
         );
-        let empty_roots = CanonicalRoots::empty();
+        let empty_roots = StateRoots::empty();
         assert_eq!(
             app_db
                 .created_exists_for(&empty_roots, &[obj_commitment], &indices)

--- a/synchronizer/src/head.rs
+++ b/synchronizer/src/head.rs
@@ -9,7 +9,7 @@ pub struct StateRoots {
     /// Root of the persistent spent-nullifiers set.
     pub nullifiers: Hash,
     /// Root of the prior-state root array committed inside `txlib::StateHeader`.
-    pub state_history: Hash,
+    pub prior_state_history: Hash,
     /// Root of the full state root history array after appending the current state root.
     pub next_state_history: Hash,
 }
@@ -25,7 +25,7 @@ impl StateRoots {
         Self {
             created: EMPTY_HASH,
             nullifiers: EMPTY_HASH,
-            state_history: EMPTY_HASH,
+            prior_state_history: EMPTY_HASH,
             next_state_history: EMPTY_HASH,
         }
     }
@@ -97,7 +97,7 @@ impl StateHead {
                 block_number as i64,
                 self.roots.created,
                 self.roots.nullifiers,
-                self.roots.state_history,
+                self.roots.prior_state_history,
             )
         })
     }

--- a/synchronizer/src/head.rs
+++ b/synchronizer/src/head.rs
@@ -1,66 +1,66 @@
 use pod2::middleware::{Hash, EMPTY_HASH};
-use txlib::StateRoot;
+use txlib::StateHeader;
 
 /// The Merkle roots that reopen the canonical persistent containers.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct CanonicalRoots {
+pub struct StateRoots {
     /// Root of the persistent global created-object set (a pod2 `Array`).
     pub created: Hash,
     /// Root of the persistent spent-nullifiers set.
     pub nullifiers: Hash,
-    /// Root of the prior-GSR array committed inside `txlib::StateRoot`.
-    pub state_root_gsrs: Hash,
-    /// Root of the full GSR history array after appending the current GSR.
-    pub gsr_history: Hash,
+    /// Root of the prior-state root array committed inside `txlib::StateHeader`.
+    pub state_history: Hash,
+    /// Root of the full state root history array after appending the current state root.
+    pub next_state_history: Hash,
 }
 
-impl Default for CanonicalRoots {
+impl Default for StateRoots {
     fn default() -> Self {
         Self::empty()
     }
 }
 
-impl CanonicalRoots {
+impl StateRoots {
     pub fn empty() -> Self {
         Self {
             created: EMPTY_HASH,
             nullifiers: EMPTY_HASH,
-            state_root_gsrs: EMPTY_HASH,
-            gsr_history: EMPTY_HASH,
+            state_history: EMPTY_HASH,
+            next_state_history: EMPTY_HASH,
         }
     }
 }
 
 /// Non-root metadata tracked alongside the canonical roots.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct HeadMetadata {
-    /// Current canonical global state root for this head, if one exists.
-    pub current_gsr: Option<Hash>,
-    /// Execution block number associated with `current_gsr`.
+pub struct StateMetadata {
+    /// Current canonical state root for this head, if one exists.
+    pub current_state_root: Option<Hash>,
+    /// Execution block number associated with `current_state_root`.
     pub current_block_number: Option<u32>,
     /// Number of objects in the canonical global created set. The array is
     /// 0-indexed, so this doubles as the next array slot.
     pub created_count: u64,
     /// Number of spent nullifiers in the canonical state.
     pub nullifier_count: u64,
-    /// Number of GSR entries in the persistent history array.
-    pub gsr_count: u64,
+    /// Number of state root entries in the persistent history array.
+    pub state_root_count: u64,
 }
 
-impl Default for HeadMetadata {
+impl Default for StateMetadata {
     fn default() -> Self {
         Self::empty()
     }
 }
 
-impl HeadMetadata {
+impl StateMetadata {
     pub fn empty() -> Self {
         Self {
-            current_gsr: None,
+            current_state_root: None,
             current_block_number: None,
             created_count: 0,
             nullifier_count: 0,
-            gsr_count: 0,
+            state_root_count: 0,
         }
     }
 }
@@ -70,34 +70,34 @@ impl HeadMetadata {
 /// `roots` are what reopen the persistent Merkle containers in RocksDB.
 /// `metadata` is the auxiliary canonical state carried alongside those roots.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct CanonicalHead {
+pub struct StateHead {
     /// Merkle roots for the canonical persistent containers.
-    pub roots: CanonicalRoots,
+    pub roots: StateRoots,
     /// Non-root metadata associated with the same canonical head.
-    pub metadata: HeadMetadata,
+    pub metadata: StateMetadata,
 }
 
-impl Default for CanonicalHead {
+impl Default for StateHead {
     fn default() -> Self {
         Self::empty()
     }
 }
 
-impl CanonicalHead {
+impl StateHead {
     pub fn empty() -> Self {
         Self {
-            roots: CanonicalRoots::empty(),
-            metadata: HeadMetadata::empty(),
+            roots: StateRoots::empty(),
+            metadata: StateMetadata::empty(),
         }
     }
 
-    pub fn current_state_root(&self) -> Option<StateRoot> {
+    pub fn current_state_header(&self) -> Option<StateHeader> {
         self.metadata.current_block_number.map(|block_number| {
-            StateRoot::new(
+            StateHeader::new(
                 block_number as i64,
                 self.roots.created,
                 self.roots.nullifiers,
-                self.roots.state_root_gsrs,
+                self.roots.state_history,
             )
         })
     }

--- a/synchronizer/src/head.rs
+++ b/synchronizer/src/head.rs
@@ -1,7 +1,7 @@
 use pod2::middleware::{Hash, EMPTY_HASH};
 use txlib::StateHeader;
 
-/// The Merkle roots that reopen the canonical persistent containers.
+/// The Merkle roots that reopen the persistent containers.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct StateRoots {
     /// Root of the persistent global created-object set (a pod2 `Array`).
@@ -31,17 +31,17 @@ impl StateRoots {
     }
 }
 
-/// Non-root metadata tracked alongside the canonical roots.
+/// Non-root metadata tracked alongside the state roots.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct StateMetadata {
-    /// Current canonical state root for this head, if one exists.
+    /// Current state root for this head, if one exists.
     pub current_state_root: Option<Hash>,
     /// Execution block number associated with `current_state_root`.
     pub current_block_number: Option<u32>,
-    /// Number of objects in the canonical global created set. The array is
+    /// Number of objects in the global created set. The array is
     /// 0-indexed, so this doubles as the next array slot.
     pub created_count: u64,
-    /// Number of spent nullifiers in the canonical state.
+    /// Number of spent nullifiers in the committed state.
     pub nullifier_count: u64,
     /// Number of state root entries in the persistent history array.
     pub state_root_count: u64,
@@ -65,15 +65,15 @@ impl StateMetadata {
     }
 }
 
-/// Canonical head snapshot used across sync, query, and storage code.
+/// State head snapshot used across sync, query, and storage code.
 ///
 /// `roots` are what reopen the persistent Merkle containers in RocksDB.
-/// `metadata` is the auxiliary canonical state carried alongside those roots.
+/// `metadata` is the auxiliary state carried alongside those roots.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct StateHead {
-    /// Merkle roots for the canonical persistent containers.
+    /// Merkle roots for the persistent containers.
     pub roots: StateRoots,
-    /// Non-root metadata associated with the same canonical head.
+    /// Non-root metadata associated with the same state head.
     pub metadata: StateMetadata,
 }
 

--- a/synchronizer/src/node.rs
+++ b/synchronizer/src/node.rs
@@ -22,8 +22,8 @@ use pod2::middleware::Hash;
 use tracing::{debug, info, trace, warn};
 
 use crate::config::AppConfig;
-use crate::head::CanonicalHead;
-use crate::state_machine::{DerivedSlot, StateMachine, MAX_GSR_AGE_BLOCKS};
+use crate::head::StateHead;
+use crate::state_machine::{DerivedSlot, StateMachine, MAX_STATE_ROOT_AGE_BLOCKS};
 use crate::sync_db::{CommittedSlotRecord, SyncDb};
 
 /// Runtime integration layer that connects network inputs (beacon/execution),
@@ -52,12 +52,9 @@ pub enum ProcessedSlot {
     /// nothing to derive against, so the previous canonical head is carried
     /// forward unchanged, committed under the new slot number to keep canonical
     /// slot history contiguous.
-    Missing {
-        slot: u32,
-        carried_head: CanonicalHead,
-    },
+    Missing { slot: u32, carried_head: StateHead },
     /// Beacon produced a block and the state machine derived the slot against
-    /// it (deriving a fresh GSR even when the block carries no usable blobs).
+    /// it (deriving a fresh state root even when the block carries no usable blobs).
     Present {
         slot: u32,
         block_root: B256,
@@ -103,7 +100,7 @@ impl Node {
         self.sync_db.slot_root(slot).await
     }
 
-    pub async fn current_head(&self) -> Result<CanonicalHead> {
+    pub async fn current_head(&self) -> Result<StateHead> {
         self.sync_db.current_head().await
     }
 
@@ -255,7 +252,7 @@ impl Node {
             block_root: Some(header.root),
             parent_root: Some(block.parent_root),
             block_number: Some(execution_payload.block_number),
-            current_gsr: None,
+            current_state_root: None,
             is_empty: false,
         })
     }
@@ -324,13 +321,13 @@ impl Node {
     /// head.
     ///
     /// The prefetch is one batched query against the created index, mirroring how
-    /// `recent_gsrs` is prefetched, so the state machine never has to query the
+    /// `recent_state_roots` is prefetched, so the state machine never has to query the
     /// database itself. It returns indices (not just a membership set) so the
     /// state machine can cross-check each hit against the array at the base root.
     async fn derive_slot(
         &self,
-        base_head: CanonicalHead,
-        recent_gsrs: Vec<(Hash, i64)>,
+        base_head: StateHead,
+        recent_state_roots: Vec<(Hash, i64)>,
         slot: u32,
         block_number: u32,
         blob_payloads: &[(u32, Vec<u8>)],
@@ -345,7 +342,7 @@ impl Node {
         let prior_indices = self.sync_db.created_indices(&candidates).await?;
         self.state_machine.derive_slot_head(
             base_head,
-            recent_gsrs,
+            recent_state_roots,
             slot,
             block_number,
             &parsed,
@@ -376,13 +373,19 @@ impl Node {
         let min_block_number = base_head
             .metadata
             .current_block_number
-            .map(|n| n.saturating_sub(MAX_GSR_AGE_BLOCKS as u32));
-        let recent_gsrs = self.sync_db.recent_gsrs(min_block_number).await?;
+            .map(|n| n.saturating_sub(MAX_STATE_ROOT_AGE_BLOCKS as u32));
+        let recent_state_roots = self.sync_db.recent_state_roots(min_block_number).await?;
 
         if !slot_ctx.has_blob_commitments {
             debug!(slot = slot_ctx.slot, "Slot has no blob commitments");
             let derived = self
-                .derive_slot(base_head, recent_gsrs, slot_ctx.slot, block_number, &[])
+                .derive_slot(
+                    base_head,
+                    recent_state_roots,
+                    slot_ctx.slot,
+                    block_number,
+                    &[],
+                )
                 .await?;
             return Ok(ProcessedSlot::Present {
                 slot: slot_ctx.slot,
@@ -444,7 +447,13 @@ impl Node {
                 "No matching target blob transactions in execution block"
             );
             let derived = self
-                .derive_slot(base_head, recent_gsrs, slot_ctx.slot, block_number, &[])
+                .derive_slot(
+                    base_head,
+                    recent_state_roots,
+                    slot_ctx.slot,
+                    block_number,
+                    &[],
+                )
                 .await?;
             return Ok(ProcessedSlot::Present {
                 slot: slot_ctx.slot,
@@ -502,7 +511,7 @@ impl Node {
         let derived = self
             .derive_slot(
                 base_head,
-                recent_gsrs,
+                recent_state_roots,
                 slot_ctx.slot,
                 block_number,
                 &blob_payloads,
@@ -543,7 +552,7 @@ impl Node {
                     block_root: Some(*block_root),
                     parent_root: Some(*parent_root),
                     block_number: Some(*block_number),
-                    current_gsr: derived.head.metadata.current_gsr,
+                    current_state_root: derived.head.metadata.current_state_root,
                     is_empty: false,
                 };
                 self.sync_db

--- a/synchronizer/src/node.rs
+++ b/synchronizer/src/node.rs
@@ -49,8 +49,8 @@ struct SlotContext {
 /// Outcome of processing one beacon slot, ready to be committed.
 pub enum ProcessedSlot {
     /// Beacon produced no block for the slot. With no execution block there is
-    /// nothing to derive against, so the previous canonical head is carried
-    /// forward unchanged, committed under the new slot number to keep canonical
+    /// nothing to derive against, so the previous state head is carried
+    /// forward unchanged, committed under the new slot number to keep the
     /// slot history contiguous.
     Missing { slot: u32, carried_head: StateHead },
     /// Beacon produced a block and the state machine derived the slot against
@@ -104,7 +104,7 @@ impl Node {
         self.sync_db.current_head().await
     }
 
-    /// Rewind to `keep_slot` by deleting later canonical slot rows; the created
+    /// Rewind to `keep_slot` by deleting later slot rows; the created
     /// index rows those slots added are pruned in the same Postgres transaction.
     pub async fn rollback_to_slot(&self, keep_slot: u32) -> Result<()> {
         self.sync_db.rollback_to_slot(keep_slot).await
@@ -317,7 +317,7 @@ impl Node {
     }
 
     /// Parse the slot's blobs, prefetch the array positions of their created
-    /// commitments that already exist in canonical state, and derive the next
+    /// commitments that already exist in committed state, and derive the next
     /// head.
     ///
     /// The prefetch is one batched query against the created index, mirroring how
@@ -527,7 +527,7 @@ impl Node {
         })
     }
 
-    /// Commit one processed slot to Postgres as the new canonical head, writing
+    /// Commit one processed slot to Postgres as the new state head, writing
     /// its created-index rows in the same transaction.
     pub async fn commit_slot(&self, processed: &ProcessedSlot) -> Result<()> {
         match processed {

--- a/synchronizer/src/state_machine.rs
+++ b/synchronizer/src/state_machine.rs
@@ -10,30 +10,30 @@ use tracing::{info, warn};
 
 use crate::{
     app_db::{created_array_holds, AppDb},
-    head::{CanonicalHead, CanonicalRoots, HeadMetadata},
+    head::{StateHead, StateMetadata, StateRoots},
 };
-use txlib::StateRoot;
+use txlib::StateHeader;
 
-/// The maximum age of a GSR used as grounding for a transaction.
+/// The maximum age of a state root used as grounding for a transaction.
 /// At one block per 12 seconds, this is one hour.
-pub const MAX_GSR_AGE_BLOCKS: i64 = 300;
+pub const MAX_STATE_ROOT_AGE_BLOCKS: i64 = 300;
 
 /// Ephemeral mutable view used while deriving one slot.
 ///
 /// This view opens the persistent POD2 containers used during slot derivation so validation can
-/// query and mutate the created-object set, nullifiers, and GSR history for one slot.
+/// query and mutate the created-object set, nullifiers, and state root history for one slot.
 struct WorkingState {
     /// Mutable non-root metadata accumulated while deriving the slot.
-    metadata: HeadMetadata,
+    metadata: StateMetadata,
     /// Persistent global created-object set (a pod2 `Array`) opened from
     /// `head.roots.created`.
     created: Array,
     /// Persistent nullifiers set opened from `head.roots.nullifiers`.
     nullifiers: Set,
-    /// Persistent full GSR history array opened from `head.roots.gsr_history`.
-    gsr_history: Array,
-    /// Recent canonical GSRs keyed by hash for grounding validation.
-    recent_gsrs: HashMap<Hash, i64>,
+    /// Persistent full state root history array opened from `head.roots.next_state_history`.
+    next_state_history: Array,
+    /// Recent canonical state roots keyed by hash for grounding validation.
+    recent_state_roots: HashMap<Hash, i64>,
     /// Commitments this slot appended to `created`, keyed to their array
     /// indices. Doubles as the within-slot duplicate check: the persistent
     /// created index reflects only committed slots, so it cannot see objects
@@ -46,18 +46,18 @@ struct WorkingState {
 /// object commitments (with array indices) it appended to `created`. The caller
 /// persists the additions to the created index when committing the slot.
 pub struct DerivedSlot {
-    pub head: CanonicalHead,
+    pub head: StateHead,
     pub created_added: HashMap<Hash, i64>,
 }
 
 /// Domain logic for the synchronizer: proof verification, state validation, and Merkle storage.
 ///
 /// `StateMachine` is intentionally decoupled from networking and canonical-head ownership.
-/// Callers supply the `CanonicalHead` they want to operate against, and Postgres remains the sole
+/// Callers supply the `StateHead` they want to operate against, and Postgres remains the sole
 /// source of truth for which head is canonical.
 pub struct StateMachine {
     /// RocksDB-backed app-state store used to open the created, nullifier, and
-    /// GSR containers during derivation.
+    /// state root containers during derivation.
     app_db: AppDb,
     /// Blob parser/verifier used to decode TxFinalized payloads from blob bytes.
     proof_parser: Arc<dyn BlobParser>,
@@ -112,8 +112,8 @@ impl StateMachine {
     /// apply it, or skip it (fail-soft) on a grounding or duplicate violation.
     ///
     /// Validation order:
-    /// 1. `payload.state_root_hash` must exist in the recent canonical GSR window
-    /// 2. that grounding must be within `MAX_GSR_AGE_BLOCKS`
+    /// 1. `payload.state_root` must exist in the recent canonical state root window
+    /// 2. that grounding must be within `MAX_STATE_ROOT_AGE_BLOCKS`
     /// 3. created-object commitments must not collide -- within the payload, with
     ///    objects added earlier this slot, or with prior committed state
     ///    (`prior_indices`, prefetched from the created index and cross-checked
@@ -135,19 +135,19 @@ impl StateMachine {
         slot: u32,
         block_number: u32,
     ) -> Result<()> {
-        let Some(&gsr_block) = state.recent_gsrs.get(&payload.state_root_hash) else {
+        let Some(&state_root_block) = state.recent_state_roots.get(&payload.state_root) else {
             warn!(
                 slot,
                 block_number,
-                "Blob proof state_root_hash not found in recent GSR history; rejecting"
+                "Blob proof state_root not found in recent state root history; rejecting"
             );
             return Ok(());
         };
-        let age = i64::from(block_number) - gsr_block;
-        if age > MAX_GSR_AGE_BLOCKS {
+        let age = i64::from(block_number) - state_root_block;
+        if age > MAX_STATE_ROOT_AGE_BLOCKS {
             warn!(
                 slot,
-                block_number, gsr_block, age, "Blob proof state_root_hash is too old; rejecting"
+                block_number, state_root_block, age, "Blob proof state_root is too old; rejecting"
             );
             return Ok(());
         }
@@ -234,15 +234,15 @@ impl StateMachine {
     /// provided base head and the slot's already-parsed payloads.
     ///
     /// It:
-    /// - reopens the persistent created-object, nullifiers, and GSR-history containers from
+    /// - reopens the persistent created-object, nullifiers, and state root-history containers from
     ///   `base_head.roots`
-    /// - seeds the per-slot `WorkingState` with the caller-provided recent-GSR window
+    /// - seeds the per-slot `WorkingState` with the caller-provided recent-state root window
     /// - applies every payload via `apply_payload`, using `prior_indices` (the created-object
     ///   commitments already canonical as of the base head, with their array positions,
     ///   prefetched from the created index) for the creation-collision check
-    /// - computes the next GSR from the updated created/nullifiers roots and the prior
-    ///   GSR-history root committed into the resulting `StateRoot`
-    /// - appends that new GSR to the full history array and returns the resulting `CanonicalHead`
+    /// - computes the next state root from the updated created/nullifiers roots and the prior
+    ///   state root-history root committed into the resulting `StateHeader`
+    /// - appends that new state root to the full history array and returns the resulting `StateHead`
     ///   together with the object commitments this slot added, as a `DerivedSlot`
     ///
     /// The returned head is only a candidate next canonical state. By the time this method
@@ -251,12 +251,12 @@ impl StateMachine {
     /// index rows) in Postgres.
     ///
     /// Empty or fully rejected slots still produce a new head with the same created and
-    /// nullifiers roots as `base_head`, but with a newly derived `current_gsr` and an appended
-    /// GSR-history entry for the slot's execution block.
+    /// nullifiers roots as `base_head`, but with a newly derived `current_state_root` and an appended
+    /// state root-history entry for the slot's execution block.
     pub fn derive_slot_head(
         &self,
-        base_head: CanonicalHead,
-        recent_gsrs: impl IntoIterator<Item = (Hash, i64)>,
+        base_head: StateHead,
+        recent_state_roots: impl IntoIterator<Item = (Hash, i64)>,
         slot: u32,
         block_number: u32,
         payloads: &[(u32, Payload)],
@@ -266,8 +266,10 @@ impl StateMachine {
             metadata: base_head.metadata,
             created: self.app_db.open_created(base_head.roots.created)?,
             nullifiers: self.app_db.open_nullifiers(base_head.roots.nullifiers)?,
-            gsr_history: self.app_db.open_gsr_history(base_head.roots.gsr_history)?,
-            recent_gsrs: recent_gsrs.into_iter().collect(),
+            next_state_history: self
+                .app_db
+                .open_next_state_history(base_head.roots.next_state_history)?,
+            recent_state_roots: recent_state_roots.into_iter().collect(),
             created_added: HashMap::new(),
         };
 
@@ -278,39 +280,40 @@ impl StateMachine {
                 })?;
         }
 
-        let prior_gsrs_root = base_head.roots.gsr_history;
-        let new_gsr = StateRoot::new(
+        let prior_state_history_root = base_head.roots.next_state_history;
+        let new_state_root = StateHeader::new(
             i64::from(block_number),
             working.created.commitment(),
             working.nullifiers.commitment(),
-            prior_gsrs_root,
+            prior_state_history_root,
         )
         .hash();
 
-        working
-            .gsr_history
-            .insert(base_head.metadata.gsr_count as usize, Value::from(new_gsr))?;
+        working.next_state_history.insert(
+            base_head.metadata.state_root_count as usize,
+            Value::from(new_state_root),
+        )?;
 
-        let new_head = CanonicalHead {
-            roots: CanonicalRoots {
+        let new_head = StateHead {
+            roots: StateRoots {
                 created: working.created.commitment(),
                 nullifiers: working.nullifiers.commitment(),
-                state_root_gsrs: prior_gsrs_root,
-                gsr_history: working.gsr_history.commitment(),
+                state_history: prior_state_history_root,
+                next_state_history: working.next_state_history.commitment(),
             },
-            metadata: HeadMetadata {
-                current_gsr: Some(new_gsr),
+            metadata: StateMetadata {
+                current_state_root: Some(new_state_root),
                 current_block_number: Some(block_number),
                 created_count: working.metadata.created_count,
                 nullifier_count: working.metadata.nullifier_count,
-                gsr_count: base_head.metadata.gsr_count + 1,
+                state_root_count: base_head.metadata.state_root_count + 1,
             },
         };
 
         info!(
             slot,
             block_number,
-            gsr_count = new_head.metadata.gsr_count,
+            state_root_count = new_head.metadata.state_root_count,
             "Slot data"
         );
 
@@ -320,17 +323,17 @@ impl StateMachine {
         })
     }
 
-    pub fn log_current_state(&self, head: CanonicalHead) {
-        let current_gsr = head
+    pub fn log_current_state(&self, head: StateHead) {
+        let current_state_root = head
             .metadata
-            .current_gsr
-            .map(|gsr| format!("{gsr:#}"))
+            .current_state_root
+            .map(|state_root| format!("{state_root:#}"))
             .unwrap_or_else(|| "none".to_string());
         info!(
             created_count = head.metadata.created_count,
             nullifier_count = head.metadata.nullifier_count,
-            gsr_count = head.metadata.gsr_count,
-            current_gsr = %current_gsr,
+            state_root_count = head.metadata.state_root_count,
+            current_state_root = %current_state_root,
             "Current state"
         );
     }
@@ -359,7 +362,7 @@ mod tests {
         tx_final: Hash,
         nullifiers: &[Hash],
         live: &[Hash],
-        state_root: Hash,
+        state_header: Hash,
     ) -> Vec<u8> {
         let hashes_json = |hashes: &[Hash]| {
             hashes
@@ -369,17 +372,17 @@ mod tests {
                 .join(",")
         };
         format!(
-            r#"{{"tx_final":"{:#}","nullifiers":[{}],"live":[{}],"state_root_hash":"{:#}"}}"#,
+            r#"{{"tx_final":"{:#}","nullifiers":[{}],"live":[{}],"state_root":"{:#}"}}"#,
             tx_final,
             hashes_json(nullifiers),
             hashes_json(live),
-            state_root
+            state_header
         )
         .into_bytes()
     }
 
-    fn seed_gsr0(sm: &StateMachine) -> CanonicalHead {
-        sm.derive_slot_head(CanonicalHead::empty(), [], 0, 0, &[], &HashMap::new())
+    fn seed_state_root0(sm: &StateMachine) -> StateHead {
+        sm.derive_slot_head(StateHead::empty(), [], 0, 0, &[], &HashMap::new())
             .unwrap()
             .head
     }
@@ -388,8 +391,8 @@ mod tests {
     /// minus the Postgres existence prefetch, which tests supply directly).
     fn derive(
         sm: &StateMachine,
-        base_head: CanonicalHead,
-        recent_gsrs: impl IntoIterator<Item = (Hash, i64)>,
+        base_head: StateHead,
+        recent_state_roots: impl IntoIterator<Item = (Hash, i64)>,
         slot: u32,
         block_number: u32,
         blobs: &[(u32, Vec<u8>)],
@@ -398,7 +401,7 @@ mod tests {
         let parsed = sm.parse_blobs(blobs, slot, block_number);
         sm.derive_slot_head(
             base_head,
-            recent_gsrs,
+            recent_state_roots,
             slot,
             block_number,
             &parsed,
@@ -410,22 +413,30 @@ mod tests {
     #[test]
     fn test_empty_slot_produces_new_head() {
         let (sm, _app_db, _dir) = make_sm();
-        let head = derive(&sm, CanonicalHead::empty(), [], 1, 7, &[], &HashMap::new()).head;
+        let head = derive(&sm, StateHead::empty(), [], 1, 7, &[], &HashMap::new()).head;
         assert_eq!(head.metadata.current_block_number, Some(7));
-        assert_eq!(head.metadata.gsr_count, 1);
+        assert_eq!(head.metadata.state_root_count, 1);
     }
 
     #[test]
     fn test_accepts_valid_blob_and_updates_counts() {
         let (sm, app_db, _dir) = make_sm();
-        let head0 = seed_gsr0(&sm);
-        let gsr0 = head0.metadata.current_gsr.unwrap();
+        let head0 = seed_state_root0(&sm);
+        let state_root0 = head0.metadata.current_state_root.unwrap();
 
         let tx_final = unique_hash(10);
         let nullifier = unique_hash(11);
         let live_obj = unique_hash(12);
-        let blob = mock_txn_bytes(tx_final, &[nullifier], &[live_obj], gsr0);
-        let derived = derive(&sm, head0, [(gsr0, 0)], 1, 1, &[(0, blob)], &HashMap::new());
+        let blob = mock_txn_bytes(tx_final, &[nullifier], &[live_obj], state_root0);
+        let derived = derive(
+            &sm,
+            head0,
+            [(state_root0, 0)],
+            1,
+            1,
+            &[(0, blob)],
+            &HashMap::new(),
+        );
         let head1 = derived.head;
         let created_present = app_db
             .created_exists_for(&head1.roots, &[live_obj], &derived.created_added)
@@ -436,15 +447,15 @@ mod tests {
 
         assert_eq!(head1.metadata.created_count, 1);
         assert_eq!(head1.metadata.nullifier_count, 1);
-        assert_eq!(head1.metadata.gsr_count, 2);
+        assert_eq!(head1.metadata.state_root_count, 2);
         assert_eq!(created_present, vec![true]);
         assert_eq!(nullifier_present, vec![true]);
     }
 
     #[test]
-    fn test_rejects_unknown_grounding_gsr() {
+    fn test_rejects_unknown_grounding_state_root() {
         let (sm, _app_db, _dir) = make_sm();
-        let head0 = seed_gsr0(&sm);
+        let head0 = seed_state_root0(&sm);
 
         let tx_final = unique_hash(21);
         let blob = mock_txn_bytes(tx_final, &[], &[unique_hash(22)], unique_hash(99));
@@ -455,12 +466,20 @@ mod tests {
     #[test]
     fn test_membership_is_scoped_to_head_root() {
         let (sm, app_db, _dir) = make_sm();
-        let head0 = seed_gsr0(&sm);
-        let gsr0 = head0.metadata.current_gsr.unwrap();
+        let head0 = seed_state_root0(&sm);
+        let state_root0 = head0.metadata.current_state_root.unwrap();
 
         let live_obj = unique_hash(32);
-        let blob = mock_txn_bytes(unique_hash(31), &[], &[live_obj], gsr0);
-        let derived = derive(&sm, head0, [(gsr0, 0)], 1, 1, &[(0, blob)], &HashMap::new());
+        let blob = mock_txn_bytes(unique_hash(31), &[], &[live_obj], state_root0);
+        let derived = derive(
+            &sm,
+            head0,
+            [(state_root0, 0)],
+            1,
+            1,
+            &[(0, blob)],
+            &HashMap::new(),
+        );
         let head1 = derived.head;
         let indices = derived.created_added;
 
@@ -480,15 +499,15 @@ mod tests {
     #[test]
     fn test_rejects_duplicate_created_object() {
         let (sm, _app_db, _dir) = make_sm();
-        let head0 = seed_gsr0(&sm);
-        let gsr0 = head0.metadata.current_gsr.unwrap();
+        let head0 = seed_state_root0(&sm);
+        let state_root0 = head0.metadata.current_state_root.unwrap();
 
         let live_obj = unique_hash(40);
-        let blob1 = mock_txn_bytes(unique_hash(41), &[], &[live_obj], gsr0);
+        let blob1 = mock_txn_bytes(unique_hash(41), &[], &[live_obj], state_root0);
         let derived1 = derive(
             &sm,
             head0,
-            [(gsr0, 0)],
+            [(state_root0, 0)],
             1,
             1,
             &[(0, blob1)],
@@ -499,12 +518,12 @@ mod tests {
 
         // A second tx in a later slot re-creates the same object. In production
         // slot 1's index row is committed; here it is passed as prior-existing.
-        let gsr1 = head1.metadata.current_gsr.unwrap();
-        let blob2 = mock_txn_bytes(unique_hash(42), &[], &[live_obj], gsr1);
+        let state_root1 = head1.metadata.current_state_root.unwrap();
+        let blob2 = mock_txn_bytes(unique_hash(42), &[], &[live_obj], state_root1);
         let head2 = derive(
             &sm,
             head1,
-            [(gsr1, 1)],
+            [(state_root1, 1)],
             2,
             2,
             &[(0, blob2)],
@@ -517,18 +536,18 @@ mod tests {
     #[test]
     fn test_rejects_duplicate_created_object_within_slot() {
         let (sm, _app_db, _dir) = make_sm();
-        let head0 = seed_gsr0(&sm);
-        let gsr0 = head0.metadata.current_gsr.unwrap();
+        let head0 = seed_state_root0(&sm);
+        let state_root0 = head0.metadata.current_state_root.unwrap();
 
         // Two blobs in one slot create the same object; the second is rejected
         // via the in-slot view, with no prior committed state.
         let dup = unique_hash(50);
-        let blob_a = mock_txn_bytes(unique_hash(51), &[], &[dup], gsr0);
-        let blob_b = mock_txn_bytes(unique_hash(52), &[], &[dup], gsr0);
+        let blob_a = mock_txn_bytes(unique_hash(51), &[], &[dup], state_root0);
+        let blob_b = mock_txn_bytes(unique_hash(52), &[], &[dup], state_root0);
         let derived = derive(
             &sm,
             head0,
-            [(gsr0, 0)],
+            [(state_root0, 0)],
             1,
             1,
             &[(0, blob_a), (1, blob_b)],
@@ -541,8 +560,8 @@ mod tests {
     #[test]
     fn test_phantom_prior_index_does_not_reject_creation() {
         let (sm, _app_db, _dir) = make_sm();
-        let head0 = seed_gsr0(&sm);
-        let gsr0 = head0.metadata.current_gsr.unwrap();
+        let head0 = seed_state_root0(&sm);
+        let state_root0 = head0.metadata.current_state_root.unwrap();
 
         // The prefetched index claims this object exists at index 1, but the
         // array at the base root does not actually hold it (a phantom/stale
@@ -550,8 +569,8 @@ mod tests {
         // creation rather than rejecting a legitimate object.
         let obj = unique_hash(60);
         let phantom = HashMap::from([(obj, 1i64)]);
-        let blob = mock_txn_bytes(unique_hash(61), &[], &[obj], gsr0);
-        let derived = derive(&sm, head0, [(gsr0, 0)], 1, 1, &[(0, blob)], &phantom);
+        let blob = mock_txn_bytes(unique_hash(61), &[], &[obj], state_root0);
+        let derived = derive(&sm, head0, [(state_root0, 0)], 1, 1, &[(0, blob)], &phantom);
         assert_eq!(derived.head.metadata.created_count, 1);
         assert_eq!(derived.created_added.get(&obj), Some(&0));
     }

--- a/synchronizer/src/state_machine.rs
+++ b/synchronizer/src/state_machine.rs
@@ -32,7 +32,7 @@ struct WorkingState {
     nullifiers: Set,
     /// Persistent full state root history array opened from `head.roots.next_state_history`.
     next_state_history: Array,
-    /// Recent canonical state roots keyed by hash for grounding validation.
+    /// Recent state roots keyed by hash for grounding validation.
     recent_state_roots: HashMap<Hash, i64>,
     /// Commitments this slot appended to `created`, keyed to their array
     /// indices. Doubles as the within-slot duplicate check: the persistent
@@ -42,7 +42,7 @@ struct WorkingState {
     created_added: HashMap<Hash, i64>,
 }
 
-/// One slot's derivation result: the candidate next canonical head plus the
+/// One slot's derivation result: the candidate next state head plus the
 /// object commitments (with array indices) it appended to `created`. The caller
 /// persists the additions to the created index when committing the slot.
 pub struct DerivedSlot {
@@ -52,9 +52,9 @@ pub struct DerivedSlot {
 
 /// Domain logic for the synchronizer: proof verification, state validation, and Merkle storage.
 ///
-/// `StateMachine` is intentionally decoupled from networking and canonical-head ownership.
+/// `StateMachine` is intentionally decoupled from networking and state-head ownership.
 /// Callers supply the `StateHead` they want to operate against, and Postgres remains the sole
-/// source of truth for which head is canonical.
+/// source of truth for which head is current.
 pub struct StateMachine {
     /// RocksDB-backed app-state store used to open the created, nullifier, and
     /// state root containers during derivation.
@@ -112,7 +112,7 @@ impl StateMachine {
     /// apply it, or skip it (fail-soft) on a grounding or duplicate violation.
     ///
     /// Validation order:
-    /// 1. `payload.state_root` must exist in the recent canonical state root window
+    /// 1. `payload.state_root` must exist in the recent state root window
     /// 2. that grounding must be within `MAX_STATE_ROOT_AGE_BLOCKS`
     /// 3. created-object commitments must not collide -- within the payload, with
     ///    objects added earlier this slot, or with prior committed state
@@ -125,7 +125,7 @@ impl StateMachine {
     /// On success it appends each created commitment to the in-progress array
     /// (recording the addition in `created_added`), inserts each nullifier, and
     /// bumps the counts. Mutating the container handles may materialize Merkle
-    /// nodes in RocksDB, but nothing becomes canonical until the caller commits
+    /// nodes in RocksDB, but nothing is committed until the caller commits
     /// the resulting head.
     fn apply_payload(
         &self,
@@ -230,7 +230,7 @@ impl StateMachine {
         }
     }
 
-    /// Derive the next canonical head for one execution slot from a caller
+    /// Derive the next state head for one execution slot from a caller
     /// provided base head and the slot's already-parsed payloads.
     ///
     /// It:
@@ -238,16 +238,16 @@ impl StateMachine {
     ///   `base_head.roots`
     /// - seeds the per-slot `WorkingState` with the caller-provided recent-state root window
     /// - applies every payload via `apply_payload`, using `prior_indices` (the created-object
-    ///   commitments already canonical as of the base head, with their array positions,
+    ///   commitments already committed as of the base head, with their array positions,
     ///   prefetched from the created index) for the creation-collision check
     /// - computes the next state root from the updated created/nullifiers roots and the prior
     ///   state root-history root committed into the resulting `StateHeader`
     /// - appends that new state root to the full history array and returns the resulting `StateHead`
     ///   together with the object commitments this slot added, as a `DerivedSlot`
     ///
-    /// The returned head is only a candidate next canonical state. By the time this method
+    /// The returned head is only a candidate next state. By the time this method
     /// returns, RocksDB may already contain Merkle nodes for the derived containers, but the
-    /// head does not become canonical until the caller persists it (and the `created_added`
+    /// head is not committed until the caller persists it (and the `created_added`
     /// index rows) in Postgres.
     ///
     /// Empty or fully rejected slots still produce a new head with the same created and

--- a/synchronizer/src/state_machine.rs
+++ b/synchronizer/src/state_machine.rs
@@ -298,7 +298,7 @@ impl StateMachine {
             roots: StateRoots {
                 created: working.created.commitment(),
                 nullifiers: working.nullifiers.commitment(),
-                state_history: prior_state_history_root,
+                prior_state_history: prior_state_history_root,
                 next_state_history: working.next_state_history.commitment(),
             },
             metadata: StateMetadata {

--- a/synchronizer/src/sync_db.rs
+++ b/synchronizer/src/sync_db.rs
@@ -13,7 +13,7 @@ use crate::{
     head::{StateHead, StateMetadata, StateRoots},
 };
 
-/// Current canonical head plus progress metadata loaded from Postgres.
+/// Current state head plus progress metadata loaded from Postgres.
 #[derive(Debug, Clone, Copy)]
 pub struct CurrentSnapshot {
     pub head: StateHead,
@@ -21,7 +21,7 @@ pub struct CurrentSnapshot {
     pub last_processed_block_number: Option<u32>,
 }
 
-/// Canonical slot metadata written when a slot is committed.
+/// Slot metadata written when a slot is committed.
 #[derive(Debug, Clone, Copy)]
 pub struct CommittedSlotRecord {
     pub slot: u32,
@@ -33,7 +33,7 @@ pub struct CommittedSlotRecord {
 }
 
 impl CommittedSlotRecord {
-    /// Record for a slot with no canonical block content: every block field
+    /// Record for a slot with no block content: every block field
     /// absent, marked empty.
     pub fn empty(slot: u32) -> Self {
         Self {
@@ -58,7 +58,7 @@ impl SyncDb {
     /// The database must already exist — provisioning is an explicit operator
     /// step so the app role does not need the `CREATEDB` privilege.
     ///
-    /// Postgres is the sole source of canonical heads. Each committed slot stores its
+    /// Postgres is the sole source of state heads. Each committed slot stores its
     /// `StateHead`,
     /// while RocksDB only stores the content-addressed Merkle node/value backing store.
     pub async fn connect(database_url: &str) -> Result<Self> {
@@ -74,8 +74,8 @@ impl SyncDb {
 
     /// Create the Postgres schema used by the synchronizer control plane.
     ///
-    /// `canonical_slots` stores per-slot metadata plus the committed canonical roots and metadata
-    /// as regular SQL columns. The highest committed slot is the current canonical head.
+    /// `canonical_slots` stores per-slot metadata plus the committed state roots and metadata
+    /// as regular SQL columns. The highest committed slot is the current state head.
     async fn bootstrap(&self) -> Result<()> {
         let statements = [
             r#"
@@ -112,7 +112,7 @@ impl SyncDb {
             // `Array`. A materialized view of committed state: rows are inserted in
             // the same transaction that commits their slot and deleted in the same
             // transaction that rolls the slot back, so the index never diverges
-            // from the canonical head. `slot` carries the rollback axis.
+            // from the state head. `slot` carries the rollback axis.
             r#"
             CREATE TABLE IF NOT EXISTS created_index (
                 commitment BYTEA PRIMARY KEY,
@@ -148,8 +148,8 @@ impl SyncDb {
         Ok(row.map(|row| row.get::<i32, _>("slot") as u32))
     }
 
-    /// Insert the bootstrap canonical row when the database is still empty, and return the
-    /// highest committed canonical slot afterward.
+    /// Insert the bootstrap row when the database is still empty, and return the
+    /// highest committed slot afterward.
     pub async fn ensure_bootstrap_row(&self, bootstrap_slot: CommittedSlotRecord) -> Result<u32> {
         if let Some(stored_last) = self.latest_committed_slot().await? {
             return Ok(stored_last);
@@ -160,24 +160,24 @@ impl SyncDb {
         Ok(bootstrap_slot.slot)
     }
 
-    /// Return the last canonical slot fully committed by the synchronizer.
+    /// Return the last committed slot fully committed by the synchronizer.
     pub async fn last_processed_slot(&self) -> Result<u32> {
         self.latest_committed_slot()
             .await?
             .ok_or_else(|| anyhow!("sync metadata not initialized"))
     }
 
-    /// Return the current canonical head without sync-progress metadata.
+    /// Return the current state head without sync-progress metadata.
     pub async fn current_head(&self) -> Result<StateHead> {
         Ok(self.current_snapshot().await?.head)
     }
 
-    /// Return the current canonical head plus sync progress from one Postgres snapshot.
+    /// Return the current state head plus sync progress from one Postgres snapshot.
     pub async fn current_snapshot(&self) -> Result<CurrentSnapshot> {
         Self::read_snapshot(&self.pool).await
     }
 
-    /// Read the current canonical head plus progress over any executor (pool or
+    /// Read the current state head plus progress over any executor (pool or
     /// transaction), so a caller can pin it to the same snapshot as other reads.
     async fn read_snapshot<'e, E: PgExecutor<'e>>(executor: E) -> Result<CurrentSnapshot> {
         let row = sqlx::query(
@@ -219,7 +219,7 @@ impl SyncDb {
         })
     }
 
-    /// Return the canonical beacon block root for a committed slot.
+    /// Return the beacon block root for a committed slot.
     pub async fn slot_root(&self, slot: u32) -> Result<Option<B256>> {
         let row = sqlx::query("SELECT block_root FROM canonical_slots WHERE slot = $1")
             .bind(slot as i32)
@@ -242,7 +242,7 @@ impl SyncDb {
         }
     }
 
-    /// Commit one new canonical slot as the new highest canonical slot, writing
+    /// Commit one new slot as the new highest slot, writing
     /// its created-index rows in the same transaction so the index is always
     /// consistent with the committed head.
     ///
@@ -317,7 +317,7 @@ impl SyncDb {
         Ok(())
     }
 
-    /// Delete canonical slots after `keep_slot`, leaving the highest remaining
+    /// Delete slots after `keep_slot`, leaving the highest remaining
     /// row as current, and prune the created-index rows those slots added in the
     /// same transaction.
     pub async fn rollback_to_slot(&self, keep_slot: u32) -> Result<()> {
@@ -393,7 +393,7 @@ impl SyncDb {
         Ok((snapshot, indices))
     }
 
-    /// Return the recent canonical state roots at or above the given execution block number.
+    /// Return the recent state roots at or above the given execution block number.
     pub async fn recent_state_roots(
         &self,
         min_block_number: Option<u32>,
@@ -749,7 +749,7 @@ mod tests {
         assert_eq!(indices.get(&b), Some(&2));
 
         // Rolling back to slot 1 prunes slot 2's index row in the same
-        // transaction as the canonical-slot delete.
+        // transaction as the slot delete.
         sync_db.rollback_to_slot(1).await?;
         let indices = sync_db.created_indices(&[a, b]).await?;
         assert_eq!(indices.get(&a), Some(&1));

--- a/synchronizer/src/sync_db.rs
+++ b/synchronizer/src/sync_db.rs
@@ -10,13 +10,13 @@ use sqlx::{
 
 use crate::{
     app_db::{db_bytes_to_hash, hash_to_db_bytes},
-    head::{CanonicalHead, CanonicalRoots, HeadMetadata},
+    head::{StateHead, StateMetadata, StateRoots},
 };
 
 /// Current canonical head plus progress metadata loaded from Postgres.
 #[derive(Debug, Clone, Copy)]
 pub struct CurrentSnapshot {
-    pub head: CanonicalHead,
+    pub head: StateHead,
     pub last_processed_slot: u32,
     pub last_processed_block_number: Option<u32>,
 }
@@ -28,7 +28,7 @@ pub struct CommittedSlotRecord {
     pub block_root: Option<B256>,
     pub parent_root: Option<B256>,
     pub block_number: Option<u32>,
-    pub current_gsr: Option<Hash>,
+    pub current_state_root: Option<Hash>,
     pub is_empty: bool,
 }
 
@@ -41,7 +41,7 @@ impl CommittedSlotRecord {
             block_root: None,
             parent_root: None,
             block_number: None,
-            current_gsr: None,
+            current_state_root: None,
             is_empty: true,
         }
     }
@@ -59,7 +59,7 @@ impl SyncDb {
     /// step so the app role does not need the `CREATEDB` privilege.
     ///
     /// Postgres is the sole source of canonical heads. Each committed slot stores its
-    /// `CanonicalHead`,
+    /// `StateHead`,
     /// while RocksDB only stores the content-addressed Merkle node/value backing store.
     pub async fn connect(database_url: &str) -> Result<Self> {
         let pool = PgPoolOptions::new()
@@ -84,17 +84,17 @@ impl SyncDb {
                 block_root BYTEA NULL,
                 parent_root BYTEA NULL,
                 execution_block_number INTEGER NULL,
-                current_gsr BYTEA NULL,
+                current_state_root BYTEA NULL,
                 is_empty BOOLEAN NOT NULL,
                 head_created_root BYTEA NOT NULL,
                 head_nullifiers_root BYTEA NOT NULL,
-                head_state_root_gsrs_root BYTEA NOT NULL,
-                head_gsr_history_root BYTEA NOT NULL,
-                head_current_gsr BYTEA NULL,
+                head_state_history_root BYTEA NOT NULL,
+                head_next_state_history_root BYTEA NOT NULL,
+                head_current_state_root BYTEA NULL,
                 head_current_block_number INTEGER NULL,
                 head_created_count BIGINT NOT NULL,
                 head_nullifier_count BIGINT NOT NULL,
-                head_gsr_count BIGINT NOT NULL,
+                head_state_root_count BIGINT NOT NULL,
                 updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
             )
             "#,
@@ -104,9 +104,9 @@ impl SyncDb {
                 WHERE block_root IS NOT NULL
             "#,
             r#"
-            CREATE INDEX IF NOT EXISTS canonical_slots_gsr_block_idx
+            CREATE INDEX IF NOT EXISTS canonical_slots_state_root_block_idx
                 ON canonical_slots(execution_block_number)
-                WHERE current_gsr IS NOT NULL AND execution_block_number IS NOT NULL
+                WHERE current_state_root IS NOT NULL AND execution_block_number IS NOT NULL
             "#,
             // Reverse index from object commitment to its position in the created
             // `Array`. A materialized view of committed state: rows are inserted in
@@ -155,7 +155,7 @@ impl SyncDb {
             return Ok(stored_last);
         }
 
-        self.commit_slot(&bootstrap_slot, &CanonicalHead::empty(), &HashMap::new())
+        self.commit_slot(&bootstrap_slot, &StateHead::empty(), &HashMap::new())
             .await?;
         Ok(bootstrap_slot.slot)
     }
@@ -168,7 +168,7 @@ impl SyncDb {
     }
 
     /// Return the current canonical head without sync-progress metadata.
-    pub async fn current_head(&self) -> Result<CanonicalHead> {
+    pub async fn current_head(&self) -> Result<StateHead> {
         Ok(self.current_snapshot().await?.head)
     }
 
@@ -186,13 +186,13 @@ impl SyncDb {
                    execution_block_number,
                    head_created_root,
                    head_nullifiers_root,
-                   head_state_root_gsrs_root,
-                   head_gsr_history_root,
-                   head_current_gsr,
+                   head_state_history_root,
+                   head_next_state_history_root,
+                   head_current_state_root,
                    head_current_block_number,
                    head_created_count,
                    head_nullifier_count,
-                   head_gsr_count
+                   head_state_root_count
             FROM canonical_slots
             ORDER BY slot DESC
             LIMIT 1
@@ -250,7 +250,7 @@ impl SyncDb {
     pub async fn commit_slot(
         &self,
         slot: &CommittedSlotRecord,
-        head: &CanonicalHead,
+        head: &StateHead,
         created_added: &HashMap<Hash, i64>,
     ) -> Result<()> {
         let mut tx = self.pool.begin().await?;
@@ -262,17 +262,17 @@ impl SyncDb {
                 block_root,
                 parent_root,
                 execution_block_number,
-                current_gsr,
+                current_state_root,
                 is_empty,
                 head_created_root,
                 head_nullifiers_root,
-                head_state_root_gsrs_root,
-                head_gsr_history_root,
-                head_current_gsr,
+                head_state_history_root,
+                head_next_state_history_root,
+                head_current_state_root,
                 head_current_block_number,
                 head_created_count,
                 head_nullifier_count,
-                head_gsr_count
+                head_state_root_count
             )
             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
             "#,
@@ -281,17 +281,17 @@ impl SyncDb {
         .bind(slot.block_root.map(|v| v.as_slice().to_vec()))
         .bind(slot.parent_root.map(|v| v.as_slice().to_vec()))
         .bind(slot.block_number.map(|v| v as i32))
-        .bind(slot.current_gsr.map(hash_to_db_bytes))
+        .bind(slot.current_state_root.map(hash_to_db_bytes))
         .bind(slot.is_empty)
         .bind(hash_to_db_bytes(head.roots.created))
         .bind(hash_to_db_bytes(head.roots.nullifiers))
-        .bind(hash_to_db_bytes(head.roots.state_root_gsrs))
-        .bind(hash_to_db_bytes(head.roots.gsr_history))
-        .bind(head.metadata.current_gsr.map(hash_to_db_bytes))
+        .bind(hash_to_db_bytes(head.roots.state_history))
+        .bind(hash_to_db_bytes(head.roots.next_state_history))
+        .bind(head.metadata.current_state_root.map(hash_to_db_bytes))
         .bind(head.metadata.current_block_number.map(|v| v as i32))
         .bind(head.metadata.created_count as i64)
         .bind(head.metadata.nullifier_count as i64)
-        .bind(head.metadata.gsr_count as i64)
+        .bind(head.metadata.state_root_count as i64)
         .execute(&mut *tx)
         .await?;
 
@@ -393,17 +393,20 @@ impl SyncDb {
         Ok((snapshot, indices))
     }
 
-    /// Return the recent canonical GSRs at or above the given execution block number.
-    pub async fn recent_gsrs(&self, min_block_number: Option<u32>) -> Result<Vec<(Hash, i64)>> {
+    /// Return the recent canonical state roots at or above the given execution block number.
+    pub async fn recent_state_roots(
+        &self,
+        min_block_number: Option<u32>,
+    ) -> Result<Vec<(Hash, i64)>> {
         let Some(min_block_number) = min_block_number else {
             return Ok(Vec::new());
         };
 
         let rows = sqlx::query(
             r#"
-            SELECT current_gsr, execution_block_number
+            SELECT current_state_root, execution_block_number
             FROM canonical_slots
-            WHERE current_gsr IS NOT NULL
+            WHERE current_state_root IS NOT NULL
               AND execution_block_number IS NOT NULL
               AND execution_block_number >= $1
             ORDER BY execution_block_number ASC, slot ASC
@@ -415,25 +418,30 @@ impl SyncDb {
 
         rows.into_iter()
             .map(|row| {
-                let current_gsr: Vec<u8> = row.get("current_gsr");
+                let current_state_root: Vec<u8> = row.get("current_state_root");
                 let block_number = row.get::<i32, _>("execution_block_number");
-                Ok((db_bytes_to_hash(&current_gsr)?, i64::from(block_number)))
+                Ok((
+                    db_bytes_to_hash(&current_state_root)?,
+                    i64::from(block_number),
+                ))
             })
             .collect()
     }
 }
 
-fn decode_head_row(row: &PgRow) -> Result<CanonicalHead> {
-    Ok(CanonicalHead {
-        roots: CanonicalRoots {
+fn decode_head_row(row: &PgRow) -> Result<StateHead> {
+    Ok(StateHead {
+        roots: StateRoots {
             created: db_bytes_to_hash(&row.get::<Vec<u8>, _>("head_created_root"))?,
             nullifiers: db_bytes_to_hash(&row.get::<Vec<u8>, _>("head_nullifiers_root"))?,
-            state_root_gsrs: db_bytes_to_hash(&row.get::<Vec<u8>, _>("head_state_root_gsrs_root"))?,
-            gsr_history: db_bytes_to_hash(&row.get::<Vec<u8>, _>("head_gsr_history_root"))?,
+            state_history: db_bytes_to_hash(&row.get::<Vec<u8>, _>("head_state_history_root"))?,
+            next_state_history: db_bytes_to_hash(
+                &row.get::<Vec<u8>, _>("head_next_state_history_root"),
+            )?,
         },
-        metadata: HeadMetadata {
-            current_gsr: row
-                .get::<Option<Vec<u8>>, _>("head_current_gsr")
+        metadata: StateMetadata {
+            current_state_root: row
+                .get::<Option<Vec<u8>>, _>("head_current_state_root")
                 .as_deref()
                 .map(db_bytes_to_hash)
                 .transpose()?,
@@ -442,7 +450,7 @@ fn decode_head_row(row: &PgRow) -> Result<CanonicalHead> {
                 .map(|value| value as u32),
             created_count: row.get::<i64, _>("head_created_count") as u64,
             nullifier_count: row.get::<i64, _>("head_nullifier_count") as u64,
-            gsr_count: row.get::<i64, _>("head_gsr_count") as u64,
+            state_root_count: row.get::<i64, _>("head_state_root_count") as u64,
         },
     })
 }
@@ -458,20 +466,20 @@ mod tests {
         hash_values(&[Value::from(n)])
     }
 
-    fn unique_head(block_number: u32, marker: i64) -> CanonicalHead {
-        CanonicalHead {
-            roots: CanonicalRoots {
+    fn unique_head(block_number: u32, marker: i64) -> StateHead {
+        StateHead {
+            roots: StateRoots {
                 created: unique_hash(marker),
                 nullifiers: unique_hash(marker + 1),
-                state_root_gsrs: unique_hash(marker + 2),
-                gsr_history: unique_hash(marker + 3),
+                state_history: unique_hash(marker + 2),
+                next_state_history: unique_hash(marker + 3),
             },
-            metadata: HeadMetadata {
-                current_gsr: Some(unique_hash(marker + 4)),
+            metadata: StateMetadata {
+                current_state_root: Some(unique_hash(marker + 4)),
                 current_block_number: Some(block_number),
                 created_count: block_number as u64,
                 nullifier_count: block_number as u64 + 1,
-                gsr_count: block_number as u64 + 2,
+                state_root_count: block_number as u64 + 2,
             },
         }
     }
@@ -536,7 +544,7 @@ mod tests {
             block_root: None,
             parent_root: None,
             block_number: None,
-            current_gsr: None,
+            current_state_root: None,
             is_empty: true,
         };
         let start_slot = sync_db
@@ -546,7 +554,7 @@ mod tests {
             .ok_or_else(|| anyhow!("last processed slot overflow"))?;
         assert_eq!(start_slot, 5);
         let snapshot = sync_db.current_snapshot().await?;
-        assert_eq!(snapshot.head, CanonicalHead::empty());
+        assert_eq!(snapshot.head, StateHead::empty());
         assert_eq!(snapshot.last_processed_slot, 4);
         assert_eq!(snapshot.last_processed_block_number, None);
         drop_db(&db_name, &admin_url).await?;
@@ -563,7 +571,7 @@ mod tests {
             block_root: None,
             parent_root: None,
             block_number: Some(7),
-            current_gsr: head.metadata.current_gsr,
+            current_state_root: head.metadata.current_state_root,
             is_empty: false,
         };
 
@@ -589,7 +597,7 @@ mod tests {
             block_root: None,
             parent_root: None,
             block_number: Some(7),
-            current_gsr: head1.metadata.current_gsr,
+            current_state_root: head1.metadata.current_state_root,
             is_empty: false,
         };
 
@@ -611,7 +619,7 @@ mod tests {
 
     #[tokio::test]
     #[ignore = "requires local postgres"]
-    async fn test_recent_gsrs_query() -> Result<()> {
+    async fn test_recent_state_roots_query() -> Result<()> {
         let (sync_db, db_name, admin_url) = fresh_sync_db().await?;
         let h1 = unique_head(5, 10);
         sync_db
@@ -621,7 +629,7 @@ mod tests {
                     block_root: None,
                     parent_root: None,
                     block_number: Some(5),
-                    current_gsr: h1.metadata.current_gsr,
+                    current_state_root: h1.metadata.current_state_root,
                     is_empty: false,
                 },
                 &h1,
@@ -637,7 +645,7 @@ mod tests {
                     block_root: None,
                     parent_root: None,
                     block_number: Some(9),
-                    current_gsr: h2.metadata.current_gsr,
+                    current_state_root: h2.metadata.current_state_root,
                     is_empty: false,
                 },
                 &h2,
@@ -645,8 +653,8 @@ mod tests {
             )
             .await?;
 
-        let recent = sync_db.recent_gsrs(Some(6)).await?;
-        assert_eq!(recent, vec![(h2.metadata.current_gsr.unwrap(), 9)]);
+        let recent = sync_db.recent_state_roots(Some(6)).await?;
+        assert_eq!(recent, vec![(h2.metadata.current_state_root.unwrap(), 9)]);
 
         drop_db(&db_name, &admin_url).await?;
         Ok(())
@@ -664,7 +672,7 @@ mod tests {
                     block_root: None,
                     parent_root: None,
                     block_number: Some(1),
-                    current_gsr: h1.metadata.current_gsr,
+                    current_state_root: h1.metadata.current_state_root,
                     is_empty: false,
                 },
                 &h1,
@@ -680,7 +688,7 @@ mod tests {
                     block_root: None,
                     parent_root: None,
                     block_number: Some(2),
-                    current_gsr: h2.metadata.current_gsr,
+                    current_state_root: h2.metadata.current_state_root,
                     is_empty: false,
                 },
                 &h2,
@@ -713,7 +721,7 @@ mod tests {
                     block_root: None,
                     parent_root: None,
                     block_number: Some(1),
-                    current_gsr: h1.metadata.current_gsr,
+                    current_state_root: h1.metadata.current_state_root,
                     is_empty: false,
                 },
                 &h1,
@@ -728,7 +736,7 @@ mod tests {
                     block_root: None,
                     parent_root: None,
                     block_number: Some(2),
-                    current_gsr: h2.metadata.current_gsr,
+                    current_state_root: h2.metadata.current_state_root,
                     is_empty: false,
                 },
                 &h2,

--- a/synchronizer/src/sync_db.rs
+++ b/synchronizer/src/sync_db.rs
@@ -88,7 +88,7 @@ impl SyncDb {
                 is_empty BOOLEAN NOT NULL,
                 head_created_root BYTEA NOT NULL,
                 head_nullifiers_root BYTEA NOT NULL,
-                head_state_history_root BYTEA NOT NULL,
+                head_prior_state_history_root BYTEA NOT NULL,
                 head_next_state_history_root BYTEA NOT NULL,
                 head_current_state_root BYTEA NULL,
                 head_current_block_number INTEGER NULL,
@@ -186,7 +186,7 @@ impl SyncDb {
                    execution_block_number,
                    head_created_root,
                    head_nullifiers_root,
-                   head_state_history_root,
+                   head_prior_state_history_root,
                    head_next_state_history_root,
                    head_current_state_root,
                    head_current_block_number,
@@ -266,7 +266,7 @@ impl SyncDb {
                 is_empty,
                 head_created_root,
                 head_nullifiers_root,
-                head_state_history_root,
+                head_prior_state_history_root,
                 head_next_state_history_root,
                 head_current_state_root,
                 head_current_block_number,
@@ -285,7 +285,7 @@ impl SyncDb {
         .bind(slot.is_empty)
         .bind(hash_to_db_bytes(head.roots.created))
         .bind(hash_to_db_bytes(head.roots.nullifiers))
-        .bind(hash_to_db_bytes(head.roots.state_history))
+        .bind(hash_to_db_bytes(head.roots.prior_state_history))
         .bind(hash_to_db_bytes(head.roots.next_state_history))
         .bind(head.metadata.current_state_root.map(hash_to_db_bytes))
         .bind(head.metadata.current_block_number.map(|v| v as i32))
@@ -434,7 +434,9 @@ fn decode_head_row(row: &PgRow) -> Result<StateHead> {
         roots: StateRoots {
             created: db_bytes_to_hash(&row.get::<Vec<u8>, _>("head_created_root"))?,
             nullifiers: db_bytes_to_hash(&row.get::<Vec<u8>, _>("head_nullifiers_root"))?,
-            state_history: db_bytes_to_hash(&row.get::<Vec<u8>, _>("head_state_history_root"))?,
+            prior_state_history: db_bytes_to_hash(
+                &row.get::<Vec<u8>, _>("head_prior_state_history_root"),
+            )?,
             next_state_history: db_bytes_to_hash(
                 &row.get::<Vec<u8>, _>("head_next_state_history_root"),
             )?,
@@ -471,7 +473,7 @@ mod tests {
             roots: StateRoots {
                 created: unique_hash(marker),
                 nullifiers: unique_hash(marker + 1),
-                state_history: unique_hash(marker + 2),
+                prior_state_history: unique_hash(marker + 2),
                 next_state_history: unique_hash(marker + 3),
             },
             metadata: StateMetadata {

--- a/synchronizer/src/sync_db.rs
+++ b/synchronizer/src/sync_db.rs
@@ -74,12 +74,12 @@ impl SyncDb {
 
     /// Create the Postgres schema used by the synchronizer control plane.
     ///
-    /// `canonical_slots` stores per-slot metadata plus the committed state roots and metadata
+    /// `state_slots` stores per-slot metadata plus the committed state roots and metadata
     /// as regular SQL columns. The highest committed slot is the current state head.
     async fn bootstrap(&self) -> Result<()> {
         let statements = [
             r#"
-            CREATE TABLE IF NOT EXISTS canonical_slots (
+            CREATE TABLE IF NOT EXISTS state_slots (
                 slot INTEGER PRIMARY KEY,
                 block_root BYTEA NULL,
                 parent_root BYTEA NULL,
@@ -99,13 +99,13 @@ impl SyncDb {
             )
             "#,
             r#"
-            CREATE UNIQUE INDEX IF NOT EXISTS canonical_slots_block_root_uq
-                ON canonical_slots(block_root)
+            CREATE UNIQUE INDEX IF NOT EXISTS state_slots_block_root_uq
+                ON state_slots(block_root)
                 WHERE block_root IS NOT NULL
             "#,
             r#"
-            CREATE INDEX IF NOT EXISTS canonical_slots_state_root_block_idx
-                ON canonical_slots(execution_block_number)
+            CREATE INDEX IF NOT EXISTS state_slots_state_root_block_idx
+                ON state_slots(execution_block_number)
                 WHERE current_state_root IS NOT NULL AND execution_block_number IS NOT NULL
             "#,
             // Reverse index from object commitment to its position in the created
@@ -137,7 +137,7 @@ impl SyncDb {
         let row = sqlx::query(
             r#"
             SELECT slot
-            FROM canonical_slots
+            FROM state_slots
             ORDER BY slot DESC
             LIMIT 1
             "#,
@@ -193,7 +193,7 @@ impl SyncDb {
                    head_created_count,
                    head_nullifier_count,
                    head_state_root_count
-            FROM canonical_slots
+            FROM state_slots
             ORDER BY slot DESC
             LIMIT 1
             "#,
@@ -209,7 +209,7 @@ impl SyncDb {
             .map(|block_number| block_number as u32);
 
         let head = decode_head_row(&row).with_context(|| {
-            format!("canonical_slots row for slot {last_processed_slot} had invalid head data")
+            format!("state_slots row for slot {last_processed_slot} had invalid head data")
         })?;
 
         Ok(CurrentSnapshot {
@@ -221,7 +221,7 @@ impl SyncDb {
 
     /// Return the beacon block root for a committed slot.
     pub async fn slot_root(&self, slot: u32) -> Result<Option<B256>> {
-        let row = sqlx::query("SELECT block_root FROM canonical_slots WHERE slot = $1")
+        let row = sqlx::query("SELECT block_root FROM state_slots WHERE slot = $1")
             .bind(slot as i32)
             .fetch_optional(&self.pool)
             .await?;
@@ -257,7 +257,7 @@ impl SyncDb {
 
         sqlx::query(
             r#"
-            INSERT INTO canonical_slots(
+            INSERT INTO state_slots(
                 slot,
                 block_root,
                 parent_root,
@@ -323,7 +323,7 @@ impl SyncDb {
     pub async fn rollback_to_slot(&self, keep_slot: u32) -> Result<()> {
         let mut tx = self.pool.begin().await?;
 
-        sqlx::query("DELETE FROM canonical_slots WHERE slot > $1")
+        sqlx::query("DELETE FROM state_slots WHERE slot > $1")
             .bind(keep_slot as i32)
             .execute(&mut *tx)
             .await?;
@@ -405,7 +405,7 @@ impl SyncDb {
         let rows = sqlx::query(
             r#"
             SELECT current_state_root, execution_block_number
-            FROM canonical_slots
+            FROM state_slots
             WHERE current_state_root IS NOT NULL
               AND execution_block_number IS NOT NULL
               AND execution_block_number >= $1

--- a/synchronizer/src/sync_loop.rs
+++ b/synchronizer/src/sync_loop.rs
@@ -43,7 +43,7 @@ enum MissingSlotAction {
     Applied,
 }
 
-/// Process beacon slots in order until shutdown, rewinding when canonical history diverges.
+/// Process beacon slots in order until shutdown, rewinding when chain history diverges.
 pub async fn run_sync_loop(
     node: Arc<Node>,
     mut shutdown_rx: watch::Receiver<bool>,
@@ -131,8 +131,8 @@ pub async fn run_sync_loop(
         // ── Single-slot path (at or near head) ──────────────────────────
         debug!(slot = next_slot, "Checking slot");
         // Resolve the target slot against beacon head; may return:
-        // - Missing: canonical empty slot
-        // - Present: canonical block header for this slot
+        // - Missing: empty slot
+        // - Present: block header for this slot
         // - Shutdown: graceful stop
         let beacon_block_header = match head_tracker
             .next_slot_header(&node, next_slot, &mut shutdown_rx)
@@ -156,7 +156,7 @@ pub async fn run_sync_loop(
             SlotHeaderState::Present(header) => header,
         };
 
-        // For present slots, centralize all "did canonical history diverge?" checks
+        // For present slots, centralize all "did chain history diverge?" checks
         // before any write side effects.
         if let Some(rewind_slot) =
             handle_reorgs_for_present_slot(&node, next_slot, &beacon_block_header).await?
@@ -177,22 +177,22 @@ pub async fn run_sync_loop(
     }
 }
 
-/// Handle a slot that currently has no canonical block header.
+/// Handle a slot that currently has no block header.
 ///
 /// Returns whether the loop should continue from a rewind slot or from the next slot.
 async fn handle_missing_slot(node: &Node, slot: u32) -> Result<MissingSlotAction> {
-    // A previously canonical slot becoming empty implies canonical history changed.
+    // A previously committed slot becoming empty implies chain history changed.
     if node.slot_root(slot).await?.is_some() {
         warn!(
             slot,
-            "Detected reorg: slot was previously canonical but is now missing; rewinding"
+            "Detected reorg: slot was previously present but is now missing; rewinding"
         );
         return Ok(MissingSlotAction::Rewound(
             rewind_for_reorg(node, slot).await?,
         ));
     }
 
-    // Skipped slots are valid on beacon; commit a Missing slot so canonical
+    // Skipped slots are valid on beacon; commit a Missing slot so the
     // slot history stays contiguous.
     let processed = ProcessedSlot::Missing {
         slot,
@@ -206,7 +206,7 @@ async fn handle_missing_slot(node: &Node, slot: u32) -> Result<MissingSlotAction
 
 /// Run all present-slot reorg checks.
 ///
-/// Returns `Some(rewind_slot)` when canonical-consistency checks fail, else `None`.
+/// Returns `Some(rewind_slot)` when chain-consistency checks fail, else `None`.
 async fn handle_reorgs_for_present_slot(
     node: &Node,
     slot: u32,
@@ -215,7 +215,7 @@ async fn handle_reorgs_for_present_slot(
     let last_processed_slot = node.last_processed_slot().await?;
     let stored_root_for_slot = node.slot_root(slot).await?;
     if last_processed_slot >= slot && stored_root_for_slot.is_none() {
-        // A previously empty canonical slot becoming non-empty implies canonical history changed.
+        // A previously empty slot becoming non-empty implies chain history changed.
         warn!(
             slot,
             "Detected reorg: slot was previously empty but now has a block; rewinding"
@@ -224,13 +224,13 @@ async fn handle_reorgs_for_present_slot(
     }
 
     if let Some(stored_root) = stored_root_for_slot {
-        // Same slot number with a different block root is a canonical reorg.
+        // Same slot number with a different block root is a reorg.
         if stored_root != beacon_block_header.root {
             warn!(
                 slot,
                 stored_root = ?stored_root,
                 fetched_root = ?beacon_block_header.root,
-                "Detected reorg: canonical root changed for slot; rewinding"
+                "Detected reorg: block root changed for slot; rewinding"
             );
             return Ok(Some(rewind_for_reorg(node, slot).await?));
         }
@@ -238,7 +238,7 @@ async fn handle_reorgs_for_present_slot(
 
     if let Some(prev_slot) = slot.checked_sub(1) {
         if let Some(prev_root) = node.slot_root(prev_slot).await? {
-            // Parent mismatch means our local chain view diverged from current canonical chain.
+            // Parent mismatch means our local chain view diverged from current chain.
             if beacon_block_header.parent_root != prev_root {
                 warn!(
                     slot,
@@ -302,7 +302,7 @@ pub(crate) async fn initialize_sync(
 
     let bootstrap_start_slot = initial_start_slot.unwrap_or(head.slot);
     let bootstrap_slot = bootstrap_start_slot.checked_sub(1).ok_or_else(|| {
-        anyhow!("bootstrap start slot must be > 0 to insert initial canonical row")
+        anyhow!("bootstrap start slot must be > 0 to insert initial bootstrap row")
     })?;
 
     if bootstrap_slot > head.slot {
@@ -411,7 +411,7 @@ impl HeadTracker {
                         continue;
                     }
 
-                    // Events are hints; re-read canonical head/slot before deciding.
+                    // Events are hints; re-read state head/slot before deciding.
                     match Self::decide_after_head_check(
                         self.resolve_slot_from_head(node, slot).await?,
                     ) {

--- a/txlib/README.md
+++ b/txlib/README.md
@@ -8,7 +8,7 @@ The SDK defines **actions** and **classes**. A class is a label for an object's 
 
 ## Transactions: verifying state changes
 
-A transaction verifies a set of state changes: newly created object states and nullifications of existing object states. It checks both that the initial states are valid (grounded in the prior global state) and that every change (creating a new object, mutating or deleting an existing one) has a valid cause.
+A transaction verifies a set of state changes: newly created object states and nullifications of existing object states. It checks both that the initial states are valid (grounded in the prior state) and that every change (creating a new object, mutating or deleting an existing one) has a valid cause.
 
 For this to work, actions need a way of saying "these are the changes I caused", and the system needs a way to look at any change and ask whether there is a valid cause for it: did this change originate in one of the permitted actions for the affected object's class?
 
@@ -22,7 +22,7 @@ Before the system can answer that question, the prover first produces **action s
 
 ## The hash chain
 
-Every event in a transaction (insert, mutate, delete) is recorded as one step of a chained hash. For each event a small per-event hash is computed (insert: `H({}, new)`; mutate: `H(old, new)`; delete: `H(old, {})`, where `{}` is the empty value) and folded into the running chain (`chain = H(prev_chain, event_hash)`). The chain is the canonical, ordering-preserving commitment to "what happened, in what order".
+Every event in a transaction (insert, mutate, delete) is recorded as one step of a chained hash. For each event a small per-event hash is computed (insert: `H({}, new)`; mutate: `H(old, new)`; delete: `H(old, {})`, where `{}` is the empty value) and folded into the running chain (`chain = H(prev_chain, event_hash)`). The chain is the definitive, ordering-preserving commitment to "what happened, in what order".
 
 An **action's range** is the pair `(chain_start, chain_end)` that brackets the action's events. The first event in the action takes `chain_start` as its `prev_chain`; the last event produces `chain_end`. The action statement commits to its range publicly so other proofs can match against it.
 

--- a/txlib/src/lib.rs
+++ b/txlib/src/lib.rs
@@ -45,9 +45,9 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 // Data structures
 // ============================================================================
 
-/// Compact committed view of canonical app state used for grounding transactions.
+/// Compact committed view of app state used for grounding transactions.
 ///
-/// Holds only the Merkle roots needed to recompute the canonical global state
+/// Holds only the Merkle roots needed to recompute the state
 /// root hash and to verify synchronizer-supplied membership proofs. Full
 /// containers are not carried -- callers prove each input's liveness with a
 /// per-object Merkle proof packaged in a [`GroundingWitness`].
@@ -77,7 +77,7 @@ impl StateHeader {
         }
     }
 
-    /// Array view used as the canonical state root record. Slot layout
+    /// Array view used as the state root record. Slot layout
     /// matches the `record StateHeader` declaration in txlib.podlang.
     /// Predicates access fields via anchored-key syntax (e.g.
     /// `state_header.created`).

--- a/txlib/src/lib.rs
+++ b/txlib/src/lib.rs
@@ -53,40 +53,40 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 /// per-object Merkle proof packaged in a [`GroundingWitness`].
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct StateRoot {
+pub struct StateHeader {
     pub block_number: i64,
     /// Root of the global created-object set: the commitment of every object
     /// state ever created. Grounding proves an input is a member here.
     pub created_root: Hash,
     pub nullifiers_root: Hash,
-    pub gsrs_root: Hash,
+    pub state_history_root: Hash,
 }
 
-impl StateRoot {
+impl StateHeader {
     pub fn new(
         block_number: i64,
         created_root: Hash,
         nullifiers_root: Hash,
-        gsrs_root: Hash,
+        state_history_root: Hash,
     ) -> Self {
         Self {
             block_number,
             created_root,
             nullifiers_root,
-            gsrs_root,
+            state_history_root,
         }
     }
 
     /// Array view used as the canonical state root record. Slot layout
-    /// matches the `record StateRoot` declaration in txlib.podlang.
+    /// matches the `record StateHeader` declaration in txlib.podlang.
     /// Predicates access fields via anchored-key syntax (e.g.
-    /// `state_root.created`).
+    /// `state_header.created`).
     pub fn array(&self) -> Array {
         Array::new(vec![
             Value::from(self.block_number),
             Value::from(self.created_root),
             Value::from(self.nullifiers_root),
-            Value::from(self.gsrs_root),
+            Value::from(self.state_history_root),
         ])
     }
 
@@ -96,34 +96,37 @@ impl StateRoot {
     }
 }
 
-/// Slot indices for the `StateRoot` record, matching the field order in
-/// the `record StateRoot` declaration in txlib.podlang.
-pub const STATE_ROOT_BLOCK_NUMBER_SLOT: usize = 0;
-pub const STATE_ROOT_CREATED_SLOT: usize = 1;
-pub const STATE_ROOT_NULLIFIERS_SLOT: usize = 2;
-pub const STATE_ROOT_GSRS_SLOT: usize = 3;
+/// Slot indices for the `StateHeader` record, matching the field order in
+/// the `record StateHeader` declaration in txlib.podlang.
+pub const STATE_HEADER_BLOCK_NUMBER_SLOT: usize = 0;
+pub const STATE_HEADER_CREATED_SLOT: usize = 1;
+pub const STATE_HEADER_NULLIFIERS_SLOT: usize = 2;
+pub const STATE_HEADER_STATE_HISTORY_SLOT: usize = 3;
 
 /// Proof-bearing grounding data required to build a new transaction.
 ///
-/// Callers use `state_root` as the committed global context and
+/// Callers use `state_header` as the committed global context and
 /// `created_proofs` to prove that each consumed input object is present in
-/// `state_root.created_root` (the global created-object set). Proofs are keyed
+/// `state_header.created_root` (the global created-object set). Proofs are keyed
 /// by object commitment (`Dictionary::commitment()`) and carry the object's
 /// array index, since grounding is `ArrayContains(created, index, obj)`. They
 /// are fetched fresh at consume time because the created set grows: a proof is
 /// only valid against the state root it was drawn from.
 #[derive(Clone, Debug)]
 pub struct GroundingWitness {
-    pub state_root: StateRoot,
+    pub state_header: StateHeader,
     /// Per-object `(index, Merkle proof)` for membership in the global created
     /// set, keyed by object commitment (`Dictionary::commitment()`).
     pub created_proofs: HashMap<Hash, (i64, MerkleProof)>,
 }
 
 impl GroundingWitness {
-    pub fn new(state_root: StateRoot, created_proofs: HashMap<Hash, (i64, MerkleProof)>) -> Self {
+    pub fn new(
+        state_header: StateHeader,
+        created_proofs: HashMap<Hash, (i64, MerkleProof)>,
+    ) -> Self {
         Self {
-            state_root,
+            state_header,
             created_proofs,
         }
     }
@@ -138,7 +141,7 @@ pub struct Tx {
     /// The after_tx dictionary. Its commitment is tx_final (the value the
     /// relayer publishes). Contains live, nullifiers, chain_start, chain_end.
     pub ctx: Dictionary,
-    pub state_root: Arc<StateRoot>,
+    pub state_header: Arc<StateHeader>,
 }
 
 impl Tx {
@@ -171,7 +174,7 @@ struct TxSerde {
     live: Set,
     nullifiers: Set,
     ctx: Dictionary,
-    state_root: StateRoot,
+    state_header: StateHeader,
 }
 
 impl Serialize for Tx {
@@ -183,7 +186,7 @@ impl Serialize for Tx {
             live: self.live.clone(),
             nullifiers: self.nullifiers.clone(),
             ctx: self.ctx.clone(),
-            state_root: (*self.state_root).clone(),
+            state_header: (*self.state_header).clone(),
         }
         .serialize(serializer)
     }
@@ -199,7 +202,7 @@ impl<'de> Deserialize<'de> for Tx {
             live: payload.live,
             nullifiers: payload.nullifiers,
             ctx: payload.ctx,
-            state_root: Arc::new(payload.state_root),
+            state_header: Arc::new(payload.state_header),
         })
     }
 }
@@ -374,7 +377,7 @@ pub struct TxBuilder {
     pub chain_start: Hash,
     live: Set,
     nullifiers: Set,
-    state_root: Arc<StateRoot>,
+    state_header: Arc<StateHeader>,
     st_inputs_grounded: Statement,
     inputs_set: Set,
     events: Vec<ChainEvent>,
@@ -505,13 +508,13 @@ impl TxBuilder {
             Value::from(inputs_set.commitment()),
             Value::from(EMPTY_VALUE),
         ]);
-        let state_root = Arc::new(grounding.state_root.clone());
+        let state_header = Arc::new(grounding.state_header.clone());
         Self {
             chain: chain_start,
             chain_start,
             live: inputs_set.clone(),
             nullifiers: set!(),
-            state_root,
+            state_header,
             st_inputs_grounded,
             inputs_set,
             events: vec![],
@@ -841,7 +844,7 @@ impl TxBuilder {
 
         // Tie grounding to the public state root: rebind the InputsGrounded
         // statement's `inputs` to `before_tx.live` (the in-tx working set) and
-        // its created set to `state_root.created`. The latter is the single
+        // its created set to `state_header.created`. The latter is the single
         // state-root array access anchoring the whole grounding tree. Two calls
         // rather than one because the entries are different anchored-key types:
         // a dict key and an array index.
@@ -852,13 +855,13 @@ impl TxBuilder {
                 self.st_inputs_grounded.clone(),
             ))
             .unwrap();
-        let state_root_arr = self.state_root.array();
+        let state_header_arr = self.state_header.array();
         let st_inputs_rebound = ctx
             .builder
             .priv_op(Operation::replace_value_with_entry(
                 vec![
                     None,
-                    Some((&state_root_arr, STATE_ROOT_CREATED_SLOT as i64)),
+                    Some((&state_header_arr, STATE_HEADER_CREATED_SLOT as i64)),
                 ],
                 st_inputs_rebound,
             ))
@@ -936,7 +939,7 @@ impl TxBuilder {
             live: self.live,
             nullifiers: self.nullifiers,
             ctx: after_tx,
-            state_root: self.state_root,
+            state_header: self.state_header,
         };
         (st, tx, stats)
     }
@@ -960,8 +963,8 @@ impl TxBuilder {
     ) -> (Statement, Set, TxStats) {
         let mut stats = TxStats::new();
         // Ground against the created-set commitment as a plain value; TxFinalized
-        // is what ties it back to `state_root.created`.
-        let created_root = grounding.state_root.created_root;
+        // is what ties it back to `state_header.created`.
+        let created_root = grounding.state_header.created_root;
         let created_value = Value::from(created_root);
 
         if inputs.is_empty() {
@@ -1122,13 +1125,13 @@ mod tests {
     /// Running grounding state for the tests: keeps the full created-object set
     /// (as an array, plus a reverse index for proofs) and the nullifier set so
     /// it can hand out real Merkle proofs, while exposing only the
-    /// commitments-only `StateRoot`. The created set is grow-only.
+    /// commitments-only `StateHeader`. The created set is grow-only.
     struct TestState {
         block_number: i64,
         created: Array,
         created_index: HashMap<Hash, i64>,
         nullifiers: Set,
-        gsrs: Array,
+        state_history: Array,
     }
 
     impl TestState {
@@ -1138,16 +1141,16 @@ mod tests {
                 created: Array::new(Vec::new()),
                 created_index: HashMap::new(),
                 nullifiers: set!(),
-                gsrs: Array::new(Vec::new()),
+                state_history: Array::new(Vec::new()),
             }
         }
 
-        fn state_root(&self) -> StateRoot {
-            StateRoot::new(
+        fn state_header(&self) -> StateHeader {
+            StateHeader::new(
                 self.block_number,
                 self.created.commitment(),
                 self.nullifiers.commitment(),
-                self.gsrs.commitment(),
+                self.state_history.commitment(),
             )
         }
 
@@ -1183,7 +1186,7 @@ mod tests {
                     (commitment, (index, proof))
                 })
                 .collect();
-            Arc::new(GroundingWitness::new(self.state_root(), created_proofs))
+            Arc::new(GroundingWitness::new(self.state_header(), created_proofs))
         }
     }
 
@@ -1229,14 +1232,14 @@ mod tests {
     }
 
     #[test]
-    fn state_root_hash_matches_array_commitment() {
-        let sr = StateRoot::new(7, test_hash(1), test_hash(2), test_hash(3));
+    fn state_header_hash_matches_array_commitment() {
+        let sr = StateHeader::new(7, test_hash(1), test_hash(2), test_hash(3));
         assert_eq!(sr.hash(), sr.array().commitment());
     }
 
     #[test]
-    fn state_root_serializes_and_deserializes_camelcase() {
-        let original = StateRoot::new(9, test_hash(1), test_hash(2), test_hash(3));
+    fn state_header_serializes_and_deserializes_camelcase() {
+        let original = StateHeader::new(9, test_hash(1), test_hash(2), test_hash(3));
         let encoded = serde_json::to_value(&original).unwrap();
         assert_eq!(encoded["blockNumber"], serde_json::json!(9));
         assert_eq!(
@@ -1248,11 +1251,11 @@ mod tests {
             serde_json::json!(hex::encode([2_u8; 32]))
         );
         assert_eq!(
-            encoded["gsrsRoot"],
+            encoded["stateHistoryRoot"],
             serde_json::json!(hex::encode([3_u8; 32]))
         );
 
-        let decoded: StateRoot = serde_json::from_value(encoded).unwrap();
+        let decoded: StateHeader = serde_json::from_value(encoded).unwrap();
         assert_eq!(decoded, original);
     }
 

--- a/txlib/src/lib.rs
+++ b/txlib/src/lib.rs
@@ -59,7 +59,7 @@ pub struct StateHeader {
     /// state ever created. Grounding proves an input is a member here.
     pub created_root: Hash,
     pub nullifiers_root: Hash,
-    pub state_history_root: Hash,
+    pub prior_state_history_root: Hash,
 }
 
 impl StateHeader {
@@ -67,13 +67,13 @@ impl StateHeader {
         block_number: i64,
         created_root: Hash,
         nullifiers_root: Hash,
-        state_history_root: Hash,
+        prior_state_history_root: Hash,
     ) -> Self {
         Self {
             block_number,
             created_root,
             nullifiers_root,
-            state_history_root,
+            prior_state_history_root,
         }
     }
 
@@ -86,7 +86,7 @@ impl StateHeader {
             Value::from(self.block_number),
             Value::from(self.created_root),
             Value::from(self.nullifiers_root),
-            Value::from(self.state_history_root),
+            Value::from(self.prior_state_history_root),
         ])
     }
 
@@ -101,7 +101,7 @@ impl StateHeader {
 pub const STATE_HEADER_BLOCK_NUMBER_SLOT: usize = 0;
 pub const STATE_HEADER_CREATED_SLOT: usize = 1;
 pub const STATE_HEADER_NULLIFIERS_SLOT: usize = 2;
-pub const STATE_HEADER_STATE_HISTORY_SLOT: usize = 3;
+pub const STATE_HEADER_PRIOR_STATE_HISTORY_SLOT: usize = 3;
 
 /// Proof-bearing grounding data required to build a new transaction.
 ///
@@ -1251,7 +1251,7 @@ mod tests {
             serde_json::json!(hex::encode([2_u8; 32]))
         );
         assert_eq!(
-            encoded["stateHistoryRoot"],
+            encoded["priorStateHistoryRoot"],
             serde_json::json!(hex::encode([3_u8; 32]))
         );
 

--- a/txlib/src/predicates/txlib.podlang
+++ b/txlib/src/predicates/txlib.podlang
@@ -16,7 +16,7 @@
 
   3. TxFinalized -- the public entry point. Ties input grounding,
      chain seeding, and full replay together. Exposes
-     (state_root, tx_final, nullifiers, live) publicly.
+     (state_header, tx_final, nullifiers, live) publicly.
 
   State convention: most predicates thread four public arguments:
   (before_tx, after_tx, before_chain, after_chain). Each step
@@ -272,7 +272,7 @@ ReplayDelete(before_tx, after_tx, before_chain, after_chain,
 // global created-object set (every object state ever created, maintained
 // by the synchronizer).
 
-record StateRoot = (block_number, created, nullifiers, gsrs)
+record StateHeader = (block_number, created, nullifiers, state_history)
 
 InputsGrounded(inputs, created) = OR(
   // Base case: empty inputs. `created` is intentionally unconstrained --
@@ -319,9 +319,9 @@ InputsGroundedRecursive(inputs, created,
 // certificate: it attests to the final state without revealing the
 // event sequence that produced it.
 
-// Exposes (state_root, tx_final, nullifiers, live) publicly. The
-// verifier sees `state_root` as a single hash -- the commitment of the
-// `StateRoot` record.
+// Exposes (state_header, tx_final, nullifiers, live) publicly. The
+// verifier sees `state_header` as a single hash -- the commitment of the
+// `StateHeader` record.
 // tx_final is the after_tx dictionary commitment, which binds the
 // live set, nullifiers, and final chain_start/chain_end together. Both
 // the nullifier set and the final live set are also surfaced as their
@@ -343,9 +343,9 @@ TxFinalBindings(tx_final, nullifiers, live) = AND(
   DictContains(tx_final, "live", live)
 )
 
-TxFinalized(state_root StateRoot, tx_final, nullifiers, live,
+TxFinalized(state_header StateHeader, tx_final, nullifiers, live,
      private: before_tx, chain_start, chain_final) = AND(
-  InputsGrounded(before_tx.live, state_root.created)
+  InputsGrounded(before_tx.live, state_header.created)
   HashOf(chain_start, before_tx.live, {})
   DictInsert(before_tx, {"nullifiers": {}, "chain_start": {}, "chain_end": {}}, "live", before_tx.live)
   TxFinalBindings(tx_final, nullifiers, live)

--- a/txlib/src/predicates/txlib.podlang
+++ b/txlib/src/predicates/txlib.podlang
@@ -272,7 +272,7 @@ ReplayDelete(before_tx, after_tx, before_chain, after_chain,
 // global created-object set (every object state ever created, maintained
 // by the synchronizer).
 
-record StateHeader = (block_number, created, nullifiers, state_history)
+record StateHeader = (block_number, created, nullifiers, prior_state_history)
 
 InputsGrounded(inputs, created) = OR(
   // Base case: empty inputs. `created` is intentionally unconstrained --

--- a/wire-types/src/lib.rs
+++ b/wire-types/src/lib.rs
@@ -10,7 +10,7 @@
 //!
 //! - [`relayer`] — DTOs for the relayer's HTTP API. The status/request
 //!   types are pure serde; the two proof-bearing response types carry pod2
-//!   `Hash` (`tx_final`, `state_root_hash`), so they live behind the
+//!   `Hash` (`tx_final`, `state_root`), so they live behind the
 //!   `chain` feature. The relayer server and the driver enable it.
 //! - [`synchronizer`] — DTOs for the synchronizer's HTTP API. Every type
 //!   carries pod2 `Hash` values directly, so the whole module lives behind

--- a/wire-types/src/relayer.rs
+++ b/wire-types/src/relayer.rs
@@ -5,7 +5,7 @@
 //! server-side deps (sqlx-postgres, alloy, axum).
 //!
 //! The status/request types are pure serde. The two response types carry
-//! pod2 `Hash` (`tx_final`, `state_root_hash`, serialized as the 64-char
+//! pod2 `Hash` (`tx_final`, `state_root`, serialized as the 64-char
 //! hex pod2 emits), so they live behind the `chain` feature; `tx_hash`
 //! stays a `String` because it is an Ethereum keccak hash, not a pod2 one.
 
@@ -113,7 +113,7 @@ pub struct SubmitProofResponse {
     /// Idempotency key derived from the decoded payload.
     pub tx_final: Hash,
     /// State root hash claimed by the payload.
-    pub state_root_hash: Hash,
+    pub state_root: Hash,
     /// Submission attempts observed so far for this job.
     pub attempt_count: u32,
     /// Job creation timestamp in unix seconds.
@@ -143,7 +143,7 @@ pub struct JobStatusResponse {
     /// Idempotency key derived from the decoded payload.
     pub tx_final: Hash,
     /// State root hash claimed by the payload.
-    pub state_root_hash: Hash,
+    pub state_root: Hash,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/wire-types/src/synchronizer.rs
+++ b/wire-types/src/synchronizer.rs
@@ -26,35 +26,35 @@ pub struct HealthResponse {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 /// Synchronization progress returned by the synchronizer API.
 pub struct SyncProgressResponse {
-    /// Last canonical slot fully committed by the synchronizer.
+    /// Last slot fully committed by the synchronizer.
     pub last_processed_slot: u32,
     /// Execution block number associated with the last processed slot, if any.
     pub last_processed_block_number: Option<u32>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-/// Summary of the current canonical head exposed to clients.
+/// Summary of the current state head exposed to clients.
 pub struct StateHeadResponse {
-    /// Last canonical slot fully committed by the synchronizer.
+    /// Last slot fully committed by the synchronizer.
     pub last_processed_slot: u32,
     /// Execution block number associated with the last processed slot, if any.
     pub last_processed_block_number: Option<u32>,
-    /// Current canonical state root, if one exists.
+    /// Current state root, if one exists.
     pub current_state_root: Option<Hash>,
     /// Execution block number committed inside the current state root, if any.
     pub current_block_number: Option<i64>,
-    /// Number of objects in the canonical global created set.
+    /// Number of objects in the global created set.
     pub created_count: usize,
-    /// Number of spent nullifiers in canonical state.
+    /// Number of spent nullifiers in committed state.
     pub nullifier_count: usize,
-    /// Number of state root entries in canonical history.
+    /// Number of state root entries in the state history.
     pub state_root_count: usize,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 /// Batch created-object-membership request.
 pub struct ObjectContainsRequest {
-    /// Object commitments to look up in the canonical created set.
+    /// Object commitments to look up in the created set.
     pub object_commitments: Vec<Hash>,
 }
 
@@ -63,16 +63,16 @@ pub struct ObjectContainsRequest {
 pub struct ObjectContainsEntry {
     /// Queried object commitment.
     pub commitment: Hash,
-    /// Whether the object is present in the canonical created set.
+    /// Whether the object is present in the created set.
     pub present: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 /// Batch created-object-membership response.
 pub struct ObjectContainsResponse {
-    /// Last canonical slot fully committed by the synchronizer.
+    /// Last slot fully committed by the synchronizer.
     pub last_processed_slot: u32,
-    /// Current canonical state root, if one exists.
+    /// Current state root, if one exists.
     pub current_state_root: Option<Hash>,
     /// Per-commitment membership results.
     pub results: Vec<ObjectContainsEntry>,
@@ -81,7 +81,7 @@ pub struct ObjectContainsResponse {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 /// Batch nullifier-membership request.
 pub struct NullifierContainsRequest {
-    /// Nullifier hashes to look up in the canonical nullifiers set.
+    /// Nullifier hashes to look up in the nullifiers set.
     pub nullifiers: Vec<Hash>,
 }
 
@@ -90,16 +90,16 @@ pub struct NullifierContainsRequest {
 pub struct NullifierContainsEntry {
     /// Queried nullifier hash.
     pub nullifier: Hash,
-    /// Whether the hash is present in the canonical nullifiers set.
+    /// Whether the hash is present in the nullifiers set.
     pub present: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 /// Batch nullifier-membership response.
 pub struct NullifierContainsResponse {
-    /// Last canonical slot fully committed by the synchronizer.
+    /// Last slot fully committed by the synchronizer.
     pub last_processed_slot: u32,
-    /// Current canonical state root, if one exists.
+    /// Current state root, if one exists.
     pub current_state_root: Option<Hash>,
     /// Per-hash membership results.
     pub results: Vec<NullifierContainsEntry>,
@@ -108,18 +108,18 @@ pub struct NullifierContainsResponse {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 /// Combined batch membership request for both created objects and nullifiers.
 pub struct MembershipRequest {
-    /// Object commitments to look up in the canonical created set.
+    /// Object commitments to look up in the created set.
     pub object_commitments: Vec<Hash>,
-    /// Nullifier hashes to look up in the canonical nullifiers set.
+    /// Nullifier hashes to look up in the nullifiers set.
     pub nullifiers: Vec<Hash>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-/// Combined batch membership response anchored to one canonical head.
+/// Combined batch membership response anchored to one state head.
 pub struct MembershipResponse {
-    /// Last canonical slot fully committed by the synchronizer.
+    /// Last slot fully committed by the synchronizer.
     pub last_processed_slot: u32,
-    /// Current canonical state root, if one exists.
+    /// Current state root, if one exists.
     pub current_state_root: Option<Hash>,
     /// Per-object created-set membership results.
     pub created_results: Vec<ObjectContainsEntry>,
@@ -131,7 +131,7 @@ pub struct MembershipResponse {
 #[serde(rename_all = "camelCase")]
 /// Request for created-object grounding proofs used by txlib execution.
 pub struct GroundingWitnessRequest {
-    /// Input object commitments that must be proven present in the canonical created set.
+    /// Input object commitments that must be proven present in the created set.
     pub object_commitments: Vec<Hash>,
 }
 
@@ -141,26 +141,26 @@ pub struct GroundingWitnessRequest {
 pub struct ObjectProofResponse {
     /// Object commitment the client asked about.
     pub commitment: Hash,
-    /// Whether the object is present in the canonical created set.
+    /// Whether the object is present in the created set.
     pub present: bool,
     /// Array index of the object in the created set. `None` when not present.
     pub index: Option<i64>,
-    /// `ArrayContains` Merkle proof against the canonical created-set root.
+    /// `ArrayContains` Merkle proof against the created-set root.
     /// `None` when the object is not present (the array has no such leaf).
     pub proof: Option<MerkleProof>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-/// txlib witness response anchored to one canonical state root.
+/// txlib witness response anchored to one state root.
 pub struct GroundingWitnessResponse {
-    /// Hash of the compact `txlib::StateHeader` built from the canonical roots.
+    /// Hash of the compact `txlib::StateHeader` built from the state roots.
     pub state_root: Hash,
     /// Execution block number committed inside that state root.
     pub block_number: i64,
-    /// Canonical created-set root.
+    /// Created-set root.
     pub created_root: Hash,
-    /// Canonical nullifiers set root.
+    /// Nullifiers set root.
     pub nullifiers_root: Hash,
     /// Prior-state root array root committed inside the state root.
     pub state_history_root: Hash,

--- a/wire-types/src/synchronizer.rs
+++ b/wire-types/src/synchronizer.rs
@@ -163,7 +163,7 @@ pub struct GroundingWitnessResponse {
     /// Nullifiers set root.
     pub nullifiers_root: Hash,
     /// Prior-state root array root committed inside the state root.
-    pub state_history_root: Hash,
+    pub prior_state_history_root: Hash,
     /// Per-input-object created-set membership proofs.
     pub created_proofs: Vec<ObjectProofResponse>,
 }

--- a/wire-types/src/synchronizer.rs
+++ b/wire-types/src/synchronizer.rs
@@ -39,16 +39,16 @@ pub struct StateHeadResponse {
     pub last_processed_slot: u32,
     /// Execution block number associated with the last processed slot, if any.
     pub last_processed_block_number: Option<u32>,
-    /// Current canonical global state root, if one exists.
-    pub current_gsr: Option<Hash>,
+    /// Current canonical state root, if one exists.
+    pub current_state_root: Option<Hash>,
     /// Execution block number committed inside the current state root, if any.
     pub current_block_number: Option<i64>,
     /// Number of objects in the canonical global created set.
     pub created_count: usize,
     /// Number of spent nullifiers in canonical state.
     pub nullifier_count: usize,
-    /// Number of GSR entries in canonical history.
-    pub gsr_count: usize,
+    /// Number of state root entries in canonical history.
+    pub state_root_count: usize,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -72,8 +72,8 @@ pub struct ObjectContainsEntry {
 pub struct ObjectContainsResponse {
     /// Last canonical slot fully committed by the synchronizer.
     pub last_processed_slot: u32,
-    /// Current canonical global state root, if one exists.
-    pub current_gsr: Option<Hash>,
+    /// Current canonical state root, if one exists.
+    pub current_state_root: Option<Hash>,
     /// Per-commitment membership results.
     pub results: Vec<ObjectContainsEntry>,
 }
@@ -99,8 +99,8 @@ pub struct NullifierContainsEntry {
 pub struct NullifierContainsResponse {
     /// Last canonical slot fully committed by the synchronizer.
     pub last_processed_slot: u32,
-    /// Current canonical global state root, if one exists.
-    pub current_gsr: Option<Hash>,
+    /// Current canonical state root, if one exists.
+    pub current_state_root: Option<Hash>,
     /// Per-hash membership results.
     pub results: Vec<NullifierContainsEntry>,
 }
@@ -119,8 +119,8 @@ pub struct MembershipRequest {
 pub struct MembershipResponse {
     /// Last canonical slot fully committed by the synchronizer.
     pub last_processed_slot: u32,
-    /// Current canonical global state root, if one exists.
-    pub current_gsr: Option<Hash>,
+    /// Current canonical state root, if one exists.
+    pub current_state_root: Option<Hash>,
     /// Per-object created-set membership results.
     pub created_results: Vec<ObjectContainsEntry>,
     /// Per-nullifier membership results.
@@ -154,16 +154,16 @@ pub struct ObjectProofResponse {
 #[serde(rename_all = "camelCase")]
 /// txlib witness response anchored to one canonical state root.
 pub struct GroundingWitnessResponse {
-    /// Hash of the compact `txlib::StateRoot` built from the canonical roots.
-    pub state_root_hash: Hash,
+    /// Hash of the compact `txlib::StateHeader` built from the canonical roots.
+    pub state_root: Hash,
     /// Execution block number committed inside that state root.
     pub block_number: i64,
     /// Canonical created-set root.
     pub created_root: Hash,
     /// Canonical nullifiers set root.
     pub nullifiers_root: Hash,
-    /// Prior-GSR array root committed inside the state root.
-    pub gsrs_root: Hash,
+    /// Prior-state root array root committed inside the state root.
+    pub state_history_root: Hash,
     /// Per-input-object created-set membership proofs.
     pub created_proofs: Vec<ObjectProofResponse>,
 }


### PR DESCRIPTION
Clarifies the state-model vocabulary across txlib, the synchronizer, wire types, and the DB:

- `StateHeader` (was `txlib::StateRoot`) is the shallow struct of Merkle roots; its hash is the **state root** (was "GSR"/"global state root", e.g. `current_gsr → current_state_root`). The array of past roots is the **state history** (was "gsrs"/"gsr history").
- Drop the `Canonical` prefix in the synchronizer: `StateHead`, `StateRoots`, `StateMetadata`.
- Pure rename, no behavior change

Fixes https://github.com/dobjlabs/zk-craft/issues/135