### PR TITLE
archiver: fix blob loss on restart and at the chain head

### DIFF
--- a/libs/eth-clients/src/beacon/types.rs
+++ b/libs/eth-clients/src/beacon/types.rs
@@ -69,8 +69,10 @@ pub struct Spec {
 }
 #[derive(Deserialize, Debug)]
 pub struct Block {
-    pub blob_kzg_commitments: Option<Vec<KzgCommitment>>,
-    pub execution_payload: Option<ExecutionPayload>,
+    // Mandatory after "Deneb"
+    pub blob_kzg_commitments: Vec<KzgCommitment>,
+    // Mandatory after "Bellatrix/The Merge"
+    pub execution_payload: ExecutionPayload,
     pub parent_root: B256,
     #[serde(deserialize_with = "deserialize_u32")]
     pub slot: u32,
@@ -87,8 +89,10 @@ pub struct ExecutionPayload {
 
 #[derive(Deserialize, Debug)]
 pub struct BlockBody {
-    pub execution_payload: Option<ExecutionPayload>,
-    pub blob_kzg_commitments: Option<Vec<KzgCommitment>>,
+    // Mandatory after "Deneb"
+    pub execution_payload: ExecutionPayload,
+    // Mandatory after "Bellatrix/The Merge"
+    pub blob_kzg_commitments: Vec<KzgCommitment>,
 }
 #[derive(Deserialize, Debug)]
 pub struct BlockMessage {

--- a/services/archiver/src/node.rs
+++ b/services/archiver/src/node.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use alloy::eips::eip4844::HeapBlob;
 use eth_clients::beacon::{
     self,
-    types::{BlockHeader, BlockId, KzgCommitment},
+    types::{Block, BlockHeader, BlockId, KzgCommitment},
     BeaconClient,
 };
 use itertools::zip_eq;
@@ -26,7 +26,7 @@ use alloy::{
 use anyhow::{anyhow, Context, Result};
 use backoff::ExponentialBackoffBuilder;
 use chrono::{DateTime, Utc};
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 
 use crate::config::Config;
 
@@ -92,9 +92,13 @@ impl Store {
             Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(()),
             Err(e) => return Err(e.into()),
         }
+        // Canonicalize the base too: blobs_path can be relative or sit under a
+        // symlinked prefix, so comparing it raw against a resolved path would
+        // reject legitimate in-store paths.
+        let blobs_root = fs::canonicalize(&self.blobs_path)?;
         let mut root_path = fs::canonicalize(slot_path)?; // Resolve symlink
         assert!(
-            root_path.starts_with(&self.blobs_path),
+            root_path.starts_with(&blobs_root),
             "root_path outside of blobs_path, removal is dangerous"
         );
         if fs::exists(&root_path)? {
@@ -143,8 +147,9 @@ impl Store {
                 } else {
                     break 'outer;
                 };
-                // Next level
-                slot_path.push(last);
+                // `entries` holds full paths, so descend by adopting the deepest
+                // directly; pushing a relative entry would append, not replace.
+                slot_path = last.clone();
             }
             // See if that block was completed, if not delete it and try again
             let mut header_path = slot_path.clone();
@@ -306,6 +311,28 @@ impl Node {
         Ok(())
     }
 
+    /// Fetch a block body whose header we already hold. At the chain head the
+    /// body can lag the header, so the beacon returns 404 (mapped to None) for a
+    /// slot that is not empty. Treat that miss as transient and retry; returning
+    /// early would let the caller commit the slot with no blobs and drop its
+    /// data-availability blobs permanently.
+    async fn fetch_block_body(&self, root: B256, slot: u32) -> Result<Block> {
+        const MAX_RETRIES: usize = 10;
+        const RETRY_DELAY: Duration = Duration::from_secs(4);
+        for attempt in 1..=MAX_RETRIES {
+            if let Some(block) = self.beacon_cli.get_block(BlockId::Hash(root)).await? {
+                return Ok(block);
+            }
+            warn!("block body for slot {slot} root {root} not available yet (attempt {attempt}/{MAX_RETRIES})");
+            if attempt < MAX_RETRIES {
+                tokio::time::sleep(RETRY_DELAY).await;
+            }
+        }
+        Err(anyhow!(
+            "block body for slot {slot} root {root} still unavailable after {MAX_RETRIES} retries"
+        ))
+    }
+
     pub(crate) async fn process_beacon_block_blobs(
         &self,
         beacon_block_header: &BlockHeader,
@@ -313,24 +340,10 @@ impl Node {
         let beacon_block_root = beacon_block_header.root;
         let slot = beacon_block_header.slot;
 
-        let beacon_block = match self
-            .beacon_cli
-            .get_block(BlockId::Hash(beacon_block_root))
-            .await?
-        {
-            Some(block) => block,
-            None => {
-                debug!("slot {} has empty block", slot);
-                return Ok(());
-            }
-        };
-        let execution_payload = match beacon_block.execution_payload {
-            Some(payload) => payload,
-            None => {
-                debug!("slot {} has no execution payload", slot);
-                return Ok(());
-            }
-        };
+        let beacon_block = self.fetch_block_body(beacon_block_root, slot).await?;
+        let execution_payload = beacon_block.execution_payload.ok_or_else(|| {
+            anyhow!("slot {slot} root {beacon_block_root} has a block but no execution payload")
+        })?;
         debug!(
             "slot {} has execution block {} at height {}",
             slot, execution_payload.block_hash, execution_payload.block_number

--- a/services/archiver/src/node.rs
+++ b/services/archiver/src/node.rs
@@ -132,7 +132,7 @@ impl Store {
             let mut slot_path = PathBuf::from(&self.blobs_path);
             slot_path.push("by_slot");
             // Find the highest slot number path
-            for _level in 0..DIR_LEVELS {
+            for level in 0..DIR_LEVELS {
                 let read_dir = match fs::read_dir(&slot_path) {
                     Ok(entries) => entries,
                     Err(e) if e.kind() == io::ErrorKind::NotFound => break 'outer,
@@ -142,10 +142,20 @@ impl Store {
                     .map(|res| res.map(|e| e.path()))
                     .collect::<Result<Vec<_>, io::Error>>()?;
                 entries.sort();
-                let last = if let Some(last) = entries.last() {
-                    last
-                } else {
-                    break 'outer;
+                let last = match entries.last() {
+                    Some(last) => last,
+                    None => {
+                        // An empty directory below the root would otherwise
+                        // abandon the valid blocks under lower-numbered siblings:
+                        // drop it and retry so the descent falls back to one
+                        // instead of giving up. An empty root just means the
+                        // store holds no blocks.
+                        if level == 0 {
+                            break 'outer;
+                        }
+                        fs::remove_dir(&slot_path)?;
+                        continue 'outer;
+                    }
                 };
                 // `entries` holds full paths, so descend by adopting the deepest
                 // directly; pushing a relative entry would append, not replace.

--- a/services/archiver/src/node.rs
+++ b/services/archiver/src/node.rs
@@ -279,7 +279,12 @@ impl Node {
         &self,
         beacon_block_header: &BlockHeader,
     ) -> Result<()> {
-        // Create the path with the symlink to the yet to be created block dir, indexed by slot
+        // Create the block dir where the filtered blobs and header will be stored, indexed by
+        // block root
+        let root_dir = self.store.root_dir(&beacon_block_header.root);
+        create_dir_all(&root_dir)?;
+
+        // Create the path with the symlink to the block dir, indexed by slot
         let slot_path = self.store.slot_dir(beacon_block_header.slot);
         let mut slot_mid_path = slot_path.clone();
         slot_mid_path.pop();
@@ -290,10 +295,6 @@ impl Node {
         );
         unix::fs::symlink(&root_dir_rel, slot_path)?;
 
-        // Create the block dir where the filtered blobs and header will be stored, indexed by
-        // block root
-        let root_dir = self.store.root_dir(&beacon_block_header.root);
-        create_dir_all(&root_dir)?;
         // We store the header as a tmp file, and only rename after successfully processing the
         // beacon block.  This way seeing the `header.json` without the `.tmp` guarantees that the
         // stored block data is valid.

--- a/services/archiver/src/node.rs
+++ b/services/archiver/src/node.rs
@@ -92,13 +92,13 @@ impl Store {
             Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(()),
             Err(e) => return Err(e.into()),
         }
-        // Canonicalize the base too: blobs_path can be relative or sit under a
-        // symlinked prefix, so comparing it raw against a resolved path would
-        // reject legitimate in-store paths.
-        let blobs_root = fs::canonicalize(&self.blobs_path)?;
-        let mut root_path = fs::canonicalize(slot_path)?; // Resolve symlink
+        // `slot_path` points to `../../../by_root/{root_hi}/{root_med}/{root_lo}`, so we remove
+        // the first 3 components and manually build the `root_path`
+        let relative_root_path: PathBuf = fs::read_link(slot_path)?.iter().skip(3).collect();
+        let mut root_path = PathBuf::from(&self.blobs_path);
+        root_path.push(relative_root_path);
         assert!(
-            root_path.starts_with(&blobs_root),
+            root_path.starts_with(&self.blobs_path),
             "root_path outside of blobs_path, removal is dangerous"
         );
         if fs::exists(&root_path)? {
@@ -289,11 +289,6 @@ impl Node {
         &self,
         beacon_block_header: &BlockHeader,
     ) -> Result<()> {
-        // Create the block dir where the filtered blobs and header will be stored, indexed by
-        // block root
-        let root_dir = self.store.root_dir(&beacon_block_header.root);
-        create_dir_all(&root_dir)?;
-
         // Create the path with the symlink to the block dir, indexed by slot
         let slot_path = self.store.slot_dir(beacon_block_header.slot);
         let mut slot_mid_path = slot_path.clone();
@@ -304,6 +299,11 @@ impl Node {
             &beacon_block_header.root,
         );
         unix::fs::symlink(&root_dir_rel, slot_path)?;
+
+        // Create the block dir where the filtered blobs and header will be stored, indexed by
+        // block root
+        let root_dir = self.store.root_dir(&beacon_block_header.root);
+        create_dir_all(&root_dir)?;
 
         // We store the header as a tmp file, and only rename after successfully processing the
         // beacon block.  This way seeing the `header.json` without the `.tmp` guarantees that the
@@ -339,9 +339,7 @@ impl Node {
             .ok_or_else(|| {
                 anyhow!("Beacon header exists for slot {slot} but full block {beacon_block_root} was not found")
             })?;
-        let execution_payload = beacon_block.execution_payload.ok_or_else(|| {
-            anyhow!("Beacon block {beacon_block_root} for slot {slot} had no execution payload")
-        })?;
+        let execution_payload = beacon_block.execution_payload;
         debug!(
             "slot {} has execution block {} at height {}",
             slot, execution_payload.block_hash, execution_payload.block_number
@@ -354,13 +352,11 @@ impl Node {
                 .unwrap_or_default(),
         );
 
-        let kzg_blob_commitments = match beacon_block.blob_kzg_commitments {
-            Some(commitments) => commitments
-                .into_iter()
-                .map(|c| (kzg_to_versioned_hash(c.as_ref()), c))
-                .collect(),
-            None => Vec::new(),
-        };
+        let kzg_blob_commitments: Vec<_> = beacon_block
+            .blob_kzg_commitments
+            .into_iter()
+            .map(|c| (kzg_to_versioned_hash(c.as_ref()), c))
+            .collect();
         if kzg_blob_commitments.is_empty() {
             debug!("slot {} has no blobs", slot);
             return Ok(());

--- a/services/archiver/src/node.rs
+++ b/services/archiver/src/node.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use alloy::eips::eip4844::HeapBlob;
 use eth_clients::beacon::{
     self,
-    types::{Block, BlockHeader, BlockId, KzgCommitment},
+    types::{BlockHeader, BlockId, KzgCommitment},
     BeaconClient,
 };
 use itertools::zip_eq;
@@ -26,7 +26,7 @@ use alloy::{
 use anyhow::{anyhow, Context, Result};
 use backoff::ExponentialBackoffBuilder;
 use chrono::{DateTime, Utc};
-use tracing::{debug, info, warn};
+use tracing::{debug, info};
 
 use crate::config::Config;
 
@@ -311,28 +311,6 @@ impl Node {
         Ok(())
     }
 
-    /// Fetch a block body whose header we already hold. At the chain head the
-    /// body can lag the header, so the beacon returns 404 (mapped to None) for a
-    /// slot that is not empty. Treat that miss as transient and retry; returning
-    /// early would let the caller commit the slot with no blobs and drop its
-    /// data-availability blobs permanently.
-    async fn fetch_block_body(&self, root: B256, slot: u32) -> Result<Block> {
-        const MAX_RETRIES: usize = 10;
-        const RETRY_DELAY: Duration = Duration::from_secs(4);
-        for attempt in 1..=MAX_RETRIES {
-            if let Some(block) = self.beacon_cli.get_block(BlockId::Hash(root)).await? {
-                return Ok(block);
-            }
-            warn!("block body for slot {slot} root {root} not available yet (attempt {attempt}/{MAX_RETRIES})");
-            if attempt < MAX_RETRIES {
-                tokio::time::sleep(RETRY_DELAY).await;
-            }
-        }
-        Err(anyhow!(
-            "block body for slot {slot} root {root} still unavailable after {MAX_RETRIES} retries"
-        ))
-    }
-
     pub(crate) async fn process_beacon_block_blobs(
         &self,
         beacon_block_header: &BlockHeader,
@@ -340,9 +318,18 @@ impl Node {
         let beacon_block_root = beacon_block_header.root;
         let slot = beacon_block_header.slot;
 
-        let beacon_block = self.fetch_block_body(beacon_block_root, slot).await?;
+        // We already hold this slot's header, so a None body is a transient miss
+        // at the head, not an empty slot. Fail instead of committing the slot with
+        // no blobs; the restart reprocesses it once the body lands.
+        let beacon_block = self
+            .beacon_cli
+            .get_block(BlockId::Hash(beacon_block_root))
+            .await?
+            .ok_or_else(|| {
+                anyhow!("Beacon header exists for slot {slot} but full block {beacon_block_root} was not found")
+            })?;
         let execution_payload = beacon_block.execution_payload.ok_or_else(|| {
-            anyhow!("slot {slot} root {beacon_block_root} has a block but no execution payload")
+            anyhow!("Beacon block {beacon_block_root} for slot {slot} had no execution payload")
         })?;
         debug!(
             "slot {} has execution block {} at height {}",

--- a/services/synchronizer/src/node.rs
+++ b/services/synchronizer/src/node.rs
@@ -256,12 +256,7 @@ impl Node {
         let block = self
             .get_beacon_block_by_hash_with_retry(slot, header.root)
             .await?;
-        let execution_payload = block.execution_payload.as_ref().ok_or_else(|| {
-            anyhow!(
-                "Beacon block {} for slot {slot} had no execution payload",
-                header.root
-            )
-        })?;
+        let execution_payload = &block.execution_payload;
 
         Ok(CommittedSlotRecord {
             slot,
@@ -285,17 +280,14 @@ impl Node {
         let slot = beacon_block_header.slot;
         let beacon_block_root = beacon_block_header.root;
 
-        let execution_payload = beacon_block.execution_payload.as_ref().ok_or_else(|| {
-            anyhow!("Beacon block {beacon_block_root} for slot {slot} had no execution payload")
-        })?;
+        let execution_payload = &beacon_block.execution_payload;
 
-        let kzg_blob_commitments = match beacon_block.blob_kzg_commitments.clone() {
-            Some(commitments) => commitments
-                .into_iter()
-                .map(|c| (kzg_to_versioned_hash(c.as_ref()), c))
-                .collect(),
-            None => Vec::new(),
-        };
+        let kzg_blob_commitments = beacon_block
+            .blob_kzg_commitments
+            .clone()
+            .into_iter()
+            .map(|c| (kzg_to_versioned_hash(c.as_ref()), c))
+            .collect();
 
         Ok(SlotContext {
             slot,


### PR DESCRIPTION
Fix archiver failure modes that can leave the synchronizer unable to fetch blobs from the archiver. The common production symptom is that the synchronizer requests a blob, gets a 404 from the archiver, retries 10x, and its sync loop dies.

All fixes are in `services/archiver/src/node.rs`.

## Fixes

1. **Resume walk dead-ended on relative `BLOBS_PATH`**

   `last_header()` descended the `by_slot` tree with `slot_path.push(entry.path())`. `DirEntry::path()` returns a full path, and `PathBuf::push` only replaces the buffer when that path is absolute.

   With a relative `BLOBS_PATH`, the walk appended paths like `blobs/by_slot/blobs/by_slot/...`, failed to find the last header, fell back to `INIT_START_SLOT`, and then tried to recreate an existing slot symlink.

   Fix: descend by adopting the entry directly with `slot_path = last.clone()`.

2. **Safe-delete guard rejected valid in-store paths**

   `delete_block_data()` compared a canonicalized block path against the raw `blobs_path`. A relative base or symlinked prefix such as macOS `/tmp -> /private/tmp` made the safety check reject legitimate paths.

   Fix: canonicalize the base path too, then compare canonical-to-canonical.

3. **Transient chain-head body miss committed a block as blobless**

   The main loop may fetch a slot header before the full beacon block body is available. The beacon client maps a 404 body lookup to `Ok(None)`, and the old code treated that as an empty slot, returned `Ok`, and committed `header.json` with no blobs.

   Fix: once a header exists, treat a missing full block body as an error instead of an empty slot. Docker restarts the process, resume cleanup removes the incomplete slot, and the archiver reprocesses it once the body is available.

   The genuinely empty slot path remains in the main loop where the header is missing. The genuine zero-blob block path is unchanged.

4. **Crash window could leave a dangling `by_slot` symlink**

   `process_beacon_block_header()` created the `by_slot` symlink before creating the corresponding `by_root` target directory. A crash in that small window left a dangling symlink that resume cleanup could not canonicalize.

   Fix: create the `by_root` directory before creating the `by_slot` symlink.

5. **Resume cleanup could stop at an empty highest slot subtree**

   A crash after creating a `by_slot` parent directory but before creating the slot symlink can leave an empty highest subtree, especially around a 1,000-slot boundary. `last_header()` would descend into that empty branch, conclude there was no stored header at all, and resume from `INIT_START_SLOT` instead of falling back to the previous valid slot.

   Fix: when `last_header()` finds an empty non-root `by_slot` directory, remove it and restart the descent so the walk can fall back to the next lower valid sibling. An empty root still means the store has no archived blocks.

## Follow-up

A better long-term fix is probably to make the archiver retry transient beacon inconsistencies the way the synchronizer does instead of relying on process restart. That needs a broader design discussion and is tracked in https://github.com/dobjlabs/digital-objects-network/issues/166.