### PR TITLE
Add toggle for MCP server, off by default

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,7 @@ Use `just` (recipes in `justfile`):
 - Postgres on `localhost:5432` (user `postgres`). `just ensure-db` creates the `synchronizer` + `relayer` DBs.
 - An Ethereum beacon + execution endpoint (configure in `services/synchronizer/.env`, `services/relayer/.env`, `services/archiver/.env`).
 - RocksDB stores under `data/` and `~/.dobj/` are created on first run; the archiver writes blobs to its `BLOBS_PATH` (filesystem, no DB).
-- `dobjd` binds **two adjacent ports**: HTTP on `DOBJD_PORT` (default `7717`) and MCP on `DOBJD_PORT + 1` (default `7718`). Both must be free or startup fails fast.
+- `dobjd` binds **two adjacent ports**: HTTP on `DOBJD_PORT` (default `7717`) and MCP on `DOBJD_PORT + 1` (default `7718`). A taken port fails startup fast. MCP serving is gated by the `mcpEnabled` setting (`dobj settings set --mcp on|off`, default **off**); toggling starts/stops the MCP server immediately, no restart.
 - `just dev-remote` skips the local chain-side services and points dobjd at the hosted synchronizer + relayer, so no local Postgres / beacon is needed.
 
 **Always run tests with `--release`** — proof generation is impractically slow in debug. Use `MockProver` (not the real Prover) in unit tests; gate real-proof tests with `#[ignore]`. Use `assert!`, not `debug_assert!`, since tests run `--release`.
@@ -119,7 +119,7 @@ Use `just` (recipes in `justfile`):
 - **`libs/payload/src/shrink.rs`** — Plonky2 wrapper circuit that re-proves a MainPod in a smaller circuit so it fits in a blob.
 - **`libs/payload/src/payload.rs`** — blob payload encoding (`PAYLOAD_MAGIC`, proof type, `tx_final`, state root, nullifiers, and the `live` object commitments).
 - **`interfaces/mcp/src/lib.rs`** — `DEFAULT_PORT = 7718`; crate is named `dobj-mcp` (depend on it as `dobj-mcp = { path = "../mcp" }`). dobjd runs MCP at `DOBJD_PORT + 1`.
-- **`services/dobjd/src/main.rs`** — daemon entry point. Binds HTTP + MCP listeners up-front (fail-fast if either port is taken), constructs `Arc<Driver>` once via `Driver::open_default()`, shares it with the embedded `dobj-mcp` server. `DEFAULT_HTTP_PORT = 7717`, override via `DOBJD_PORT`.
+- **`services/dobjd/src/main.rs`** — daemon entry point. Binds listeners up-front (fail-fast if a port is taken; MCP only when enabled), constructs `Arc<Driver>` once via `Driver::open_default()`, shares it with the embedded `dobj-mcp` server (start/stop lives in `src/mcp.rs::McpRuntime`). `DEFAULT_HTTP_PORT = 7717`, override via `DOBJD_PORT`.
 - **`services/dobjd/src/routes/mod.rs`** — axum routes: `/healthz`, `/objects`, `/state-root`, `/objects/{dir,file_name}`, `/classes[/{name}]`, `/settings`, `/actions[/run,/{id}[/feasibility]]`, `/actions/runs/{id}[/events]` (run-status poll + per-run replayable SSE), `/events` (SSE). dobjd is API-only; the UI is served separately.
 - **`services/dobjd/src/runs.rs`** — the run registry. `POST /actions/run` is non-blocking: it registers a run, spawns a background worker, and returns a `runId`. The worker records status + progress + terminal result/error into an in-memory, TTL-reaped registry that backs `/actions/runs/{id}` (poll) and its SSE. Shared by the HTTP routes and the MCP server.
 - **`services/dobjd/src/events.rs`** — broadcast hub behind SSE `/events`, shared with the MCP server so progress updates fan out to every client.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -4,7 +4,7 @@ Installing the driver gives you:
 
 - `~/.dobj/bin/dobjd` (`dobjd.exe` on Windows) — long-running driver daemon serving:
   - REST/SSE on `http://127.0.0.1:7717`
-  - MCP on `http://127.0.0.1:7718/mcp`
+  - MCP on `http://127.0.0.1:7718/mcp` (off by default; see [Connect an agent](#connect-an-agent-mcp))
 - `~/.dobj/bin/dobj` — terminal CLI that talks to dobjd
 - `~/.dobj/bin/dobj-mcp-proxy` — stdio↔HTTP bridge for agents that only speak stdio (e.g. Claude Desktop)
 
@@ -78,8 +78,16 @@ the daemon's action catalog — no restart needed. For example, **craft-basics**
 
 ### Connect an agent (MCP)
 
-dobjd serves MCP at `http://127.0.0.1:7718/mcp`. Installing the binaries does
-not register it with any agent — do that per agent:
+dobjd can serve MCP at `http://127.0.0.1:7718/mcp`, but it's **off by
+default**. Turn it on first (takes effect immediately, persists across
+restarts):
+
+```bash
+dobj settings set --mcp on
+```
+
+Installing the binaries does not register MCP with any agent — do that per
+agent:
 
 **Claude Code** (idempotent, safe to re-run):
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -4,7 +4,7 @@ Set up the **Digital Objects driver** on this machine. After this runs you'll ha
 
 - `~/.dobj/bin/dobjd` (`dobjd.exe` on Windows) - the driver daemon, serving:
   - REST/SSE on `http://127.0.0.1:7717`
-  - MCP on `http://127.0.0.1:7718/mcp`
+  - MCP on `http://127.0.0.1:7718/mcp` (off by default; step 5 turns it on)
 - `~/.dobj/bin/dobj` - terminal CLI that talks to dobjd
 - `~/.dobj/bin/dobj-mcp-proxy` - stdio<->HTTP bridge for Claude Desktop
 - `~/.dobj/actions/craft-basics.pexe` - the bundled crafting plugin
@@ -107,8 +107,25 @@ You should see `dobjd is running (pid ...)`, the craft-basics actions, and a
 
 ### 5. Register MCP with the agent
 
-dobjd serves MCP at `http://127.0.0.1:7718/mcp` so this agent can drive
+dobjd can serve MCP at `http://127.0.0.1:7718/mcp` so this agent can drive
 Digital Objects directly (list objects, run actions, inspect classes).
+
+MCP is **off by default**, so first turn it on. This takes effect
+immediately - no daemon restart - and persists across restarts.
+
+macOS / Linux:
+
+```bash
+~/.dobj/bin/dobj settings set --mcp on
+```
+
+Windows (PowerShell):
+
+```powershell
+& "$env:USERPROFILE\.dobj\bin\dobj.exe" settings set --mcp on
+```
+
+Then register the MCP client.
 
 **Claude Code** - if `claude` is on the PATH, register it now (idempotent):
 

--- a/interfaces/cli/README.md
+++ b/interfaces/cli/README.md
@@ -31,7 +31,7 @@ Two flavors of commands.
 | `objects-dir`                                   | `GET /objects/dir`                                                                                                  |
 | `import <path>`                                 | `POST /objects/import` (reads the `.dobj` file locally, sends contents)                                             |
 | `settings get`                                  | `GET /settings`                                                                                                     |
-| `settings set --synchronizer URL --relayer URL` | `PUT /settings` (omitted flags left unchanged)                                                                      |
+| `settings set [--synchronizer URL] [--relayer URL] [--mcp on\|off]` | `PUT /settings` (omitted flags left unchanged; the MCP toggle starts/stops the server immediately) |
 | `run <action> [paths...]`                       | `POST /actions/run`, then follows `/actions/runs/{id}/events` and polls `/actions/runs/{id}` to the terminal result |
 | `events`                                        | `GET /events` SSE — prints every event as JSON lines                                                                |
 

--- a/interfaces/cli/src/commands.rs
+++ b/interfaces/cli/src/commands.rs
@@ -144,13 +144,21 @@ pub async fn import(client: &DobjdClient, path: PathBuf, json: bool) -> Result<(
     Ok(())
 }
 
+fn print_settings(settings: &DriverSettings) {
+    println!("synchronizer = {}", settings.synchronizer_api_url);
+    println!("relayer      = {}", settings.relayer_api_url);
+    println!(
+        "mcp          = {}",
+        if settings.mcp_enabled { "on" } else { "off" }
+    );
+}
+
 pub async fn settings_get(client: &DobjdClient, json: bool) -> Result<()> {
     let settings: DriverSettings = client.get_json("/settings").await?;
     if json {
         println!("{}", serde_json::to_string_pretty(&settings)?);
     } else {
-        println!("synchronizer = {}", settings.synchronizer_api_url);
-        println!("relayer      = {}", settings.relayer_api_url);
+        print_settings(&settings);
     }
     Ok(())
 }
@@ -159,6 +167,7 @@ pub async fn settings_set(
     client: &DobjdClient,
     synchronizer: Option<String>,
     relayer: Option<String>,
+    mcp: Option<bool>,
 ) -> Result<()> {
     let mut current: DriverSettings = client.get_json("/settings").await?;
     if let Some(s) = synchronizer {
@@ -167,9 +176,11 @@ pub async fn settings_set(
     if let Some(r) = relayer {
         current.relayer_api_url = r;
     }
+    if let Some(m) = mcp {
+        current.mcp_enabled = m;
+    }
     let saved: DriverSettings = client.put_json("/settings", &current).await?;
-    println!("synchronizer = {}", saved.synchronizer_api_url);
-    println!("relayer      = {}", saved.relayer_api_url);
+    print_settings(&saved);
     Ok(())
 }
 

--- a/interfaces/cli/src/daemon.rs
+++ b/interfaces/cli/src/daemon.rs
@@ -36,6 +36,7 @@ use std::process::{Command, Stdio};
 use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result, anyhow, bail};
+use wire_types::DriverSettings;
 
 use crate::client::DobjdClient;
 
@@ -399,12 +400,25 @@ async fn start_dobjd(client: &DobjdClient, dobjd_bin: Option<OsString>) -> Resul
     drop(child);
 
     println!(
-        "starting dobjd (pid {pid}, http {}, mcp http://127.0.0.1:{mcp_port}/mcp, log {})…",
+        "starting dobjd (pid {pid}, http {}, log {})…",
         client.base_url(),
         paths.log_file.display(),
     );
     wait_until_ready(client, pid, READY_TIMEOUT).await?;
-    println!("dobjd is up");
+
+    // MCP is off by default and toggled via settings, so report what the
+    // daemon actually serves rather than assuming the adjacent port is live.
+    // dobjd binds (or skips) the MCP port before it answers HTTP, so by the
+    // time we're ready `/settings` reflects the running state.
+    match client.get_json::<DriverSettings>("/settings").await {
+        Ok(settings) if settings.mcp_enabled => {
+            println!("dobjd is up (mcp http://127.0.0.1:{mcp_port}/mcp)");
+        }
+        Ok(_) => {
+            println!("dobjd is up (mcp disabled; enable with `dobj settings set --mcp on`)");
+        }
+        Err(_) => println!("dobjd is up"),
+    }
     Ok(())
 }
 

--- a/interfaces/cli/src/main.rs
+++ b/interfaces/cli/src/main.rs
@@ -98,7 +98,8 @@ enum Cmd {
         /// Path to a `.pexe` file, or an http(s) URL to download one from.
         source: String,
     },
-    /// Read or write driver settings (synchronizer / relayer URLs).
+    /// Read or write daemon settings (synchronizer / relayer URLs, MCP
+    /// toggle).
     #[command(subcommand)]
     Settings(SettingsCmd),
     /// Execute an action. Streams progress to stderr; result on stdout.
@@ -150,12 +151,16 @@ enum Cmd {
 enum SettingsCmd {
     /// Print current settings.
     Get,
-    /// Update one or both URLs. Omitted flags are left unchanged.
+    /// Update any subset of settings. Omitted flags are left unchanged.
     Set {
         #[arg(long)]
         synchronizer: Option<String>,
         #[arg(long)]
         relayer: Option<String>,
+        /// Serve MCP on the port adjacent to the HTTP port (on/off).
+        /// Takes effect immediately.
+        #[arg(long, value_name = "ON|OFF", value_parser = clap::builder::BoolishValueParser::new())]
+        mcp: Option<bool>,
     },
 }
 
@@ -199,7 +204,8 @@ async fn main() -> Result<()> {
         Cmd::Settings(SettingsCmd::Set {
             synchronizer,
             relayer,
-        }) => commands::settings_set(&client, synchronizer, relayer).await,
+            mcp,
+        }) => commands::settings_set(&client, synchronizer, relayer, mcp).await,
         Cmd::Run {
             qualified_id,
             inputs,

--- a/interfaces/gui/src/features/settings/SettingsModal.tsx
+++ b/interfaces/gui/src/features/settings/SettingsModal.tsx
@@ -19,6 +19,7 @@ export function SettingsModal({ open, onClose }: SettingsModalProps) {
   const [form, setForm] = useState<AppSettingsPayload>({
     synchronizerApiUrl: "",
     relayerApiUrl: "",
+    mcpEnabled: false,
   });
 
   useEffect(() => {
@@ -33,7 +34,7 @@ export function SettingsModal({ open, onClose }: SettingsModalProps) {
       })
       .catch((err) => {
         if (cancelled) return;
-        setError(normalizeErrorMessage(err, "Failed to save settings"));
+        setError(normalizeErrorMessage(err, "Failed to load settings"));
       })
       .finally(() => {
         if (!cancelled) setLoading(false);

--- a/interfaces/gui/src/shared/api/wireTypes.ts
+++ b/interfaces/gui/src/shared/api/wireTypes.ts
@@ -119,4 +119,6 @@ export interface CpuSample {
 export interface AppSettingsPayload {
   synchronizerApiUrl: string;
   relayerApiUrl: string;
+  /** Whether dobjd serves MCP on the adjacent port (default off). */
+  mcpEnabled: boolean;
 }

--- a/interfaces/mcp/README.md
+++ b/interfaces/mcp/README.md
@@ -68,7 +68,7 @@ production implementation lives in
 | `run_action`                       | Start an action; returns a `runId` immediately (non-blocking)  |
 | `get_run`                          | Poll a run's status, result/error, and progress log by `runId` |
 | `check_feasibility`                | Whether an action can run with current objects                 |
-| `read_settings` / `write_settings` | Synchronizer + relayer URLs                                    |
+| `read_settings` / `write_settings` | Synchronizer + relayer URLs and the `mcpEnabled` toggle (partial writes merge) |
 | `get_objects_dir`                  | Path to `~/.dobj/objects/`                                     |
 | `read_doc`                         | Reference docs (podlang, object-lifecycle, generated podlang)  |
 

--- a/interfaces/mcp/docs/instructions.md
+++ b/interfaces/mcp/docs/instructions.md
@@ -60,8 +60,8 @@ grounded in a recent state root (within ~300 blocks / ~1 hour). The
 
 ### Configuration
 
-- `read_settings` — current synchronizer + relayer URLs the daemon is using
-- `write_settings({ synchronizerApiUrl, relayerApiUrl })` — update both URLs (pass current values for fields you don't want to change)
+- `read_settings` — the daemon's current synchronizer + relayer URLs and its `mcpEnabled` toggle
+- `write_settings({ synchronizerApiUrl?, relayerApiUrl?, mcpEnabled? })` — update a subset of settings; any field you omit keeps its current value. Setting `mcpEnabled` to `false` shuts down the MCP server you are connected through.
 - `get_objects_dir` — filesystem path to `~/.dobj/objects/` (useful for showing the user where their objects live)
 
 ## Recommended workflow

--- a/interfaces/mcp/src/lib.rs
+++ b/interfaces/mcp/src/lib.rs
@@ -17,7 +17,9 @@ use rmcp::transport::streamable_http_server::{
     StreamableHttpServerConfig, StreamableHttpService, session::local::LocalSessionManager,
 };
 use server::DobjMcpService;
-use tokio_util::sync::CancellationToken;
+// Re-exported so embedders constructing an `McpConfig` name the exact type
+// this crate's tokio-util resolves to, without pinning their own copy.
+pub use tokio_util::sync::CancellationToken;
 
 /// Configuration for the MCP server.
 pub struct McpConfig {

--- a/interfaces/mcp/src/mock.rs
+++ b/interfaces/mcp/src/mock.rs
@@ -253,12 +253,15 @@ impl DobjOps for MockDobjOps {
         Ok(DriverSettings {
             synchronizer_api_url: "http://127.0.0.1:3000".to_string(),
             relayer_api_url: "http://127.0.0.1:3200".to_string(),
+            mcp_enabled: true,
         })
     }
 
-    fn write_settings(&self, settings: DriverSettings) -> anyhow::Result<DriverSettings> {
-        // Mock is read-only — just echo back what was passed in.
-        Ok(settings)
+    fn write_settings(&self, patch: DriverSettingsPatch) -> anyhow::Result<DriverSettings> {
+        // Mock has no persistence; merge onto the fixed base and echo back.
+        let mut merged = self.read_settings()?;
+        patch.apply_to(&mut merged);
+        Ok(merged)
     }
 
     fn get_objects_dir(&self) -> anyhow::Result<String> {

--- a/interfaces/mcp/src/ops.rs
+++ b/interfaces/mcp/src/ops.rs
@@ -23,11 +23,14 @@ pub trait DobjOps: Send + Sync + 'static {
     /// Returns the filed object's summary.
     fn import_object_file(&self, path: &str) -> anyhow::Result<ObjectSummary>;
 
-    /// Read the driver's current configuration (synchronizer + relayer URLs).
+    /// Read the daemon's current configuration.
     fn read_settings(&self) -> anyhow::Result<DriverSettings>;
-    /// Persist updated driver configuration. Implementations should accept
-    /// only the URLs we expose — the schema is intentionally minimal.
-    fn write_settings(&self, settings: DriverSettings) -> anyhow::Result<DriverSettings>;
+    /// Apply a partial configuration update, merging the patch's present
+    /// fields onto the current settings and returning the saved result.
+    /// Absent fields are left unchanged, so a caller can flip one setting
+    /// without echoing the rest. `mcp_enabled` actuates: the host starts or
+    /// stops its MCP server to match.
+    fn write_settings(&self, patch: DriverSettingsPatch) -> anyhow::Result<DriverSettings>;
     /// Filesystem path to the objects directory (`~/.dobj/objects/`).
     fn get_objects_dir(&self) -> anyhow::Result<String>;
 

--- a/interfaces/mcp/src/server.rs
+++ b/interfaces/mcp/src/server.rs
@@ -225,7 +225,9 @@ impl<T: DobjOps> DobjMcpService<T> {
             .map_err(|e| e.to_string())
     }
 
-    #[tool(description = "Read the driver's current configuration: synchronizer + relayer URLs.")]
+    #[tool(
+        description = "Read the daemon's current configuration: synchronizer + relayer URLs and the MCP server toggle."
+    )]
     fn read_settings(&self) -> Result<Json<DriverSettings>, String> {
         self.ops
             .read_settings()
@@ -234,11 +236,11 @@ impl<T: DobjOps> DobjMcpService<T> {
     }
 
     #[tool(
-        description = "Update the driver's configuration. Both synchronizer and relayer URLs are required — pass the current value for whichever you don't want to change. Most callers will read_settings first, mutate, then write_settings."
+        description = "Update the daemon's configuration. Send only the fields you want to change; any field you omit keeps its current value. Setting mcpEnabled to false shuts down the MCP server you are connected through."
     )]
     fn write_settings(
         &self,
-        Parameters(params): Parameters<DriverSettings>,
+        Parameters(params): Parameters<DriverSettingsPatch>,
     ) -> Result<Json<DriverSettings>, String> {
         self.ops
             .write_settings(params)

--- a/interfaces/mcp/src/types.rs
+++ b/interfaces/mcp/src/types.rs
@@ -12,9 +12,9 @@ use serde::{Deserialize, Serialize};
 
 pub use wire_types::{
     ActionSummary, CheckActionCandidate as FeasibilityInput,
-    CheckActionReport as FeasibilityReport, ClassRef, ClassSummary, DriverSettings, ObjectStatus,
-    ObjectSummary, ObjectsDirInfo, QualifiedName, RunAccepted, RunActionInput,
-    RunActionResult as RunActionInner, RunState, RunStatus,
+    CheckActionReport as FeasibilityReport, ClassRef, ClassSummary, DriverSettings,
+    DriverSettingsPatch, ObjectStatus, ObjectSummary, ObjectsDirInfo, QualifiedName, RunAccepted,
+    RunActionInput, RunActionResult as RunActionInner, RunState, RunStatus,
 };
 
 // -- List response wrappers (MCP outputSchema requires root type "object") --

--- a/libs/driver/src/settings.rs
+++ b/libs/driver/src/settings.rs
@@ -16,6 +16,7 @@ pub fn default_settings() -> DriverSettings {
         relayer_api_url: option_env!("DEFAULT_RELAYER_API_URL")
             .unwrap_or(DEFAULT_RELAYER_API_URL)
             .to_string(),
+        mcp_enabled: false,
     }
 }
 

--- a/libs/wire-types/src/lib.rs
+++ b/libs/wire-types/src/lib.rs
@@ -386,13 +386,50 @@ pub struct RunActionProgress {
 // Driver configuration
 // ===========================================================================
 
-/// The driver's persisted configuration: synchronizer + relayer URLs.
+/// The persisted configuration shared by the driver and dobjd:
+/// synchronizer + relayer URLs, plus the daemon's MCP server toggle.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct DriverSettings {
     pub synchronizer_api_url: String,
     pub relayer_api_url: String,
+    /// Whether dobjd serves MCP on the adjacent port (default off).
+    #[serde(default)]
+    pub mcp_enabled: bool,
+}
+
+/// Partial update for [`DriverSettings`], accepted by `PUT /settings`. Absent
+/// fields keep their current persisted value, so a caller can flip one
+/// setting without echoing the others. This is why the field type is
+/// `Option` rather than reusing `DriverSettings`: there, an omitted
+/// `mcpEnabled` would deserialize to `false` (`#[serde(default)]`, needed for
+/// reading older settings files) and silently stop the MCP server.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
+#[serde(rename_all = "camelCase")]
+pub struct DriverSettingsPatch {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub synchronizer_api_url: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub relayer_api_url: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mcp_enabled: Option<bool>,
+}
+
+impl DriverSettingsPatch {
+    /// Overlay the present fields onto `base`, leaving absent fields untouched.
+    pub fn apply_to(self, base: &mut DriverSettings) {
+        if let Some(url) = self.synchronizer_api_url {
+            base.synchronizer_api_url = url;
+        }
+        if let Some(url) = self.relayer_api_url {
+            base.relayer_api_url = url;
+        }
+        if let Some(enabled) = self.mcp_enabled {
+            base.mcp_enabled = enabled;
+        }
+    }
 }
 
 /// Filesystem location of the local objects directory. Returned by

--- a/services/dobjd/README.md
+++ b/services/dobjd/README.md
@@ -26,7 +26,9 @@ Two concurrent listeners:
 - **MCP on `127.0.0.1:7718`** (`DOBJD_PORT + 1`) — streamable-HTTP MCP server (from the
   [`dobj-mcp`](../../interfaces/mcp) crate) sharing the same `Arc<Driver>` as the
   HTTP routes, so an MCP-driven action shows up in real time on every
-  other connected client.
+  other connected client. Gated by the `mcpEnabled` setting (default
+  **off**); when off, the MCP port is not bound at all. See
+  [Settings](#settings) for toggle semantics.
 
 dobjd is API-only — the UI is served separately (Vite on `:1420` in
 dev, Tauri's webview for the desktop app).
@@ -123,10 +125,24 @@ Read on every `load_settings()` call from `~/.dobj/settings.json`:
 ```json
 {
   "synchronizerApiUrl": "https://synchronizer.don.pateldhvani.com",
-  "relayerApiUrl": "https://relayer.don.pateldhvani.com"
+  "relayerApiUrl": "https://relayer.don.pateldhvani.com",
+  "mcpEnabled": false
 }
 ```
 
 Compile-time defaults come from `DEFAULT_SYNCHRONIZER_API_URL` /
 `DEFAULT_RELAYER_API_URL` env vars at build time (set by the release
 workflow), overridden by anything in the settings file at runtime.
+
+Saving `mcpEnabled` through any settings write path (`PUT /settings`,
+`dobj settings set --mcp`, the MCP `write_settings` tool) starts or
+stops the embedded MCP server on the spot — no daemon restart. On the
+HTTP path, enabling fails (and nothing is persisted) if the adjacent
+port is already taken. The MCP tool instead persists first and
+reconciles in the background, so a self-disabling agent's final
+response can flush before the server stops.
+
+Both `PUT /settings` and the MCP `write_settings` tool take a partial
+body and merge it onto the current settings: any field you omit keeps
+its stored value, so a write that leaves out `mcpEnabled` will not stop
+a running MCP server.

--- a/services/dobjd/src/main.rs
+++ b/services/dobjd/src/main.rs
@@ -43,19 +43,34 @@ async fn main() -> Result<()> {
     let (event_tx, _initial_rx) = events::channel();
     let runs = RunRegistry::new();
 
-    let state = AppState::new(driver.clone(), event_tx.clone(), runs.clone());
+    let mcp_runtime = Arc::new(mcp::McpRuntime::new(
+        driver.clone(),
+        event_tx.clone(),
+        runs.clone(),
+        format!("127.0.0.1:{mcp_port}"),
+    ));
+
+    let state = AppState::new(
+        driver.clone(),
+        event_tx.clone(),
+        runs.clone(),
+        mcp_runtime.clone(),
+    );
     let app = routes::router(state);
 
-    // Bind both listeners up-front so we fail fast and synchronously if
-    // either port is taken. Without this, an MCP bind failure would surface
-    // asynchronously (or get lost in a spawned task) while the HTTP side
-    // looks healthy — and a half-running dobjd is worse than no dobjd,
-    // because every other client expects MCP on the adjacent port.
+    // Bind both ports up-front (HTTP here, MCP via `prebind`) so startup
+    // fails fast and synchronously if a port is taken -- a half-running
+    // dobjd is worse than no dobjd. The MCP listener is only served once
+    // the circuits are warm (the `apply` below), so the first MCP action
+    // does not pay the cold-build cost.
     let addr = format!("127.0.0.1:{port}");
     let http_listener = tokio::net::TcpListener::bind(&addr).await?;
 
-    let mcp_addr = format!("127.0.0.1:{mcp_port}");
-    let mcp_listener = tokio::net::TcpListener::bind(&mcp_addr).await?;
+    let mcp_enabled = driver.load_settings()?.mcp_enabled;
+    mcp_runtime.prebind(mcp_enabled).await?;
+    if !mcp_enabled {
+        tracing::info!("MCP server disabled by settings (mcpEnabled=false)");
+    }
 
     // Load the proving circuits (recursive MainPod, empty pod, and the VDF +
     // lt_eq_u256 intro pods) before accepting requests, so the first action
@@ -70,6 +85,10 @@ async fn main() -> Result<()> {
         .await
         .map_err(|err| anyhow!("circuit warm-up task panicked: {err}"))?;
 
+    // Circuits are warm; serve the pre-bound MCP listener (no-op when
+    // disabled). Deferred to here so an MCP action can't land mid-warm-up.
+    mcp_runtime.apply(mcp_enabled).await?;
+
     // Reap terminal runs whose retention window has elapsed, bounding the
     // in-memory registry. Runs that are still in flight are never reaped.
     let reaper_runs = runs.clone();
@@ -80,20 +99,6 @@ async fn main() -> Result<()> {
             reaper_runs.reap();
         }
     });
-
-    // Both ports are ours. Spawn the MCP server; share `Arc<Driver>`, the
-    // broadcast hub, and the run registry so MCP, the desktop, and the
-    // website drive one process and one set of runs.
-    let mcp_event_tx = event_tx.clone();
-    let mcp_driver = driver.clone();
-    let mcp_runs = runs.clone();
-    tokio::spawn(async move {
-        if let Err(err) = start_mcp_server(mcp_driver, mcp_event_tx, mcp_runs, mcp_listener).await {
-            tracing::error!("MCP server crashed after startup: {err:#}");
-            std::process::exit(1);
-        }
-    });
-    tracing::info!("MCP server listening on http://{mcp_addr}/mcp");
 
     tracing::info!("listening on http://{addr}");
     axum::serve(http_listener, app).await?;
@@ -113,19 +118,6 @@ fn http_port_from_env() -> Result<u16> {
 fn mcp_port_for_http_port(port: u16) -> Result<u16> {
     port.checked_add(1)
         .ok_or_else(|| anyhow!("DOBJD_PORT={port} cannot derive an adjacent MCP port"))
-}
-
-async fn start_mcp_server(
-    driver: Arc<Driver>,
-    events: events::EventTx,
-    runs: RunRegistry,
-    listener: tokio::net::TcpListener,
-) -> Result<()> {
-    let ops = mcp::DobjdOps::new(driver, events, runs);
-    let config = dobj_mcp::McpConfig::default();
-    let server = dobj_mcp::McpServer::new(ops, config);
-    server.serve(listener).await?;
-    Ok(())
 }
 
 /// Initialize the global tracing subscriber.

--- a/services/dobjd/src/mcp.rs
+++ b/services/dobjd/src/mcp.rs
@@ -1,30 +1,162 @@
 //! MCP (Model Context Protocol) operations backed by the same `Arc<Driver>`
-//! and broadcast hub used by the HTTP routes.
+//! and broadcast hub used by the HTTP routes, plus the runtime that starts
+//! and stops the embedded MCP server when the `mcpEnabled` setting changes.
 //!
-//! Most methods are thin passes through the driver — the MCP types are
-//! aliases for the same `wire-types` definitions the HTTP routes use, so
-//! there's nothing to convert.
+//! Most `DobjdOps` methods are thin passes through the driver -- the MCP
+//! types are aliases for the same `wire-types` definitions the HTTP routes
+//! use, so there's nothing to convert.
 
 use std::sync::Arc;
+use std::time::Duration;
 
+use anyhow::{Context, Result};
+use dobj_mcp::CancellationToken;
 use dobj_mcp::ops::DobjOps;
 use dobj_mcp::types as mcp;
+use tokio::task::JoinHandle;
 
 use crate::events::EventTx;
 use crate::runs::RunRegistry;
+
+/// How long a stop waits for graceful shutdown (in-flight responses
+/// flushing, sessions closing) before the serve task is aborted outright.
+const SHUTDOWN_GRACE: Duration = Duration::from_secs(5);
+
+/// Owns the embedded MCP server's lifecycle. When enabled, the listener is
+/// bound and served; when disabled, the port is not bound at all. [`apply`]
+/// is the single reconcile point for every settings write path (HTTP PUT,
+/// MCP `write_settings`, startup).
+///
+/// [`apply`]: McpRuntime::apply
+pub struct McpRuntime {
+    driver: Arc<::driver::Driver>,
+    events: EventTx,
+    runs: RunRegistry,
+    addr: String,
+    running: tokio::sync::Mutex<Option<RunningServer>>,
+    prebound: tokio::sync::Mutex<Option<tokio::net::TcpListener>>,
+}
+
+struct RunningServer {
+    cancel: CancellationToken,
+    task: JoinHandle<()>,
+}
+
+impl McpRuntime {
+    pub fn new(
+        driver: Arc<::driver::Driver>,
+        events: EventTx,
+        runs: RunRegistry,
+        addr: String,
+    ) -> Self {
+        Self {
+            driver,
+            events,
+            runs,
+            addr,
+            running: tokio::sync::Mutex::new(None),
+            prebound: tokio::sync::Mutex::new(None),
+        }
+    }
+
+    /// Bind the listener up front without serving it, so a taken port fails
+    /// startup fast -- ahead of the slow circuit warm-up rather than after.
+    /// The next [`apply(true)`] serves this pre-bound listener instead of
+    /// binding a fresh one, so the first MCP action arrives on warm circuits.
+    ///
+    /// [`apply(true)`]: McpRuntime::apply
+    pub async fn prebind(&self, enabled: bool) -> Result<()> {
+        if !enabled {
+            return Ok(());
+        }
+        let listener = tokio::net::TcpListener::bind(&self.addr)
+            .await
+            .with_context(|| format!("binding MCP listener on {}", self.addr))?;
+        *self.prebound.lock().await = Some(listener);
+        Ok(())
+    }
+
+    /// Reconcile the running server with the desired setting. Idempotent;
+    /// concurrent calls serialize on the internal lock. A failed enable
+    /// (e.g. the port is taken) returns the error to the caller and leaves
+    /// the server stopped.
+    pub async fn apply(self: &Arc<Self>, enabled: bool) -> Result<()> {
+        let mut running = self.running.lock().await;
+        if enabled {
+            if running.is_some() {
+                return Ok(());
+            }
+            // Serve the listener `prebind` bound at startup if there is one;
+            // a runtime enable (no pre-bind) binds fresh here instead.
+            let listener = match self.prebound.lock().await.take() {
+                Some(listener) => listener,
+                None => tokio::net::TcpListener::bind(&self.addr)
+                    .await
+                    .with_context(|| format!("binding MCP listener on {}", self.addr))?,
+            };
+            let ops = DobjdOps::new(
+                self.driver.clone(),
+                self.events.clone(),
+                self.runs.clone(),
+                self.clone(),
+            );
+            let cancel = CancellationToken::new();
+            let config = dobj_mcp::McpConfig {
+                cancellation_token: cancel.clone(),
+            };
+            let server = dobj_mcp::McpServer::new(ops, config);
+            let task = tokio::spawn(async move {
+                if let Err(err) = server.serve(listener).await {
+                    // A crashed (not cancelled) MCP server leaves the daemon
+                    // half-running; refuse to limp along.
+                    tracing::error!("MCP server crashed: {err:#}");
+                    std::process::exit(1);
+                }
+            });
+            tracing::info!("MCP server listening on http://{}/mcp", self.addr);
+            *running = Some(RunningServer { cancel, task });
+        } else if let Some(server) = running.take() {
+            // Hold the lock across shutdown deliberately: the serve task keeps
+            // the listener bound until its future drops, so releasing here
+            // would let a concurrent `apply(true)` try to rebind a port that
+            // is still in use. The wait is bounded by SHUTDOWN_GRACE and is
+            // near-instant once cancellation closes any open sessions.
+            server.cancel.cancel();
+            let mut task = server.task;
+            if tokio::time::timeout(SHUTDOWN_GRACE, &mut task)
+                .await
+                .is_err()
+            {
+                // Dropping the serve future closes the listener and every
+                // connection a lingering session was holding open.
+                task.abort();
+                let _ = task.await;
+            }
+            tracing::info!("MCP server stopped");
+        }
+        Ok(())
+    }
+}
 
 pub struct DobjdOps {
     driver: Arc<::driver::Driver>,
     events: EventTx,
     runs: RunRegistry,
+    mcp_runtime: Arc<McpRuntime>,
 }
 
 impl DobjdOps {
-    pub fn new(driver: Arc<::driver::Driver>, events: EventTx, runs: RunRegistry) -> Self {
+    pub fn new(
+        driver: Arc<::driver::Driver>,
+        events: EventTx,
+        runs: RunRegistry,
+        mcp_runtime: Arc<McpRuntime>,
+    ) -> Self {
         Self {
             driver,
             events,
             runs,
+            mcp_runtime,
         }
     }
 }
@@ -109,8 +241,27 @@ impl DobjOps for DobjdOps {
         self.driver.load_settings()
     }
 
-    fn write_settings(&self, settings: mcp::DriverSettings) -> anyhow::Result<mcp::DriverSettings> {
-        self.driver.save_settings(&settings)
+    fn write_settings(
+        &self,
+        patch: mcp::DriverSettingsPatch,
+    ) -> anyhow::Result<mcp::DriverSettings> {
+        // Merge onto current so an omitted field keeps its value; in
+        // particular, a patch without `mcpEnabled` must not stop the server
+        // the calling agent is connected through.
+        let mut merged = self.driver.load_settings()?;
+        patch.apply_to(&mut merged);
+        let saved = self.driver.save_settings(&merged)?;
+        // Reconcile asynchronously: this is a sync trait method, and an agent
+        // disabling MCP over MCP needs this response to flush before the
+        // graceful shutdown tears the transport down.
+        let runtime = self.mcp_runtime.clone();
+        let enabled = saved.mcp_enabled;
+        tokio::spawn(async move {
+            if let Err(err) = runtime.apply(enabled).await {
+                tracing::error!("failed to apply MCP setting: {err:#}");
+            }
+        });
+        Ok(saved)
     }
 
     fn get_objects_dir(&self) -> anyhow::Result<String> {

--- a/services/dobjd/src/routes/settings.rs
+++ b/services/dobjd/src/routes/settings.rs
@@ -1,5 +1,5 @@
 use axum::{Json, extract::State};
-use wire_types::DriverSettings;
+use wire_types::{DriverSettings, DriverSettingsPatch};
 
 use crate::error::ApiResult;
 use crate::state::AppState;
@@ -11,8 +11,20 @@ pub async fn get_settings(State(state): State<AppState>) -> ApiResult<Json<Drive
 
 pub async fn put_settings(
     State(state): State<AppState>,
-    Json(input): Json<DriverSettings>,
+    Json(patch): Json<DriverSettingsPatch>,
 ) -> ApiResult<Json<DriverSettings>> {
-    let saved = state.driver.save_settings(&input)?;
+    // Merge onto the current settings so an absent field keeps its value
+    // rather than reverting to a type default -- in particular, a body that
+    // omits `mcpEnabled` must not stop a running MCP server.
+    let mut merged = state.driver.load_settings()?;
+    patch.apply_to(&mut merged);
+    // Reconcile the MCP server before persisting, so a failed enable (the
+    // adjacent port is taken) is reported to the caller without recording
+    // a setting that isn't in effect. If `apply` succeeds but the save below
+    // then fails, the running server and the persisted setting diverge with
+    // no rollback; save failures are rare and otherwise fatal, so we accept
+    // it rather than add a compensating stop/restart.
+    state.mcp.apply(merged.mcp_enabled).await?;
+    let saved = state.driver.save_settings(&merged)?;
     Ok(Json(saved))
 }

--- a/services/dobjd/src/state.rs
+++ b/services/dobjd/src/state.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use driver::Driver;
 
 use crate::events::EventTx;
+use crate::mcp::McpRuntime;
 use crate::runs::RunRegistry;
 
 #[derive(Clone)]
@@ -10,14 +11,21 @@ pub struct AppState {
     pub driver: Arc<Driver>,
     pub events: EventTx,
     pub runs: RunRegistry,
+    pub mcp: Arc<McpRuntime>,
 }
 
 impl AppState {
-    pub fn new(driver: Arc<Driver>, events: EventTx, runs: RunRegistry) -> Self {
+    pub fn new(
+        driver: Arc<Driver>,
+        events: EventTx,
+        runs: RunRegistry,
+        mcp: Arc<McpRuntime>,
+    ) -> Self {
         Self {
             driver,
             events,
             runs,
+            mcp,
         }
     }
 }


### PR DESCRIPTION
Closes #153 

This adds a setting to enable/disable the MCP server. It's off by default, so must be enabled intentionally before use. Enabling/disabling takes effect immediately, so the MCP server will be stopped or started in response to the configuration change.