### PR TITLE
Add install command to dobj CLI

### DIFF
--- a/cli/src/client.rs
+++ b/cli/src/client.rs
@@ -68,6 +68,20 @@ impl DobjdClient {
             .with_context(|| format!("PUT {url}"))?;
         decode_json(res).await
     }
+
+    /// POST raw bytes (e.g. a `.pexe` archive) and decode the JSON response.
+    pub async fn post_bytes<T: DeserializeOwned>(&self, path: &str, bytes: Vec<u8>) -> Result<T> {
+        let url = self.url(path);
+        let res = self
+            .http
+            .post(&url)
+            .header(reqwest::header::CONTENT_TYPE, "application/octet-stream")
+            .body(bytes)
+            .send()
+            .await
+            .with_context(|| format!("POST {url}"))?;
+        decode_json(res).await
+    }
 }
 
 async fn decode_json<T: DeserializeOwned>(res: reqwest::Response) -> Result<T> {

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -463,6 +463,44 @@ pub async fn feasibility(client: &DobjdClient, action_id: String, json: bool) ->
     Ok(())
 }
 
+/// Install a plugin from a local path or an http(s) URL. The bytes are sent to
+/// dobjd, which writes the `.pexe` into `~/.dobj/actions/` and hot-reloads the
+/// catalog so the plugin is usable immediately (no restart).
+pub async fn install(client: &DobjdClient, source: String, json: bool) -> Result<()> {
+    let bytes = read_or_download(&source).await?;
+    let plugin: String = client.post_bytes("/actions/install", bytes).await?;
+    if json {
+        println!(
+            "{}",
+            serde_json::to_string(&serde_json::json!({ "plugin": plugin }))?
+        );
+    } else {
+        println!("installed plugin '{plugin}' - run `dobj actions` to see what it added");
+    }
+    Ok(())
+}
+
+/// Resolve the install source: an http(s) URL is downloaded, anything else is
+/// read as a local file path. The byte cap is enforced authoritatively by
+/// dobjd (the request body limit), so there's no client-side limit here.
+async fn read_or_download(source: &str) -> Result<Vec<u8>> {
+    let is_url = reqwest::Url::parse(source)
+        .map(|u| matches!(u.scheme(), "http" | "https"))
+        .unwrap_or(false);
+    if is_url {
+        Ok(reqwest::get(source)
+            .await
+            .with_context(|| format!("GET {source}"))?
+            .error_for_status()
+            .with_context(|| format!("download failed: {source}"))?
+            .bytes()
+            .await?
+            .to_vec())
+    } else {
+        std::fs::read(source).with_context(|| format!("reading {source}"))
+    }
+}
+
 fn short_hex(hex: &str) -> String {
     let trimmed = hex.trim_start_matches("0x");
     if trimmed.len() <= 12 {

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use anyhow::{Context, Result, anyhow};
+use anyhow::{Context, Result, anyhow, bail};
 use futures_util::StreamExt;
 use reqwest_eventsource::{Event as SseEvent, EventSource};
 use serde_json::Value;
@@ -480,23 +480,43 @@ pub async fn install(client: &DobjdClient, source: String, json: bool) -> Result
     Ok(())
 }
 
+/// Mirror of `pexe::MAX_PEXE_BYTES`, to avoid pulling in pexe's dependency tree.
+const MAX_PEXE_BYTES: u64 = 8 * 1024 * 1024;
+
 /// Resolve the install source: an http(s) URL is downloaded, anything else is
-/// read as a local file path. The byte cap is enforced authoritatively by
-/// dobjd (the request body limit), so there's no client-side limit here.
+/// read as a local file path. Both are bounded by `MAX_PEXE_BYTES` so an
+/// over-large source fails before the whole thing is buffered in memory.
 async fn read_or_download(source: &str) -> Result<Vec<u8>> {
     let is_url = reqwest::Url::parse(source)
         .map(|u| matches!(u.scheme(), "http" | "https"))
         .unwrap_or(false);
     if is_url {
-        Ok(reqwest::get(source)
+        let mut res = reqwest::get(source)
             .await
             .with_context(|| format!("GET {source}"))?
             .error_for_status()
-            .with_context(|| format!("download failed: {source}"))?
-            .bytes()
-            .await?
-            .to_vec())
+            .with_context(|| format!("download failed: {source}"))?;
+        let mut buf = Vec::new();
+        while let Some(chunk) = res
+            .chunk()
+            .await
+            .with_context(|| format!("reading from {source}"))?
+        {
+            if buf.len() as u64 + chunk.len() as u64 > MAX_PEXE_BYTES {
+                bail!("{source} exceeds the {MAX_PEXE_BYTES}-byte plugin limit");
+            }
+            buf.extend_from_slice(&chunk);
+        }
+        Ok(buf)
     } else {
+        // Check size before reading so a wrong path can't pull a huge file
+        // into memory.
+        let len = std::fs::metadata(source)
+            .with_context(|| format!("reading {source}"))?
+            .len();
+        if len > MAX_PEXE_BYTES {
+            bail!("{source} ({len} bytes) exceeds the {MAX_PEXE_BYTES}-byte plugin limit");
+        }
         std::fs::read(source).with_context(|| format!("reading {source}"))
     }
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -82,6 +82,12 @@ enum Cmd {
         /// to dobjd, which files the object under a canonical name.
         path: PathBuf,
     },
+    /// Install a plugin (`.pexe`) from a local path or URL, then hot-reload
+    /// the daemon's action catalog so it's usable right away.
+    Install {
+        /// Path to a `.pexe` file, or an http(s) URL to download one from.
+        source: String,
+    },
     /// Read or write driver settings (synchronizer / relayer URLs).
     #[command(subcommand)]
     Settings(SettingsCmd),
@@ -155,6 +161,7 @@ async fn main() -> Result<()> {
         Cmd::StateRoot => commands::state_root(&client).await,
         Cmd::ObjectsDir => commands::objects_dir(&client).await,
         Cmd::Import { path } => commands::import(&client, path, cli.json).await,
+        Cmd::Install { source } => commands::install(&client, source, cli.json).await,
         Cmd::Settings(SettingsCmd::Get) => commands::settings_get(&client, cli.json).await,
         Cmd::Settings(SettingsCmd::Set {
             synchronizer,

--- a/dobjd/src/routes/actions.rs
+++ b/dobjd/src/routes/actions.rs
@@ -1,6 +1,7 @@
 use anyhow::{Result, anyhow};
 use axum::{
     Json,
+    body::Bytes,
     extract::{Path, State},
 };
 use wire_types::{
@@ -71,6 +72,19 @@ pub async fn run_action(
     .map_err(|err| anyhow!("run_action task panicked: {err}"))??;
 
     Ok(Json(result))
+}
+
+/// `POST /actions/install` — install a `.pexe` (raw archive bytes in the
+/// request body) into the actions dir and hot-reload the catalog, so the
+/// plugin is usable without restarting dobjd. The catalog is validated before
+/// the swap commits and a bad archive is removed, so a failed install leaves
+/// the running catalog untouched. Returns the installed plugin name.
+pub async fn install_plugin(State(state): State<AppState>, body: Bytes) -> ApiResult<Json<String>> {
+    let driver = state.driver.clone();
+    let name = tokio::task::spawn_blocking(move || driver.install_plugin(&body))
+        .await
+        .map_err(|err| anyhow!("install_plugin task panicked: {err}"))??;
+    Ok(Json(name))
 }
 
 /// `GET /actions` — full catalog of every action the loaded plugins

--- a/dobjd/src/routes/mod.rs
+++ b/dobjd/src/routes/mod.rs
@@ -1,5 +1,6 @@
 use axum::{
     Router,
+    extract::DefaultBodyLimit,
     routing::{get, post},
 };
 use tower_http::cors::CorsLayer;
@@ -41,6 +42,14 @@ pub fn router(app_state: AppState) -> Router {
         )
         .route("/actions", get(actions::list_actions))
         .route("/actions/run", post(actions::run_action))
+        // Raw `.pexe` bytes; raise the body cap from axum's 2 MiB default to
+        // the pexe limit so larger plugins aren't rejected before the daemon
+        // can validate them.
+        .route(
+            "/actions/install",
+            post(actions::install_plugin)
+                .layer(DefaultBodyLimit::max(driver::MAX_PEXE_BYTES as usize)),
+        )
         .route("/actions/{id}", get(actions::inspect_action))
         .route("/actions/{id}/feasibility", get(actions::check_feasibility))
         .route("/events", get(events::stream))

--- a/driver/src/driver.rs
+++ b/driver/src/driver.rs
@@ -131,19 +131,54 @@ impl Driver {
     }
 
     /// Install a `.pexe` into the actions dir and hot-reload the catalog.
-    /// Validates the archive and plugin name first; if the reload fails, the
-    /// just-written file is removed so it can't break the next startup.
-    /// Returns the installed plugin name.
+    /// Validates the archive and plugin name first. If the reload fails, the
+    /// previously-installed plugin of the same name is restored (or the new
+    /// file removed if there was none), so a failed upgrade can't destroy a
+    /// working plugin or break the next startup. Returns the installed name.
     pub fn install_plugin(&self, bytes: &[u8]) -> Result<String> {
         let (manifest, _script) = pexe::unpack(bytes).context("invalid .pexe archive")?;
         let name = manifest.plugin.name.clone();
         crate::pexe_catalog::validate_plugin_name(&name)?;
-        let path = pexe::install(bytes, &self.paths.actions_dir, &name)?;
-        if let Err(err) = self.reload_catalog() {
-            let _ = std::fs::remove_file(&path);
-            return Err(err.context(format!("plugin {name} failed to load; not installed")));
+
+        let dest = self
+            .paths
+            .actions_dir
+            .join(format!("{name}.{}", pexe::PEXE_EXTENSION));
+        // Move any same-named plugin aside first, so a failed reload can restore
+        // it rather than leaving the user with nothing. The `.bak` name stays
+        // out of the catalog scan, which only picks up `.pexe`.
+        let backup = dest.exists().then(|| {
+            self.paths
+                .actions_dir
+                .join(format!("{name}.{}.bak", pexe::PEXE_EXTENSION))
+        });
+        if let Some(backup) = &backup {
+            std::fs::rename(&dest, backup)
+                .with_context(|| format!("failed to back up {}", dest.display()))?;
         }
-        Ok(name)
+
+        // reload only swaps the in-memory catalog on success, so on failure the
+        // running catalog still reflects the prior plugin - restoring the file
+        // keeps disk and memory consistent.
+        let outcome = pexe::install(bytes, &self.paths.actions_dir, &name)
+            .and_then(|_| self.reload_catalog());
+        match outcome {
+            Ok(_) => {
+                if let Some(backup) = backup {
+                    let _ = std::fs::remove_file(backup);
+                }
+                Ok(name)
+            }
+            Err(err) => {
+                let _ = std::fs::remove_file(&dest);
+                if let Some(backup) = backup {
+                    let _ = std::fs::rename(&backup, &dest);
+                }
+                Err(err.context(format!(
+                    "plugin {name} failed to load; previous version left in place"
+                )))
+            }
+        }
     }
 
     pub fn load_settings(&self) -> Result<DriverSettings> {
@@ -506,8 +541,11 @@ impl Driver {
         reporter: &R,
     ) -> Result<ExecuteActionResult> {
         let settings = self.load_settings()?;
-        let action = self
-            .catalog()
+        // Pin one catalog snapshot for the whole execute: a concurrent
+        // `dobj install` can hot-swap the catalog, and the action resolved here
+        // must be the one we execute below.
+        let catalog = self.catalog();
+        let action = catalog
             .get_action(&input.action)
             .ok_or_else(|| anyhow!("unknown action: {}", input.action))?;
 
@@ -533,11 +571,8 @@ impl Driver {
             .iter()
             .map(|input| input.record.spendable())
             .collect::<Vec<_>>();
-        let spendable_outputs = self.catalog().execute_action(
-            input.action.clone(),
-            grounding_witness,
-            execution_inputs,
-        )?;
+        let spendable_outputs =
+            catalog.execute_action(input.action.clone(), grounding_witness, execution_inputs)?;
         reporter.on_done(ExecutionPhase::GenerateProof, None);
 
         let mut commit_ctx = ExecutionStepContext {

--- a/driver/src/driver.rs
+++ b/driver/src/driver.rs
@@ -1,8 +1,9 @@
 use std::collections::HashSet;
 use std::path::Path;
 use std::sync::Arc;
+use std::sync::RwLock;
 
-use anyhow::{Result, anyhow};
+use anyhow::{Context, Result, anyhow};
 use common::{decode_hash_hex, encode_hash_hex};
 use pod2::middleware::Hash;
 use sdk::SpendableObjects;
@@ -57,7 +58,7 @@ impl PayloadBuilder for DefaultPayloadBuilder {
 
 #[derive(Clone)]
 pub struct DriverDeps {
-    pub catalog: Arc<dyn ActionCatalog>,
+    pub catalog: Arc<RwLock<Arc<dyn ActionCatalog>>>,
     pub synchronizer: Arc<dyn SynchronizerClient>,
     pub relayer: Arc<dyn RelayerClient>,
     pub payload_builder: Arc<dyn PayloadBuilder>,
@@ -80,7 +81,7 @@ impl DriverDeps {
             );
         }
         Ok(Self {
-            catalog: Arc::new(catalog),
+            catalog: Arc::new(RwLock::new(Arc::new(catalog))),
             synchronizer: Arc::new(HttpSynchronizerClient),
             relayer: Arc::new(HttpRelayerClient),
             payload_builder: Arc::new(DefaultPayloadBuilder),
@@ -109,6 +110,40 @@ impl Driver {
 
     pub fn paths(&self) -> &DriverPaths {
         &self.paths
+    }
+
+    fn catalog(&self) -> Arc<dyn ActionCatalog> {
+        self.deps
+            .catalog
+            .read()
+            .expect("catalog lock poisoned")
+            .clone()
+    }
+
+    /// Rebuild the action catalog from `actions_dir` and swap it in. Loads
+    /// first, so a failed load (e.g. a bad .pexe) leaves the current catalog
+    /// intact. Returns the new plugin count.
+    pub fn reload_catalog(&self) -> Result<usize> {
+        let catalog = PexeCatalog::load(&self.paths.actions_dir)?;
+        let count = catalog.plugin_count();
+        *self.deps.catalog.write().expect("catalog lock poisoned") = Arc::new(catalog);
+        Ok(count)
+    }
+
+    /// Install a `.pexe` into the actions dir and hot-reload the catalog.
+    /// Validates the archive and plugin name first; if the reload fails, the
+    /// just-written file is removed so it can't break the next startup.
+    /// Returns the installed plugin name.
+    pub fn install_plugin(&self, bytes: &[u8]) -> Result<String> {
+        let (manifest, _script) = pexe::unpack(bytes).context("invalid .pexe archive")?;
+        let name = manifest.plugin.name.clone();
+        crate::pexe_catalog::validate_plugin_name(&name)?;
+        let path = pexe::install(bytes, &self.paths.actions_dir, &name)?;
+        if let Err(err) = self.reload_catalog() {
+            let _ = std::fs::remove_file(&path);
+            return Err(err.context(format!("plugin {name} failed to load; not installed")));
+        }
+        Ok(name)
     }
 
     pub fn load_settings(&self) -> Result<DriverSettings> {
@@ -223,7 +258,7 @@ impl Driver {
     }
 
     pub fn list_actions(&self, query: Option<&ActionQuery>) -> Result<Vec<ActionSummary>> {
-        let actions = self.deps.catalog.list_actions();
+        let actions = self.catalog().list_actions();
         Ok(actions
             .into_iter()
             .filter(|action| {
@@ -245,8 +280,7 @@ impl Driver {
     /// Look up a single action by its qualified name. Errors if no plugin
     /// provides the action.
     pub fn get_action(&self, action: &QualifiedName) -> Result<ActionSummary> {
-        self.deps
-            .catalog
+        self.catalog()
             .get_action(action)
             .ok_or_else(|| anyhow!("unknown action: {action}"))
     }
@@ -257,8 +291,7 @@ impl Driver {
             .filter(|entry| entry.record.status == ObjectStatus::Live)
             .collect::<Vec<_>>();
         Ok(self
-            .deps
-            .catalog
+            .catalog()
             .list_classes()
             .into_iter()
             .map(|class_info| ClassSummary {
@@ -273,8 +306,7 @@ impl Driver {
 
     pub fn get_class(&self, class: &QualifiedName) -> Result<ClassSummary> {
         let class_info = self
-            .deps
-            .catalog
+            .catalog()
             .get_class(class)
             .ok_or_else(|| anyhow!("unknown class: {class}"))?;
         let live_count = load_object_files(&self.paths)?
@@ -291,8 +323,7 @@ impl Driver {
 
     pub fn check_action(&self, action: &QualifiedName) -> Result<CheckActionReport> {
         let action_summary = self
-            .deps
-            .catalog
+            .catalog()
             .get_action(action)
             .ok_or_else(|| anyhow!("unknown action: {action}"))?;
         let entries = load_object_files(&self.paths)?;
@@ -378,8 +409,7 @@ impl Driver {
         //    the second check catches a `class` label that drifted from the
         //    object's actual pod-level identity.
         let class_info = self
-            .deps
-            .catalog
+            .catalog()
             .get_class(&record.class)
             .ok_or_else(|| DriverError::UnknownClass(record.class.to_string()))?;
         let expected_class_hash = decode_hash_hex(class_info.hash.as_str()).map_err(|err| {
@@ -477,8 +507,7 @@ impl Driver {
     ) -> Result<ExecuteActionResult> {
         let settings = self.load_settings()?;
         let action = self
-            .deps
-            .catalog
+            .catalog()
             .get_action(&input.action)
             .ok_or_else(|| anyhow!("unknown action: {}", input.action))?;
 
@@ -504,7 +533,7 @@ impl Driver {
             .iter()
             .map(|input| input.record.spendable())
             .collect::<Vec<_>>();
-        let spendable_outputs = self.deps.catalog.execute_action(
+        let spendable_outputs = self.catalog().execute_action(
             input.action.clone(),
             grounding_witness,
             execution_inputs,
@@ -676,13 +705,12 @@ impl Driver {
     }
 
     pub fn generated_podlang(&self) -> Option<String> {
-        self.deps.catalog.generated_podlang()
+        self.catalog().generated_podlang()
     }
 
     fn object_summary(&self, entry: &ObjectFileEntry) -> ObjectSummary {
         let class_hash = self
-            .deps
-            .catalog
+            .catalog()
             .get_class(&entry.record.class)
             .map(|c| c.hash)
             .unwrap_or_default();

--- a/driver/src/lib.rs
+++ b/driver/src/lib.rs
@@ -28,3 +28,4 @@ pub use crate::types::{
     ExecutionStepContext, NoopExecutionReporter, ObjectQuery,
 };
 pub use crate::warm::warm_proving_circuits;
+pub use pexe::MAX_PEXE_BYTES;

--- a/driver/src/pexe_catalog.rs
+++ b/driver/src/pexe_catalog.rs
@@ -375,7 +375,7 @@ fn load_plugin_from_bytes(path: PathBuf, bytes: &[u8]) -> Result<Plugin> {
 /// the `::` qualified-id separator), every path-significant character
 /// (`/`, `\`, `.`), whitespace, and any reserved/control characters that
 /// would otherwise leak into filenames or split qualified ids unexpectedly.
-fn validate_plugin_name(name: &str) -> Result<()> {
+pub(crate) fn validate_plugin_name(name: &str) -> Result<()> {
     if name.is_empty() {
         return Err(anyhow!("plugin name must be non-empty"));
     }

--- a/driver/src/tests.rs
+++ b/driver/src/tests.rs
@@ -1,5 +1,6 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
+use std::sync::RwLock;
 
 use anyhow::{Result, anyhow};
 use common::test_state::TestState;
@@ -95,7 +96,7 @@ fn make_input_record(file_name: &str) -> (ObjectFileEntry, DriverDeps) {
             record,
         },
         DriverDeps {
-            catalog: Arc::new(catalog),
+            catalog: Arc::new(RwLock::new(Arc::new(catalog))),
             synchronizer: Arc::new(MockSynchronizer {
                 state,
                 ..MockSynchronizer::default()
@@ -254,7 +255,7 @@ fn test_list_actions_filters_by_input_class() {
     let paths = temp_paths();
     ensure_store_dirs(&paths).unwrap();
     let deps = DriverDeps {
-        catalog: Arc::new(make_catalog()),
+        catalog: Arc::new(RwLock::new(Arc::new(make_catalog()))),
         synchronizer: Arc::new(MockSynchronizer::default()),
         relayer: Arc::new(MockRelayer::default()),
         payload_builder: Arc::new(MockPayloadBuilder),
@@ -419,7 +420,7 @@ fn import_driver(
     let paths = temp_paths();
     ensure_store_dirs(&paths).unwrap();
     let deps = DriverDeps {
-        catalog: Arc::new(make_catalog()),
+        catalog: Arc::new(RwLock::new(Arc::new(make_catalog()))),
         synchronizer: Arc::new(MockSynchronizer {
             membership_grounded: grounded,
             membership_nullifiers: nullifiers,
@@ -448,6 +449,57 @@ fn test_import_ungrounded_object_is_unknown() {
     let driver = import_driver(HashSet::new(), HashSet::new(), false);
     let summary = driver.import_object(&json).unwrap();
     assert_eq!(summary.status, ObjectStatus::Unknown);
+}
+
+/// A driver with an empty catalog and mock chain deps. `install_plugin` only
+/// touches the actions dir and the catalog, so the mocks are never exercised.
+fn empty_catalog_driver() -> Driver {
+    let paths = temp_paths();
+    ensure_store_dirs(&paths).unwrap();
+    let empty =
+        PexeCatalog::from_bytes(std::iter::empty::<(std::path::PathBuf, Vec<u8>)>(), true).unwrap();
+    let deps = DriverDeps {
+        catalog: Arc::new(RwLock::new(Arc::new(empty))),
+        synchronizer: Arc::new(MockSynchronizer::default()),
+        relayer: Arc::new(MockRelayer::default()),
+        payload_builder: Arc::new(MockPayloadBuilder),
+    };
+    Driver::open(paths, deps).unwrap()
+}
+
+#[test]
+fn install_plugin_writes_and_hot_reloads() {
+    let driver = empty_catalog_driver();
+    assert!(driver.list_actions(None).unwrap().is_empty());
+
+    let name = driver.install_plugin(&test_plugin_bytes()).unwrap();
+    assert_eq!(name, "craft-basics");
+    // Live without a restart...
+    assert!(!driver.list_actions(None).unwrap().is_empty());
+    // ...and the archive landed in the actions dir.
+    assert!(
+        driver
+            .paths()
+            .actions_dir
+            .join("craft-basics.pexe")
+            .exists()
+    );
+}
+
+#[test]
+fn install_plugin_rejects_bad_archive_and_leaves_catalog_intact() {
+    let driver = empty_catalog_driver();
+    let err = driver.install_plugin(b"not a valid pexe").unwrap_err();
+    assert!(
+        err.to_string().contains("archive") || err.to_string().contains("pexe"),
+        "expected an archive error, got: {err}"
+    );
+    // A rejected install must not populate the catalog or leave a file behind.
+    assert!(driver.list_actions(None).unwrap().is_empty());
+    let leftovers = std::fs::read_dir(&driver.paths().actions_dir)
+        .map(|rd| rd.filter_map(|e| e.ok()).count())
+        .unwrap_or(0);
+    assert_eq!(leftovers, 0, "a rejected install left files behind");
 }
 
 #[test]


### PR DESCRIPTION
This adds a `dobj install file|url` command, allowing users to install pexe files easily.

The actual installation is performed by the daemon, which then reloads the catalog - this avoids the need to restart the daemon in order to pick up the new pexe file.