### PR TITLE
run archiver in production

### DIFF
--- a/.github/release-notes.md.tpl
+++ b/.github/release-notes.md.tpl
@@ -26,9 +26,10 @@ rollback) and leaves your plugins under `~/.dobj/actions/` untouched.
 - **`craft-basics.pexe`** — the bundled crafting plugin (Log,
   Wood, Stone, sticks, picks…).
 
-Plus `synchronizer-{target}.tar.gz` and `relayer-{target}.tar.gz` —
-server binaries used by the install-test CI workflow. End users don't
-need these; the installer doesn't fetch them.
+Plus `synchronizer-{target}.tar.gz`, `relayer-{target}.tar.gz`, and
+(Linux/macOS only) `archiver-{target}.tar.gz` — server binaries used by
+the install-test CI workflow. End users don't need these; the installer
+doesn't fetch them.
 
 Targets: `aarch64-apple-darwin`, `x86_64-apple-darwin`,
 `x86_64-unknown-linux-gnu`, `x86_64-pc-windows-msvc`.

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -1,12 +1,13 @@
 name: Images
 
-# Builds the synchronizer and relayer container images and pushes them to GHCR.
+# Builds the synchronizer, relayer, and archiver container images and pushes them
+# to GHCR.
 #
 # Production runs amd64 (most container hosts) and GitHub's
 # Linux runners are amd64, so the build is native - no QEMU emulation. The
 # whole compile happens inside the Dockerfile's debian builder, scoped to
-# `-p synchronizer -p relayer`, so unlike the Rust CI workflows this needs no
-# Tauri/GTK packages on the runner - it only drives buildx.
+# `-p synchronizer -p relayer -p archiver`, so unlike the Rust CI workflows this
+# needs no Tauri/GTK packages on the runner - it only drives buildx.
 
 on:
   push:
@@ -100,6 +101,33 @@ jobs:
           push: true
           tags: ${{ steps.meta-relayer.outputs.tags }}
           labels: ${{ steps.meta-relayer.outputs.labels }}
+          provenance: false
+          cache-from: type=gha,scope=don-build
+          cache-to: type=gha,scope=don-build,mode=max
+
+      - name: Archiver image metadata
+        id: meta-archiver
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ github.repository }}/archiver
+          flavor: |
+            latest=false
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha,prefix=sha-,format=short
+            type=raw,value=latest
+
+      - name: Build and push archiver
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          target: archiver
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta-archiver.outputs.tags }}
+          labels: ${{ steps.meta-archiver.outputs.labels }}
           provenance: false
           cache-from: type=gha,scope=don-build
           cache-to: type=gha,scope=don-build,mode=max

--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -108,10 +108,6 @@ jobs:
       # `secrets` context isn't available in a workflow-level `env` block.
       RPC_URL: ${{ secrets.SEPOLIA_RPC_URL }}
       BEACON_URL: ${{ secrets.SEPOLIA_BEACON_URL }}
-      # The synchronizer reads historical blobs from an archiver. The archiver is
-      # a drop-in beacon-blobs source, so a beacon endpoint serves the recent
-      # blobs this test produces - point ARCHIVER_URL at the same Sepolia beacon.
-      ARCHIVER_URL: ${{ secrets.SEPOLIA_BEACON_URL }}
       TO_ADDRESS: ${{ secrets.SEPOLIA_TO_ADDRESS }}
       # Per-matrix key (see the matrix comment) — dynamic secrets indexing
       # by the name carried in `matrix.pk_secret`.
@@ -321,7 +317,6 @@ jobs:
           INITIAL_START_SLOT="$INITIAL_START_SLOT" \
           RPC_URL="$RPC_URL" \
           BEACON_URL="$BEACON_URL" \
-          ARCHIVER_URL="$ARCHIVER_URL" \
           TO_ADDRESS="$TO_ADDRESS" \
           RPC_RETRIES=10 \
           RPC_RETRY_MS=4000 \
@@ -399,8 +394,8 @@ jobs:
           New-Item -ItemType Directory -Force -Path logs | Out-Null
 
           # Launch the servers HERE (see the note above) so they stay alive
-          # through `dobj run`. RPC_URL/BEACON_URL/ARCHIVER_URL/TO_ADDRESS/PRIVATE_KEY
-          # are job-level env; INITIAL_START_SLOT is inherited from the resolve
+          # through `dobj run`. RPC_URL/BEACON_URL/TO_ADDRESS/PRIVATE_KEY are
+          # job-level env; INITIAL_START_SLOT is inherited from the resolve
           # step via GITHUB_ENV. Both Start-Process children inherit all of
           # those plus the per-server vars set inline below.
           $env:SYNC_METADATA_DB_URL = "postgres://postgres:root@127.0.0.1:5432/synchronizer"

--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -309,7 +309,7 @@ jobs:
       # (dotenvy falls through when there's no .env file in cwd).
       # =====================================================================
 
-      - name: Start synchronizer + relayer (Unix)
+      - name: Start archiver + synchronizer + relayer (Unix)
         if: runner.os != 'Windows'
         shell: bash
         run: |

--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -108,6 +108,10 @@ jobs:
       # `secrets` context isn't available in a workflow-level `env` block.
       RPC_URL: ${{ secrets.SEPOLIA_RPC_URL }}
       BEACON_URL: ${{ secrets.SEPOLIA_BEACON_URL }}
+      # The synchronizer reads historical blobs from an archiver. The archiver is
+      # a drop-in beacon-blobs source, so a beacon endpoint serves the recent
+      # blobs this test produces - point ARCHIVER_URL at the same Sepolia beacon.
+      ARCHIVER_URL: ${{ secrets.SEPOLIA_BEACON_URL }}
       TO_ADDRESS: ${{ secrets.SEPOLIA_TO_ADDRESS }}
       # Per-matrix key (see the matrix comment) — dynamic secrets indexing
       # by the name carried in `matrix.pk_secret`.
@@ -317,6 +321,7 @@ jobs:
           INITIAL_START_SLOT="$INITIAL_START_SLOT" \
           RPC_URL="$RPC_URL" \
           BEACON_URL="$BEACON_URL" \
+          ARCHIVER_URL="$ARCHIVER_URL" \
           TO_ADDRESS="$TO_ADDRESS" \
           RPC_RETRIES=10 \
           RPC_RETRY_MS=4000 \
@@ -394,8 +399,8 @@ jobs:
           New-Item -ItemType Directory -Force -Path logs | Out-Null
 
           # Launch the servers HERE (see the note above) so they stay alive
-          # through `dobj run`. RPC_URL/BEACON_URL/TO_ADDRESS/PRIVATE_KEY are
-          # job-level env; INITIAL_START_SLOT is inherited from the resolve
+          # through `dobj run`. RPC_URL/BEACON_URL/ARCHIVER_URL/TO_ADDRESS/PRIVATE_KEY
+          # are job-level env; INITIAL_START_SLOT is inherited from the resolve
           # step via GITHUB_ENV. Both Start-Process children inherit all of
           # those plus the per-server vars set inline below.
           $env:SYNC_METADATA_DB_URL = "postgres://postgres:root@127.0.0.1:5432/synchronizer"

--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -292,7 +292,7 @@ jobs:
             | python3 -c "import sys, json; print(json.load(sys.stdin)['data']['header']['message']['slot'])")
           START=$((HEAD - 5))
           echo "synchronizer start slot: $START (head $HEAD)"
-          echo "INITIAL_START_SLOT=$START" >> "$GITHUB_ENV"
+          echo "INIT_START_SLOT=$START" >> "$GITHUB_ENV"
 
       - name: Resolve recent Sepolia head slot (Windows)
         if: runner.os == 'Windows'
@@ -302,7 +302,7 @@ jobs:
           $start = [int]$head - 5
           Write-Host "synchronizer start slot: $start (head $head)"
           # -Encoding ascii avoids any BOM that would break the GITHUB_ENV parser.
-          "INITIAL_START_SLOT=$start" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding ascii
+          "INIT_START_SLOT=$start" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding ascii
 
       # =====================================================================
       # Start the local stack. Both binaries read config from process env
@@ -321,7 +321,7 @@ jobs:
           # then point the synchronizer's ARCHIVER_URL at it. On Windows there is
           # no archiver and ARCHIVER_URL is unset, so the synchronizer reads blobs
           # from BEACON_URL instead.
-          INIT_START_SLOT="$INITIAL_START_SLOT" \
+          INIT_START_SLOT="$INIT_START_SLOT" \
           RPC_URL="$RPC_URL" \
           BEACON_URL="$BEACON_URL" \
           FILTER_ADDRESS="$TO_ADDRESS" \
@@ -331,7 +331,7 @@ jobs:
               > logs/archiver.log 2>&1 &
           echo "archiver pid: $!"
 
-          INITIAL_START_SLOT="$INITIAL_START_SLOT" \
+          INIT_START_SLOT="$INIT_START_SLOT" \
           RPC_URL="$RPC_URL" \
           BEACON_URL="$BEACON_URL" \
           ARCHIVER_URL="http://127.0.0.1:3001" \
@@ -413,7 +413,7 @@ jobs:
 
           # Launch the servers HERE (see the note above) so they stay alive
           # through `dobj run`. RPC_URL/BEACON_URL/TO_ADDRESS/PRIVATE_KEY are
-          # job-level env; INITIAL_START_SLOT is inherited from the resolve
+          # job-level env; INIT_START_SLOT is inherited from the resolve
           # step via GITHUB_ENV. Both Start-Process children inherit all of
           # those plus the per-server vars set inline below.
           $env:SYNC_METADATA_DB_URL = "postgres://postgres:root@127.0.0.1:5432/synchronizer"

--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -208,13 +208,21 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p artifacts
+          # The archiver ships on Linux/macOS only (it can't compile on Windows);
+          # the Windows leg skips it and the synchronizer falls back to the beacon.
+          patterns=(
+            --pattern "dobjd-$TARGET.tar.gz"
+            --pattern "dobj-$TARGET.tar.gz"
+            --pattern "synchronizer-$TARGET.tar.gz"
+            --pattern "relayer-$TARGET.tar.gz"
+            --pattern "craft-basics*.pexe"
+          )
+          if [[ "$RUNNER_OS" != "Windows" ]]; then
+            patterns+=(--pattern "archiver-$TARGET.tar.gz")
+          fi
           gh release download "$TAG" \
             --repo dobjlabs/zk-craft-releases \
-            --pattern "dobjd-$TARGET.tar.gz" \
-            --pattern "dobj-$TARGET.tar.gz" \
-            --pattern "synchronizer-$TARGET.tar.gz" \
-            --pattern "relayer-$TARGET.tar.gz" \
-            --pattern "craft-basics*.pexe" \
+            "${patterns[@]}" \
             --dir artifacts
           ls -la artifacts
 
@@ -239,8 +247,11 @@ jobs:
           mkdir -p "$GITHUB_WORKSPACE/server-bin"
           tar -xzf "artifacts/synchronizer-$TARGET.tar.gz" -C "$GITHUB_WORKSPACE/server-bin"
           tar -xzf "artifacts/relayer-$TARGET.tar.gz"      -C "$GITHUB_WORKSPACE/server-bin"
+          # Archiver on Linux/macOS only (this whole step is Unix-gated).
+          tar -xzf "artifacts/archiver-$TARGET.tar.gz"     -C "$GITHUB_WORKSPACE/server-bin"
           chmod +x "$GITHUB_WORKSPACE/server-bin/synchronizer" \
-                   "$GITHUB_WORKSPACE/server-bin/relayer"
+                   "$GITHUB_WORKSPACE/server-bin/relayer" \
+                   "$GITHUB_WORKSPACE/server-bin/archiver"
 
           # dobjd talks to the local stack on loopback. The synchronizer
           # listens on :3000, relayer on :3200 (their defaults).
@@ -314,9 +325,25 @@ jobs:
           set -euo pipefail
           mkdir -p logs
 
+          # Archiver (Linux/macOS only; it can't run on Windows). Start it before
+          # the synchronizer so it has a head start indexing toward chain head,
+          # then point the synchronizer's ARCHIVER_URL at it. On Windows there is
+          # no archiver and ARCHIVER_URL is unset, so the synchronizer reads blobs
+          # from BEACON_URL instead.
+          INIT_START_SLOT="$INITIAL_START_SLOT" \
+          RPC_URL="$RPC_URL" \
+          BEACON_URL="$BEACON_URL" \
+          FILTER_ADDRESS="$TO_ADDRESS" \
+          BLOBS_PATH="$GITHUB_WORKSPACE/archiver-blobs" \
+          HTTP_BIND=127.0.0.1:3001 \
+            nohup "$GITHUB_WORKSPACE/server-bin/archiver" \
+              > logs/archiver.log 2>&1 &
+          echo "archiver pid: $!"
+
           INITIAL_START_SLOT="$INITIAL_START_SLOT" \
           RPC_URL="$RPC_URL" \
           BEACON_URL="$BEACON_URL" \
+          ARCHIVER_URL="http://127.0.0.1:3001" \
           TO_ADDRESS="$TO_ADDRESS" \
           RPC_RETRIES=10 \
           RPC_RETRY_MS=4000 \
@@ -338,7 +365,7 @@ jobs:
 
           # Wait for both HTTP listeners. /healthz on each returns 200 once
           # the server is bound + initialized.
-          for endpoint in http://127.0.0.1:3000/healthz http://127.0.0.1:3200/healthz; do
+          for endpoint in http://127.0.0.1:3001/healthz http://127.0.0.1:3000/healthz http://127.0.0.1:3200/healthz; do
             ok=0
             for i in $(seq 1 90); do
               if curl -fsSL --max-time 2 "$endpoint" >/dev/null 2>&1; then
@@ -471,7 +498,7 @@ jobs:
         if: failure() && runner.os != 'Windows'
         shell: bash
         run: |
-          for name in synchronizer relayer; do
+          for name in archiver synchronizer relayer; do
             echo "--- logs/$name.log (tail 300) ---"
             tail -300 "logs/$name.log" 2>/dev/null || echo "(no log)"
           done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -414,8 +414,6 @@ jobs:
         if: runner.os != 'Windows'
         uses: softprops/action-gh-release@v2
         with:
-          repository: ${{ env.RELEASES_REPO }}
-          token: ${{ secrets.RELEASES_REPO_TOKEN }}
           files: archiver-${{ matrix.target }}.tar.gz
           tag_name: ${{ env.RELEASE_TAG }}
           draft: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -197,6 +197,14 @@ jobs:
         # No rocksdb (sqlx + alloy only), so this builds clean everywhere.
         run: cargo build --release --locked -p relayer --target ${{ matrix.target }}
 
+      - name: Build archiver
+        # Server binary used by install-test on Linux/macOS only. The archiver
+        # indexes blobs on disk via Unix symlinks, so it does not compile on
+        # Windows; install-test's Windows leg leaves ARCHIVER_URL unset and the
+        # synchronizer reads blobs from the beacon instead.
+        if: runner.os != 'Windows'
+        run: cargo build --release --locked -p archiver --target ${{ matrix.target }}
+
       - name: Stage tarball directories
         run: |
           set -euo pipefail
@@ -255,6 +263,16 @@ jobs:
           } >> "$GITHUB_ENV"
           ls -la "$SYNCHRONIZER_STAGE" "$RELAYER_STAGE"
 
+          # Archiver builds on Linux/macOS only (see the build step). Stage it
+          # under the same staging/ root so the macOS notarize bundle picks it up.
+          if [[ "$RUNNER_OS" != "Windows" ]]; then
+            ARCHIVER_STAGE="$GITHUB_WORKSPACE/staging/archiver"
+            mkdir -p "$ARCHIVER_STAGE"
+            cp "$OUT/archiver${{ matrix.exe_suffix }}" "$ARCHIVER_STAGE/"
+            echo "ARCHIVER_STAGE=$ARCHIVER_STAGE" >> "$GITHUB_ENV"
+            ls -la "$ARCHIVER_STAGE"
+          fi
+
       # ---------- macOS codesign + notarize -----------------------------------
 
       - name: Validate macOS signing secrets
@@ -312,11 +330,14 @@ jobs:
             --options runtime --timestamp "$DOBJ_STAGE/dobj"
 
           # Server binaries (used by install-test only) — sign them too
-          # so notarization below doesn't reject the bundle.
+          # so notarization below doesn't reject the bundle. The archiver is
+          # built on macOS (non-Windows), so its stage dir is present here.
           codesign --force --sign "$IDENTITY" \
             --options runtime --timestamp "$SYNCHRONIZER_STAGE/synchronizer"
           codesign --force --sign "$IDENTITY" \
             --options runtime --timestamp "$RELAYER_STAGE/relayer"
+          codesign --force --sign "$IDENTITY" \
+            --options runtime --timestamp "$ARCHIVER_STAGE/archiver"
 
           # Verify each one. `codesign --verify` exits non-zero if anything's
           # off — we want the workflow to fail loudly here rather than ship
@@ -326,6 +347,7 @@ jobs:
           codesign --verify --verbose=2 "$DOBJ_STAGE/dobj"
           codesign --verify --verbose=2 "$SYNCHRONIZER_STAGE/synchronizer"
           codesign --verify --verbose=2 "$RELAYER_STAGE/relayer"
+          codesign --verify --verbose=2 "$ARCHIVER_STAGE/archiver"
 
       - name: Notarize macOS binaries
         if: runner.os == 'macOS'
@@ -358,6 +380,10 @@ jobs:
           tar -czf "dobj-${{ matrix.target }}.tar.gz"         -C "$DOBJ_STAGE"         .
           tar -czf "synchronizer-${{ matrix.target }}.tar.gz" -C "$SYNCHRONIZER_STAGE" .
           tar -czf "relayer-${{ matrix.target }}.tar.gz"      -C "$RELAYER_STAGE"      .
+          # Archiver tarball on Linux/macOS only (no archiver build on Windows).
+          if [[ "$RUNNER_OS" != "Windows" ]]; then
+            tar -czf "archiver-${{ matrix.target }}.tar.gz" -C "$ARCHIVER_STAGE" .
+          fi
 
       - name: Render release notes
         # Substitute DEFAULT_*_URL into the template so the body shown on
@@ -386,6 +412,20 @@ jobs:
           draft: true
           fail_on_unmatched_files: true
           body_path: release-notes.md
+
+      - name: Upload archiver to draft release
+        # Separate step rather than another line in the files: block above:
+        # the archiver tarball exists only on Linux/macOS, and that step sets
+        # fail_on_unmatched_files: true.
+        if: runner.os != 'Windows'
+        uses: softprops/action-gh-release@v2
+        with:
+          repository: ${{ env.RELEASES_REPO }}
+          token: ${{ secrets.RELEASES_REPO_TOKEN }}
+          files: archiver-${{ matrix.target }}.tar.gz
+          tag_name: ${{ env.RELEASE_TAG }}
+          draft: true
+          fail_on_unmatched_files: true
 
   plugin:
     needs: validate

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,8 +47,8 @@ env:
   # Hosted defaults baked into dobjd at compile time (see
   # driver/src/settings.rs::default_settings) AND surfaced in the release
   # notes via envsubst. Change here, both move together.
-  DEFAULT_SYNCHRONIZER_API_URL: https://sync.don.pateldhvani.com
-  DEFAULT_RELAYER_API_URL: https://relay.don.pateldhvani.com
+  DEFAULT_SYNCHRONIZER_API_URL: https://synchronizer.don.pateldhvani.com
+  DEFAULT_RELAYER_API_URL: https://relayer.don.pateldhvani.com
 
 # Releases are drafts on this repo until manually published (drafts are
 # invisible to the public until then). Top-level stays read-only; the jobs

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,14 @@
 # syntax=docker/dockerfile:1
 
-# Builds the two headless server binaries into separate, minimal images that
-# share one cooked dependency layer. Build either one independently:
+# Builds the three headless server binaries into separate, minimal images that
+# share one cooked dependency layer. Build any one independently:
 #
 #   docker build --target synchronizer -t don/synchronizer .
 #   docker build --target relayer      -t don/relayer .
+#   docker build --target archiver     -t don/archiver .
 #
-# --target synchronizer compiles only the synchronizer binary (and vice versa);
-# the expensive dependency compile is cooked once and reused by both.
+# --target synchronizer compiles only the synchronizer binary (and so on); the
+# expensive dependency compile is cooked once and reused by all three.
 
 # ---- chef: pinned toolchain + cargo-chef, shared by every build stage ----
 # Build and run on the same Debian release so the binary's glibc, libssl, and
@@ -40,13 +41,13 @@ RUN cargo chef prepare --recipe-path recipe.json
 
 # ---- cook: compile the shared dependency graph once ----
 # pod2 + plonky2 + rocksdb + alloy dominate build time. Cooking them here makes
-# a cached layer both services reuse, which only changes when a dependency
+# a cached layer all three services reuse, which only changes when a dependency
 # changes. The -p scope also keeps the Tauri desktop crate (interfaces/gui/src-tauri,
 # which needs GTK/WebKit) out of the build entirely.
 FROM chef AS cook
 COPY --from=planner /app/recipe.json recipe.json
 RUN cargo chef cook --release --recipe-path recipe.json \
-      -p synchronizer -p relayer
+      -p synchronizer -p relayer -p archiver
 
 # ---- per-service builds: each target compiles only its own binary ----
 # Each logs the binary's dynamic deps so a dependency bump that pulls in a new
@@ -61,12 +62,17 @@ COPY . .
 RUN cargo build --release --locked -p relayer
 RUN echo "--- relayer ldd ---" && ldd target/release/relayer || true
 
+FROM cook AS build-archiver
+COPY . .
+RUN cargo build --release --locked -p archiver
+RUN echo "--- archiver ldd ---" && ldd target/release/archiver || true
+
 # ---- runtime base: shared minimal runtime, non-root user ----
-# Runtime libraries both binaries dynamically link, confirmed via the ldd output
-# above: TLS (libssl3 provides libssl + libcrypto), zlib and zstd (rocksdb and
-# others), and libgcc. ca-certificates verifies TLS to the Ethereum endpoints
+# Runtime libraries the service binaries dynamically link, confirmed via the ldd
+# output above: TLS (libssl3 provides libssl + libcrypto), zlib and zstd (rocksdb
+# and others), and libgcc. ca-certificates verifies TLS to the Ethereum endpoints
 # and Postgres. All of these package names exist on amd64 and arm64. The service
-# user gets a fixed uid/gid so the synchronizer volume's ownership survives image
+# user gets a fixed uid/gid so the mounted volumes' ownership survives image
 # rebuilds and upgrades.
 FROM debian:trixie-slim AS runtime
 ENV DEBIAN_FRONTEND=noninteractive
@@ -103,3 +109,20 @@ ENV HTTP_BIND=0.0.0.0:3200
 USER don
 EXPOSE 3200
 ENTRYPOINT ["/usr/local/bin/relayer"]
+
+# ---- archiver image ----
+# Like the relayer, the archiver links no C++ runtime (it pulls in neither
+# rocksdb nor any other C++ dependency), so the shared runtime base is enough.
+# But it keeps a durable on-disk blob store instead of using Postgres, so it
+# mounts a volume the way the synchronizer does.
+FROM runtime AS archiver
+COPY --from=build-archiver /app/target/release/archiver /usr/local/bin/archiver
+RUN mkdir -p /var/lib/don && chown -R don:don /var/lib/don
+# BLOBS_PATH lives under the mounted volume so the archive survives restarts
+# instead of re-downloading from the chain on every boot.
+ENV HTTP_BIND=0.0.0.0:3001 \
+    BLOBS_PATH=/var/lib/don/blobs
+VOLUME ["/var/lib/don"]
+USER don
+EXPOSE 3001
+ENTRYPOINT ["/usr/local/bin/archiver"]

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -15,9 +15,10 @@ RPC_URL=https://YOUR_EXECUTION_RPC
 # Beacon (consensus) API with blob sidecars. Used by the synchronizer and archiver.
 BEACON_URL=https://YOUR_BEACON_API
 
-# Beacon slot the archiver starts from. It durably stores every matching blob from
-# this slot forward; pick one at or before the earliest blob you need to retain.
-# Required when running the archiver.
+# Beacon slot the synchronizer and archiver start from on first run. The archiver
+# durably stores every matching blob from this slot forward; the synchronizer
+# builds state from this slot forward. Pick one at or before the earliest blob you
+# need to retain. Required when running either service.
 INIT_START_SLOT=YOUR_START_SLOT
 
 # Relayer hot wallet: signs and pays for EIP-4844 blob txs. ONLY needed if you

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -5,14 +5,20 @@
 # published image.
 IMAGE_TAG=latest
 
-# Shared: the L1 address blob txs are sent to / filtered on.
+# Shared: the L1 address blob txs are sent to / filtered on. All three services
+# use it (the archiver reads it as FILTER_ADDRESS).
 TO_ADDRESS=0xYOUR_TARGET_ADDRESS
 
-# Execution-layer RPC. Used by both services.
+# Execution-layer RPC. Used by all three services.
 RPC_URL=https://YOUR_EXECUTION_RPC
 
-# Beacon (consensus) API with blob sidecars. Synchronizer only.
+# Beacon (consensus) API with blob sidecars. Used by the synchronizer and archiver.
 BEACON_URL=https://YOUR_BEACON_API
+
+# Beacon slot the archiver starts from. It durably stores every matching blob from
+# this slot forward; pick one at or before the earliest blob you need to retain.
+# Required when running the archiver.
+INIT_START_SLOT=YOUR_START_SLOT
 
 # Relayer hot wallet: signs and pays for EIP-4844 blob txs. ONLY needed if you
 # run the relayer; a synchronizer-only (verify) node can leave this unset.
@@ -25,6 +31,10 @@ POSTGRES_PASSWORD=change-me
 # managed/external Postgres instead, set these to full connection URLs.
 # SYNC_METADATA_DB_URL=postgres://user:pass@host:5432/synchronizer
 # DB_URL=postgres://user:pass@host:5432/relayer
+
+# Archiver the synchronizer reads historical blobs from (optional): defaults to
+# the bundled archiver. Set to point the synchronizer at an external archiver.
+# ARCHIVER_URL=http://archiver:3001
 
 # Optional log filter.
 RUST_LOG=info

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,13 +1,14 @@
-# Run the synchronizer and relayer
+# Run the synchronizer, relayer, and archiver
 
-Both services ship as published container images:
+All three services ship as published container images:
 
 - `ghcr.io/dobjlabs/digital-objects-network/synchronizer`
 - `ghcr.io/dobjlabs/digital-objects-network/relayer`
+- `ghcr.io/dobjlabs/digital-objects-network/archiver`
 
-Run the full stack, or just a **synchronizer** to independently verify the
-network's canonical state from Ethereum chain data without trusting anyone
-else's instance.
+Run the full stack, or just a **synchronizer** (with its **archiver**) to
+independently verify the network's canonical state from Ethereum chain data
+without trusting anyone else's instance.
 
 ## Quick start
 
@@ -16,12 +17,13 @@ cp deploy/.env.example deploy/.env   # fill in your endpoints
 docker compose -f deploy/compose.yaml up -d
 ```
 
-This brings up Postgres plus both services. Check them:
+This brings up Postgres plus all three services. Check them:
 
 ```bash
 curl localhost:3000/healthz         # synchronizer up
 curl localhost:3000/sync-progress   # is it following chain head?
 curl localhost:3200/healthz         # relayer up
+curl localhost:3001/healthz         # archiver up
 ```
 
 (Requires the published images. If they aren't published yet, build them
@@ -29,8 +31,9 @@ locally first - see "Building the images yourself" below.)
 
 ### Just a synchronizer (verify-only)
 
-A synchronizer needs only an execution RPC, a beacon endpoint, and Postgres -
-no wallet key. Run only those services:
+A synchronizer needs an execution RPC, a beacon endpoint, Postgres, and an
+**archiver** (for blobs older than the chain's ~18-day retention) - no wallet
+key. Compose pulls the archiver in automatically via `depends_on`:
 
 ```bash
 docker compose -f deploy/compose.yaml up -d synchronizer postgres
@@ -38,7 +41,8 @@ docker compose -f deploy/compose.yaml up -d synchronizer postgres
 
 Or fully standalone against your own Postgres, no compose. Create the
 `synchronizer` database first - the service creates its tables, but not the
-database:
+database. The synchronizer requires `ARCHIVER_URL`; point it at an archiver you
+run or a hosted one:
 
 ```bash
 psql "postgres://user:pass@host:5432/postgres" -c 'CREATE DATABASE synchronizer'
@@ -47,9 +51,23 @@ docker run -d --name synchronizer -p 3000:3000 \
   -e RPC_URL=https://your-execution-rpc \
   -e BEACON_URL=https://your-beacon-api \
   -e TO_ADDRESS=0x... \
+  -e ARCHIVER_URL=http://your-archiver:3001 \
   -e SYNC_METADATA_DB_URL=postgres://user:pass@host:5432/synchronizer \
   -v don_data:/var/lib/don \
   ghcr.io/dobjlabs/digital-objects-network/synchronizer:latest
+```
+
+To run an archiver standalone, give it the same target address (as
+`FILTER_ADDRESS`), a start slot, and a volume for its on-disk blob store:
+
+```bash
+docker run -d --name archiver -p 3001:3001 \
+  -e RPC_URL=https://your-execution-rpc \
+  -e BEACON_URL=https://your-beacon-api \
+  -e FILTER_ADDRESS=0x... \
+  -e INIT_START_SLOT=10413441 \
+  -v don_blobs:/var/lib/don \
+  ghcr.io/dobjlabs/digital-objects-network/archiver:latest
 ```
 
 ## Configuration
@@ -58,27 +76,34 @@ Set via `.env` (compose) or `-e` flags (`docker run`). Image defaults:
 `HTTP_BIND=0.0.0.0:<port>`, and the synchronizer's
 `APP_STATE_DB_PATH=/var/lib/don/synchronizer-db`.
 
-| Variable               | Service      | Required     | Notes                                                             |
-| ---------------------- | ------------ | ------------ | ----------------------------------------------------------------- |
-| `RPC_URL`              | both         | yes          | Execution-layer RPC                                               |
-| `BEACON_URL`           | synchronizer | yes          | Beacon API with blob sidecars                                     |
-| `TO_ADDRESS`           | both         | yes          | L1 target address; must match across both                         |
-| `PRIVATE_KEY`          | relayer      | relayer only | Hot wallet that signs/pays for blob txs                           |
-| `SYNC_METADATA_DB_URL` | synchronizer | no           | Defaults to the bundled Postgres; set to point at an external one |
-| `DB_URL`               | relayer      | no           | Defaults to the bundled Postgres; set to point at an external one |
-| `IMAGE_TAG`            | compose      | no           | Image tag to run; pin to a release                                |
-| `APP_STATE_DB_PATH`    | synchronizer | no           | RocksDB cache path; mount a volume here                           |
-| `HTTP_BIND`            | both         | no           | Defaults to `0.0.0.0:3000` / `0.0.0.0:3200`                       |
-| `RUST_LOG`             | both         | no           | e.g. `info`                                                       |
+| Variable               | Service                | Required      | Notes                                                                       |
+| ---------------------- | ---------------------- | ------------- | --------------------------------------------------------------------------- |
+| `RPC_URL`              | all                    | yes           | Execution-layer RPC                                                         |
+| `BEACON_URL`           | synchronizer, archiver | yes           | Beacon API with blob sidecars                                              |
+| `TO_ADDRESS`           | all                    | yes           | L1 target address; must match across services (archiver reads `FILTER_ADDRESS`) |
+| `INIT_START_SLOT`      | archiver               | archiver only | Beacon slot the archiver starts archiving from                             |
+| `PRIVATE_KEY`          | relayer                | relayer only  | Hot wallet that signs/pays for blob txs                                    |
+| `ARCHIVER_URL`         | synchronizer           | no            | Archiver for historical blobs; compose defaults to the bundled archiver     |
+| `SYNC_METADATA_DB_URL` | synchronizer           | no            | Defaults to the bundled Postgres; set to point at an external one          |
+| `DB_URL`               | relayer                | no            | Defaults to the bundled Postgres; set to point at an external one          |
+| `BLOBS_PATH`           | archiver               | no            | On-disk blob store path; mount a volume here                               |
+| `IMAGE_TAG`            | compose                | no            | Image tag to run; pin to a release                                         |
+| `APP_STATE_DB_PATH`    | synchronizer           | no            | RocksDB cache path; mount a volume here                                    |
+| `HTTP_BIND`            | all                    | no            | Defaults to `0.0.0.0:3000` / `:3200` / `:3001`                             |
+| `RUST_LOG`             | all                    | no            | e.g. `info`                                                                |
 
 The synchronizer's `/var/lib/don` holds RocksDB - a rebuildable cache (the
 authoritative state lives in Postgres), but mounting a volume avoids a slow cold
-re-sync on restart. The relayer keeps no local state.
+re-sync on restart. The relayer keeps no local state. The archiver's
+`/var/lib/don` holds its blob store on disk (no database); mount a volume so
+the archive survives restarts instead of re-downloading from the chain.
 
 ## Operational notes
 
-- Both services are **singletons**. Never run two of either against the same
-  database (the relayer collides on nonces; the synchronizer on slot commits).
+- Each service is a **singleton** in a single deployment. Never run two against
+  the same database or volume (the relayer collides on nonces, the synchronizer
+  on slot commits, the archiver on its blob-store directory). The network can
+  have many independent archivers; just never point two at one volume.
 - **Pin `IMAGE_TAG`** to a release (e.g. `v0.1.0`) for reproducible runs.
 - **Hardened production:** point `SYNC_METADATA_DB_URL` / `DB_URL` at a managed
   Postgres (the synchronizer's state is authoritative - back it up) and inject
@@ -93,5 +118,6 @@ the names the compose expects and point `IMAGE_TAG` at your tag:
 ```bash
 docker build --target synchronizer -t ghcr.io/dobjlabs/digital-objects-network/synchronizer:dev .
 docker build --target relayer      -t ghcr.io/dobjlabs/digital-objects-network/relayer:dev .
+docker build --target archiver     -t ghcr.io/dobjlabs/digital-objects-network/archiver:dev .
 # then set IMAGE_TAG=dev in deploy/.env
 ```

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -76,21 +76,21 @@ Set via `.env` (compose) or `-e` flags (`docker run`). Image defaults:
 `HTTP_BIND=0.0.0.0:<port>`, and the synchronizer's
 `APP_STATE_DB_PATH=/var/lib/don/synchronizer-db`.
 
-| Variable               | Service                | Required      | Notes                                                                       |
-| ---------------------- | ---------------------- | ------------- | --------------------------------------------------------------------------- |
-| `RPC_URL`              | all                    | yes           | Execution-layer RPC                                                         |
-| `BEACON_URL`           | synchronizer, archiver | yes           | Beacon API with blob sidecars                                              |
-| `TO_ADDRESS`           | all                    | yes           | L1 target address; must match across services (archiver reads `FILTER_ADDRESS`) |
-| `INIT_START_SLOT`      | archiver               | archiver only | Beacon slot the archiver starts archiving from                             |
-| `PRIVATE_KEY`          | relayer                | relayer only  | Hot wallet that signs/pays for blob txs                                    |
-| `ARCHIVER_URL`         | synchronizer           | no            | Blobs older than beacon retention; unset, falls back to `BEACON_URL`        |
-| `SYNC_METADATA_DB_URL` | synchronizer           | no            | Defaults to the bundled Postgres; set to point at an external one          |
-| `DB_URL`               | relayer                | no            | Defaults to the bundled Postgres; set to point at an external one          |
-| `BLOBS_PATH`           | archiver               | no            | On-disk blob store path; mount a volume here                               |
-| `IMAGE_TAG`            | compose                | no            | Image tag to run; pin to a release                                         |
-| `APP_STATE_DB_PATH`    | synchronizer           | no            | RocksDB cache path; mount a volume here                                    |
-| `HTTP_BIND`            | all                    | no            | Defaults to `0.0.0.0:3000` / `:3200` / `:3001`                             |
-| `RUST_LOG`             | all                    | no            | e.g. `info`                                                                |
+| Variable               | Service                | Required     | Notes                                                                           |
+| ---------------------- | ---------------------- | ------------ | ------------------------------------------------------------------------------- |
+| `RPC_URL`              | all                    | yes          | Execution-layer RPC                                                             |
+| `BEACON_URL`           | synchronizer, archiver | yes          | Beacon API with blob sidecars                                                   |
+| `TO_ADDRESS`           | all                    | yes          | L1 target address; must match across services (archiver reads `FILTER_ADDRESS`) |
+| `INIT_START_SLOT`      | synchronizer, archiver | yes          | Beacon slot both services start from on first run                               |
+| `PRIVATE_KEY`          | relayer                | relayer only | Hot wallet that signs/pays for blob txs                                         |
+| `ARCHIVER_URL`         | synchronizer           | no           | Blobs older than beacon retention; unset, falls back to `BEACON_URL`            |
+| `SYNC_METADATA_DB_URL` | synchronizer           | no           | Defaults to the bundled Postgres; set to point at an external one               |
+| `DB_URL`               | relayer                | no           | Defaults to the bundled Postgres; set to point at an external one               |
+| `BLOBS_PATH`           | archiver               | no           | On-disk blob store path; mount a volume here                                    |
+| `IMAGE_TAG`            | compose                | no           | Image tag to run; pin to a release                                              |
+| `APP_STATE_DB_PATH`    | synchronizer           | no           | RocksDB cache path; mount a volume here                                         |
+| `HTTP_BIND`            | all                    | no           | Defaults to `0.0.0.0:3000` / `:3200` / `:3001`                                  |
+| `RUST_LOG`             | all                    | no           | e.g. `info`                                                                     |
 
 The synchronizer's `/var/lib/don` holds RocksDB - a rebuildable cache (the
 authoritative state lives in Postgres), but mounting a volume avoids a slow cold

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -31,9 +31,10 @@ locally first - see "Building the images yourself" below.)
 
 ### Just a synchronizer (verify-only)
 
-A synchronizer needs an execution RPC, a beacon endpoint, Postgres, and an
-**archiver** (for blobs older than the chain's ~18-day retention) - no wallet
-key. Compose pulls the archiver in automatically via `depends_on`:
+A synchronizer needs an execution RPC, a beacon endpoint, and Postgres - no
+wallet key. With just those it reads blobs from the beacon (recent blobs only).
+To sync history older than the beacon's ~18-day retention, also run an
+**archiver** and point `ARCHIVER_URL` at it. The bundled compose includes one:
 
 ```bash
 docker compose -f deploy/compose.yaml up -d synchronizer postgres
@@ -41,8 +42,8 @@ docker compose -f deploy/compose.yaml up -d synchronizer postgres
 
 Or fully standalone against your own Postgres, no compose. Create the
 `synchronizer` database first - the service creates its tables, but not the
-database. The synchronizer requires `ARCHIVER_URL`; point it at an archiver you
-run or a hosted one:
+database. `ARCHIVER_URL` is optional: unset, the synchronizer reads blobs from
+`BEACON_URL` (recent blobs only); set it to an archiver for older history:
 
 ```bash
 psql "postgres://user:pass@host:5432/postgres" -c 'CREATE DATABASE synchronizer'
@@ -51,7 +52,6 @@ docker run -d --name synchronizer -p 3000:3000 \
   -e RPC_URL=https://your-execution-rpc \
   -e BEACON_URL=https://your-beacon-api \
   -e TO_ADDRESS=0x... \
-  -e ARCHIVER_URL=http://your-archiver:3001 \
   -e SYNC_METADATA_DB_URL=postgres://user:pass@host:5432/synchronizer \
   -v don_data:/var/lib/don \
   ghcr.io/dobjlabs/digital-objects-network/synchronizer:latest
@@ -83,7 +83,7 @@ Set via `.env` (compose) or `-e` flags (`docker run`). Image defaults:
 | `TO_ADDRESS`           | all                    | yes           | L1 target address; must match across services (archiver reads `FILTER_ADDRESS`) |
 | `INIT_START_SLOT`      | archiver               | archiver only | Beacon slot the archiver starts archiving from                             |
 | `PRIVATE_KEY`          | relayer                | relayer only  | Hot wallet that signs/pays for blob txs                                    |
-| `ARCHIVER_URL`         | synchronizer           | no            | Archiver for historical blobs; compose defaults to the bundled archiver     |
+| `ARCHIVER_URL`         | synchronizer           | no            | Blobs older than beacon retention; unset, falls back to `BEACON_URL`        |
 | `SYNC_METADATA_DB_URL` | synchronizer           | no            | Defaults to the bundled Postgres; set to point at an external one          |
 | `DB_URL`               | relayer                | no            | Defaults to the bundled Postgres; set to point at an external one          |
 | `BLOBS_PATH`           | archiver               | no            | On-disk blob store path; mount a volume here                               |

--- a/deploy/compose.yaml
+++ b/deploy/compose.yaml
@@ -39,6 +39,8 @@ services:
       RUST_LOG: ${RUST_LOG:-info}
       HTTP_BIND: 0.0.0.0:3000
       APP_STATE_DB_PATH: /var/lib/don/synchronizer-db
+      # INIT_START_SLOT (first-run start slot) comes from .env via env_file above,
+      # shared with the archiver so both start from the same slot.
       # Bundled Postgres by default; set SYNC_METADATA_DB_URL in .env to override
       # (e.g. a managed/external Postgres).
       SYNC_METADATA_DB_URL: ${SYNC_METADATA_DB_URL:-postgres://postgres:${POSTGRES_PASSWORD:-postgres}@postgres:5432/synchronizer}

--- a/deploy/compose.yaml
+++ b/deploy/compose.yaml
@@ -1,14 +1,15 @@
-# Self-host stack for the synchronizer and relayer: pulls the published GHCR
-# images and runs each as a single instance with a bundled Postgres. Run both,
-# or just the synchronizer to verify network state from chain data yourself:
+# Self-host stack for the synchronizer, relayer, and archiver: pulls the
+# published GHCR images and runs each as a single instance with a bundled
+# Postgres. Run the full stack, or just the synchronizer to verify network state
+# from chain data yourself (its archiver comes along via depends_on):
 #
 #   cp deploy/.env.example deploy/.env    # fill in your endpoints
 #   docker compose -f deploy/compose.yaml up -d
 #   docker compose -f deploy/compose.yaml up -d synchronizer postgres   # verify-only
 #
-# The images must be published (or built locally - see README.md). Both services
-# are singletons: never scale either past one replica per database. For hardened
-# production (managed Postgres, secret-store key) see README.md.
+# The images must be published (or built locally - see README.md). Each service
+# is a singleton: never scale one past a single replica per database/volume. For
+# hardened production (managed Postgres, secret-store key) see README.md.
 name: don
 
 services:
@@ -41,6 +42,9 @@ services:
       # Bundled Postgres by default; set SYNC_METADATA_DB_URL in .env to override
       # (e.g. a managed/external Postgres).
       SYNC_METADATA_DB_URL: ${SYNC_METADATA_DB_URL:-postgres://postgres:${POSTGRES_PASSWORD:-postgres}@postgres:5432/synchronizer}
+      # Historical blobs (older than the chain's ~18-day retention) are read from
+      # the archiver. Defaults to the bundled one; override to use an external one.
+      ARCHIVER_URL: ${ARCHIVER_URL:-http://archiver:3001}
     volumes:
       - syncdata:/var/lib/don
     ports:
@@ -48,6 +52,8 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+      archiver:
+        condition: service_started
 
   relayer:
     image: ghcr.io/dobjlabs/digital-objects-network/relayer:${IMAGE_TAG:-latest}
@@ -64,9 +70,27 @@ services:
       postgres:
         condition: service_healthy
 
+  archiver:
+    image: ghcr.io/dobjlabs/digital-objects-network/archiver:${IMAGE_TAG:-latest}
+    restart: unless-stopped
+    env_file: .env
+    environment:
+      RUST_LOG: ${RUST_LOG:-info}
+      HTTP_BIND: 0.0.0.0:3001
+      BLOBS_PATH: /var/lib/don/blobs
+      # The archiver filters blobs by their L1 destination; this is the same
+      # address the other services call TO_ADDRESS. RPC_URL, BEACON_URL, and
+      # INIT_START_SLOT come from .env via env_file above.
+      FILTER_ADDRESS: ${TO_ADDRESS}
+    volumes:
+      - archiverdata:/var/lib/don
+    ports:
+      - "3001:3001"
+
 volumes:
   pgdata:
   syncdata:
+  archiverdata:
 
 configs:
   init-databases:

--- a/justfile
+++ b/justfile
@@ -70,7 +70,7 @@ wait-health URL:
 # Idempotently point ~/.dobj/settings.json at the hosted synchronizer + relayer
 ensure-remote-settings:
     @mkdir -p ~/.dobj
-    @printf '{"synchronizerApiUrl":"https://sync.don.pateldhvani.com","relayerApiUrl":"https://relay.don.pateldhvani.com"}\n' > ~/.dobj/settings.json
+    @printf '{"synchronizerApiUrl":"https://synchronizer.don.pateldhvani.com","relayerApiUrl":"https://relayer.don.pateldhvani.com"}\n' > ~/.dobj/settings.json
     @echo "~/.dobj/settings.json → hosted sync + relayer"
 
 # Install plugins into ~/.dobj/actions/ if none are present. Runs as part of

--- a/justfile
+++ b/justfile
@@ -40,7 +40,7 @@ dobjd:
 # shell — all backed by one dobjd process. Open http://localhost:1420 in a
 # browser to use the website client; the desktop window opens automatically.
 # https://github.com/pvolok/mprocs
-dev: ensure-db ensure-plugins ensure-mcp
+dev: ensure-db ensure-start-slot ensure-plugins ensure-mcp
     mprocs --config mprocs.yaml
 
 # Like `just dev`, but without spawning the local synchronizer + relayer —
@@ -104,13 +104,83 @@ ensure-db:
     @psql postgres://postgres@localhost:5432/postgres -tAc "SELECT 1 FROM pg_database WHERE datname='synchronizer'" | grep -q 1 || psql postgres://postgres@localhost:5432/postgres -c 'CREATE DATABASE synchronizer'
     @psql postgres://postgres@localhost:5432/postgres -tAc "SELECT 1 FROM pg_database WHERE datname='relayer'" | grep -q 1 || psql postgres://postgres@localhost:5432/postgres -c 'CREATE DATABASE relayer'
 
-# Wipe local state (RocksDB + local Postgres DBs + objects)
+# Point the synchronizer + archiver at the current chain head on a *fresh* start.
+# Both require INIT_START_SLOT but use it only when their store is empty (they
+# resume from on-disk progress otherwise), so we rewrite a service's .env to the
+# current beacon head when its db is absent, or when INIT_START_SLOT is unset (the
+# var is required, so a resumed service still needs *some* value). Runs as part of
+# `just dev`; a no-op once each db exists and the var is set.
+ensure-start-slot:
+    #!/usr/bin/env bash
+    set -uo pipefail
+
+    read_env() {  # <file> <KEY> -> value (uncommented only, quotes/space stripped)
+        local file="$1" key="$2" line
+        [ -f "$file" ] || return 0
+        line="$(grep -E "^[[:space:]]*${key}=" "$file" | tail -n1 || true)"
+        [ -n "$line" ] || return 0
+        printf '%s' "${line#*=}" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' -e 's/^"//' -e 's/"$//' -e "s/^'//" -e "s/'\$//"
+    }
+
+    set_env() {  # <file> <KEY> <VALUE> -> upsert, dropping any prior commented/plain line
+        local file="$1" key="$2" val="$3" tmp
+        tmp="$(mktemp)"
+        grep -vE "^[[:space:]]*#?[[:space:]]*${key}=" "$file" > "$tmp" 2>/dev/null || true
+        echo "${key}=${val}" >> "$tmp"
+        mv "$tmp" "$file"
+    }
+
+    head_slot() {  # <beacon_url> -> head slot number
+        local beacon="${1%/}" json
+        json="$(curl -fsSL "${beacon}/eth/v1/beacon/headers/head")" || return 1
+        if command -v jq >/dev/null 2>&1; then
+            printf '%s' "$json" | jq -r '.data.header.message.slot'
+        else
+            printf '%s' "$json" | python3 -c "import sys,json;print(json.load(sys.stdin)['data']['header']['message']['slot'])"
+        fi
+    }
+
+    ensure_slot() {  # <label> <env_file> <fresh:true|false>
+        local label="$1" env="$2" fresh="$3" cur beacon slot
+        if [ ! -f "$env" ]; then echo "$label: $env missing; skipping"; return 0; fi
+        cur="$(read_env "$env" INIT_START_SLOT)"
+        if [ "$fresh" = "false" ] && [ -n "$cur" ]; then
+            echo "$label: resuming; INIT_START_SLOT=$cur unchanged"; return 0
+        fi
+        beacon="$(read_env "$env" BEACON_URL)"
+        if [ -z "$beacon" ]; then echo "$label: no BEACON_URL in $env; leaving INIT_START_SLOT as-is"; return 0; fi
+        slot="$(head_slot "$beacon" 2>/dev/null || true)"
+        if [[ "$slot" =~ ^[0-9]+$ ]]; then
+            set_env "$env" INIT_START_SLOT "$slot"
+            echo "$label: INIT_START_SLOT -> $slot (head)"
+        else
+            echo "$label: could not resolve beacon head; leaving INIT_START_SLOT as-is"
+        fi
+    }
+
+    sync_db="$(read_env services/synchronizer/.env APP_STATE_DB_PATH)"; sync_db="${sync_db:-data/synchronizer-db}"
+    [ -d "$sync_db" ] && sync_fresh=false || sync_fresh=true
+    ensure_slot synchronizer services/synchronizer/.env "$sync_fresh"
+
+    blobs="$(read_env services/archiver/.env BLOBS_PATH)"; blobs="${blobs:-/tmp/blobs/}"
+    [ -d "${blobs%/}/by_slot" ] && arch_fresh=false || arch_fresh=true
+    ensure_slot archiver services/archiver/.env "$arch_fresh"
+
+# Wipe local state (RocksDB + local Postgres DBs + objects + archiver blobs)
 reset:
-    @[ -x ~/.dobj/bin/dobj ] && ~/.dobj/bin/dobj stop || true
+    #!/usr/bin/env bash
+    set -uo pipefail
+    [ -x ~/.dobj/bin/dobj ] && ~/.dobj/bin/dobj stop || true
     rm -rf data/ ~/.dobj
-    @command -v claude >/dev/null 2>&1 && claude mcp remove dobj 2>/dev/null && echo "removed: dobj MCP registration" || true
-    psql postgres://postgres@localhost:5432/postgres -c 'DROP DATABASE IF EXISTS synchronizer;'
-    psql postgres://postgres@localhost:5432/postgres -c 'DROP DATABASE IF EXISTS relayer;'
+    command -v claude >/dev/null 2>&1 && claude mcp remove dobj 2>/dev/null && echo "removed: dobj MCP registration" || true
+    psql postgres://postgres@localhost:5432/postgres -c 'DROP DATABASE IF EXISTS synchronizer;' || true
+    psql postgres://postgres@localhost:5432/postgres -c 'DROP DATABASE IF EXISTS relayer;' || true
+    blobs="$(sed -n 's/^[[:space:]]*BLOBS_PATH=//p' services/archiver/.env 2>/dev/null | tail -n1 | tr -d '"' | sed 's/[[:space:]]*$//')"
+    blobs="${blobs:-/tmp/blobs/}"
+    case "$blobs" in
+        /|"") echo "refusing to rm blobs path '$blobs'" ;;
+        *) rm -rf "$blobs" && echo "removed archiver blobs: $blobs" ;;
+    esac
 
 # Run all tests (except ignored)
 test:

--- a/services/archiver/src/config.rs
+++ b/services/archiver/src/config.rs
@@ -1,7 +1,7 @@
 use std::{net::SocketAddr, str::FromStr};
 
 use alloy::primitives::Address;
-use anyhow::Result;
+use anyhow::{Context, Result};
 
 const DEFAULT_HTTP_BIND: &str = "127.0.0.1:3001";
 
@@ -23,10 +23,10 @@ pub fn load_config() -> Result<Config> {
     let http_bind: SocketAddr = http_bind.parse()?;
 
     let blobs_path = dotenvy::var("BLOBS_PATH").unwrap();
-    let init_start_slot = dotenvy::var("INIT_START_SLOT")
-        .ok()
-        .and_then(|v| v.parse::<u32>().ok())
-        .unwrap();
+    let init_start_slot: u32 = dotenvy::var("INIT_START_SLOT")
+        .context("INIT_START_SLOT must be set (beacon slot to start archiving from)")?
+        .parse()
+        .context("INIT_START_SLOT must be a valid u32 beacon slot")?;
 
     let rpc_url: String = dotenvy::var("RPC_URL")?;
     let beacon_url: String = dotenvy::var("BEACON_URL")?;

--- a/services/dobjd/README.md
+++ b/services/dobjd/README.md
@@ -122,8 +122,8 @@ Read on every `load_settings()` call from `~/.dobj/settings.json`:
 
 ```json
 {
-  "synchronizerApiUrl": "https://sync.don.pateldhvani.com",
-  "relayerApiUrl": "https://relay.don.pateldhvani.com"
+  "synchronizerApiUrl": "https://synchronizer.don.pateldhvani.com",
+  "relayerApiUrl": "https://relayer.don.pateldhvani.com"
 }
 ```
 

--- a/services/synchronizer/.env.example
+++ b/services/synchronizer/.env.example
@@ -2,6 +2,10 @@
 RPC_URL=https://ethereum-sepolia-rpc.publicnode.com
 BEACON_URL=https://ethereum-sepolia-beacon-api.publicnode.com
 TO_ADDRESS=0x4343434343434343434343434343434343434343
+# Beacon slot to start syncing from on first run; resumed from stored progress
+# afterward. `just dev` overwrites this with the current head when starting fresh
+# (no synchronizer db yet).
+INIT_START_SLOT=10413441
 
 # Optional (shown with their defaults)
 # Blob source. Defaults to BEACON_URL (recent blobs only); set to an archiver to
@@ -12,7 +16,6 @@ TO_ADDRESS=0x4343434343434343434343434343434343434343
 # SYNC_METADATA_DB_URL=postgres://postgres@localhost:5432/synchronizer
 # RPC_RETRIES=6
 # RPC_RETRY_MS=1000
-# INITIAL_START_SLOT=
 
 # Rate-limit-aware defaults (derived from 15 req/s RPC limit):
 # SYNC_DELAY_MS=173          # delay between slots at head; override with caution

--- a/services/synchronizer/.env.example
+++ b/services/synchronizer/.env.example
@@ -1,10 +1,12 @@
 # Required
 RPC_URL=https://ethereum-sepolia-rpc.publicnode.com
 BEACON_URL=https://ethereum-sepolia-beacon-api.publicnode.com
-ARCHIVER_URL=https://ethereum-sepolia-beacon-api.publicnode.com
 TO_ADDRESS=0x4343434343434343434343434343434343434343
 
 # Optional (shown with their defaults)
+# Blob source. Defaults to BEACON_URL (recent blobs only); set to an archiver to
+# read blobs older than the beacon's retention window.
+# ARCHIVER_URL=https://ethereum-sepolia-beacon-api.publicnode.com
 # HTTP_BIND=127.0.0.1:3000
 # APP_STATE_DB_PATH=data/synchronizer-db
 # SYNC_METADATA_DB_URL=postgres://postgres@localhost:5432/synchronizer

--- a/services/synchronizer/.env.example
+++ b/services/synchronizer/.env.example
@@ -10,7 +10,7 @@ INIT_START_SLOT=10413441
 # Optional (shown with their defaults)
 # Blob source. Defaults to BEACON_URL (recent blobs only); set to an archiver to
 # read blobs older than the beacon's retention window.
-# ARCHIVER_URL=https://ethereum-sepolia-beacon-api.publicnode.com
+# ARCHIVER_URL="http://localhost:3001"
 # HTTP_BIND=127.0.0.1:3000
 # APP_STATE_DB_PATH=data/synchronizer-db
 # SYNC_METADATA_DB_URL=postgres://postgres@localhost:5432/synchronizer

--- a/services/synchronizer/README.md
+++ b/services/synchronizer/README.md
@@ -211,6 +211,7 @@ Hashes in request and response bodies are pod2 `Hash` values, serialized as lowe
 - `RPC_URL`
 - `BEACON_URL`
 - `TO_ADDRESS`
+- `INIT_START_SLOT` (beacon slot to start syncing from on first run; resumed from stored progress afterward)
 
 ## Optional env vars
 
@@ -219,7 +220,6 @@ Hashes in request and response bodies are pod2 `Hash` values, serialized as lowe
 - `HTTP_BIND` (default: `127.0.0.1:3000`)
 - `RPC_RETRIES` (default: `6`)
 - `RPC_RETRY_MS` (default: `1000`)
-- `INITIAL_START_SLOT` (default: unset, meaning start from current head on first run)
 - `SYNC_DELAY_MS` (default: derived from RPC rate limit, currently `173`) — delay in ms between slots when at head. Override with caution to avoid exceeding the RPC rate limit.
 - `CATCHUP_BATCH_SIZE` (default: derived from RPC rate limit, currently `7`) — number of slots fetched concurrently during catch-up. Override with caution to avoid exceeding the RPC rate limit.
 

--- a/services/synchronizer/src/config.rs
+++ b/services/synchronizer/src/config.rs
@@ -2,7 +2,7 @@ use std::{net::SocketAddr, str::FromStr, time::Duration};
 
 use alloy::primitives::Address;
 use anyhow::Result;
-use tracing::warn;
+use tracing::{info, warn};
 
 const DEFAULT_APP_STATE_DB_PATH: &str = "data/synchronizer-db";
 const DEFAULT_SYNC_METADATA_DB_URL: &str = "postgres://postgres@localhost:5432/synchronizer";
@@ -94,7 +94,14 @@ pub fn load_config() -> Result<AppConfig> {
 
     let rpc_url: String = dotenvy::var("RPC_URL")?;
     let beacon_url: String = dotenvy::var("BEACON_URL")?;
-    let archiver_url: String = dotenvy::var("ARCHIVER_URL")?;
+    // Blob source. An archiver serves blobs via the same getBlobs API as a beacon
+    // node, so when ARCHIVER_URL is unset we read blobs straight from the beacon.
+    // The beacon only retains recent blobs, so syncing history older than its
+    // retention window still requires an archiver.
+    let archiver_url: String = dotenvy::var("ARCHIVER_URL").unwrap_or_else(|_| {
+        info!("ARCHIVER_URL not set; reading blobs from BEACON_URL (recent blobs only)");
+        beacon_url.clone()
+    });
     let to_address: Address = Address::from_str(&dotenvy::var("TO_ADDRESS")?)?;
 
     Ok(AppConfig {

--- a/services/synchronizer/src/config.rs
+++ b/services/synchronizer/src/config.rs
@@ -2,7 +2,7 @@ use std::{net::SocketAddr, str::FromStr, time::Duration};
 
 use alloy::primitives::Address;
 use anyhow::{Context, Result};
-use tracing::{info, warn};
+use tracing::warn;
 
 const DEFAULT_APP_STATE_DB_PATH: &str = "data/synchronizer-db";
 const DEFAULT_SYNC_METADATA_DB_URL: &str = "postgres://postgres@localhost:5432/synchronizer";
@@ -100,7 +100,7 @@ pub fn load_config() -> Result<AppConfig> {
     // The beacon only retains recent blobs, so syncing history older than its
     // retention window still requires an archiver.
     let archiver_url: String = dotenvy::var("ARCHIVER_URL").unwrap_or_else(|_| {
-        info!("ARCHIVER_URL not set; reading blobs from BEACON_URL (recent blobs only)");
+        warn!("ARCHIVER_URL not set; reading blobs from BEACON_URL (recent blobs only)");
         beacon_url.clone()
     });
     let to_address: Address = Address::from_str(&dotenvy::var("TO_ADDRESS")?)?;

--- a/services/synchronizer/src/config.rs
+++ b/services/synchronizer/src/config.rs
@@ -1,7 +1,7 @@
 use std::{net::SocketAddr, str::FromStr, time::Duration};
 
 use alloy::primitives::Address;
-use anyhow::Result;
+use anyhow::{Context, Result};
 use tracing::{info, warn};
 
 const DEFAULT_APP_STATE_DB_PATH: &str = "data/synchronizer-db";
@@ -34,7 +34,7 @@ pub struct AppConfig {
     pub rpc_retries: u32,
     pub rpc_retry_delay: Duration,
     pub catchup_batch_size: usize,
-    pub initial_start_slot: Option<u32>,
+    pub init_start_slot: u32,
     pub rpc_url: String,
     pub beacon_url: String,
     pub archiver_url: String,
@@ -88,9 +88,10 @@ pub fn load_config() -> Result<AppConfig> {
         .ok()
         .and_then(|v| v.parse::<u64>().ok())
         .unwrap_or(DEFAULT_RPC_RETRY_MS);
-    let initial_start_slot = dotenvy::var("INITIAL_START_SLOT")
-        .ok()
-        .and_then(|v| v.parse::<u32>().ok());
+    let init_start_slot: u32 = dotenvy::var("INIT_START_SLOT")
+        .context("INIT_START_SLOT must be set (beacon slot to start syncing from)")?
+        .parse()
+        .context("INIT_START_SLOT must be a valid u32 beacon slot")?;
 
     let rpc_url: String = dotenvy::var("RPC_URL")?;
     let beacon_url: String = dotenvy::var("BEACON_URL")?;
@@ -112,7 +113,7 @@ pub fn load_config() -> Result<AppConfig> {
         rpc_retries,
         rpc_retry_delay: Duration::from_millis(rpc_retry_ms),
         catchup_batch_size,
-        initial_start_slot,
+        init_start_slot,
         rpc_url,
         beacon_url,
         archiver_url,

--- a/services/synchronizer/src/main.rs
+++ b/services/synchronizer/src/main.rs
@@ -35,7 +35,7 @@ async fn main() -> Result<()> {
     let sync_db = Arc::new(SyncDb::connect(&cfg.sync_metadata_db_url).await?);
     let state_machine = Arc::new(StateMachine::new(app_db, Arc::new(ProofParser::new()?)));
     let node = Arc::new(Node::new(cfg, Arc::clone(&state_machine), Arc::clone(&sync_db)).await?);
-    let sync_start = initialize_sync(&node, node.config.initial_start_slot).await?;
+    let sync_start = initialize_sync(&node, node.config.init_start_slot).await?;
     let (shutdown_tx, shutdown_rx) = watch::channel(false);
 
     let server_task = tokio::spawn(run_api_server(

--- a/services/synchronizer/src/sync_loop.rs
+++ b/services/synchronizer/src/sync_loop.rs
@@ -290,24 +290,21 @@ async fn find_divergence_slot(node: &Node, current_slot: u32) -> Result<u32> {
     ))
 }
 
-pub(crate) async fn initialize_sync(
-    node: &Node,
-    initial_start_slot: Option<u32>,
-) -> Result<SyncStart> {
+pub(crate) async fn initialize_sync(node: &Node, init_start_slot: u32) -> Result<SyncStart> {
     let spec = node.get_beacon_spec_with_retry().await?;
     info!(?spec, "Loaded beacon spec");
 
     let head = node.get_beacon_head_header_with_retry().await?;
     info!(head_slot = head.slot, head_root = ?head.root, "Fetched initial beacon head");
 
-    let bootstrap_start_slot = initial_start_slot.unwrap_or(head.slot);
+    let bootstrap_start_slot = init_start_slot;
     let bootstrap_slot = bootstrap_start_slot.checked_sub(1).ok_or_else(|| {
         anyhow!("bootstrap start slot must be > 0 to insert initial bootstrap row")
     })?;
 
     if bootstrap_slot > head.slot {
         return Err(anyhow!(
-            "INITIAL_START_SLOT {bootstrap_start_slot} is ahead of current beacon head {}; cannot bootstrap slot {}",
+            "INIT_START_SLOT {bootstrap_start_slot} is ahead of current beacon head {}; cannot bootstrap slot {}",
             head.slot,
             bootstrap_slot
         ));


### PR DESCRIPTION
Ships the archiver as a published service and unifies start-slot config across the synchronizer and archiver.

### Archiver as a shipped service
- New `archiver` build target + runtime image in the Dockerfile, published to GHCR alongside the synchronizer/relayer (`images.yml`, `release.yml`).
- `deploy/compose.yaml` now runs the archiver, with the synchronizer depending on it; deploy `.env.example` + README updated.
- `install-test.yml` starts the archiver in the smoke test and points the synchronizer's `ARCHIVER_URL` at it.

### Synchronizer reads blobs from the archiver (optional)
- `ARCHIVER_URL` is now optional: unset, the synchronizer reads blobs straight from `BEACON_URL` (recent blobs only); set it to sync history older than the beacon's retention window.

### Unified start-slot config
- Renamed the synchronizer's `INITIAL_START_SLOT` → `INIT_START_SLOT` to match the archiver, and made it **required** (both services fail with a clear message if unset). In compose they share one value, so both start from the same slot.

### Dev conveniences
- `just dev` anchors `INIT_START_SLOT` to the current beacon head when a service's store is fresh (resumes from stored progress otherwise).
- `just reset` now also wipes the archiver blob store.

**Heads-up:** existing `services/synchronizer/.env` files must now set `INIT_START_SLOT` (was `INITIAL_START_SLOT`, and optional). `just dev` backfills it automatically.