### PR TITLE
Include pexe binary in releases

### DIFF
--- a/.github/release-notes.md.tpl
+++ b/.github/release-notes.md.tpl
@@ -4,9 +4,9 @@ Paste this to Claude Code, Cursor, or any MCP-aware agent:
 
 > Read https://raw.githubusercontent.com/dobjlabs/digital-objects-network/main/INSTALL.md, install and start the Digital Objects driver, install the craft-rocket plugin, and configure MCP for this agent if supported.
 
-The guide installs `dobjd`, `dobj`, and `dobj-mcp-proxy` into `~/.dobj/`.
-The prompt also asks the agent to install the `craft-rocket` plugin and
-register MCP so you can drive Digital Objects directly.
+The guide installs `dobjd`, `dobj`, `dobj-mcp-proxy`, and `pexe` into
+`~/.dobj/`. The prompt also asks the agent to install the `craft-rocket`
+plugin and register MCP so you can drive Digital Objects directly.
 
 ## Manual install
 
@@ -15,7 +15,7 @@ See [INSTALL.md](https://github.com/dobjlabs/digital-objects-network/blob/main/I
 ## Upgrading
 
 Already installed? Run `dobj update` to upgrade in place to this release. It
-swaps `dobj`, `dobjd`, and `dobj-mcp-proxy` as a unit (atomic, with
+swaps `dobj`, `dobjd`, `dobj-mcp-proxy`, and `pexe` as a unit (atomic, with
 rollback) and leaves your plugins under `~/.dobj/actions/` untouched.
 
 ## What's in the release
@@ -23,6 +23,9 @@ rollback) and leaves your plugins under `~/.dobj/actions/` untouched.
 - **`dobjd-{target}.tar.gz`** — the daemon (HTTP API on `:7717`,
   MCP on `:7718`). Bundles `dobj-mcp-proxy` alongside.
 - **`dobj-{target}.tar.gz`** — terminal CLI for the daemon.
+- **`pexe-{target}.tar.gz`** — packaging tool for building and inspecting
+  `.pexe` plugin archives. The installer drops it in `~/.dobj/bin` alongside
+  `dobj`; plugin authors use it to produce the `*.pexe` files below.
 - **`*.pexe`** — the example plugins, one archive per plugin under
   `examples/` (e.g. `craft-basics.pexe`, `craft-rocket.pexe`).
 

--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -5,6 +5,7 @@ name: Install test
 # relayer + dobjd — pointed at Ethereum Sepolia.
 # Then exercises the full action round-trip:
 # `dobj start → status → actions → run FindLog → objects → stop`.
+# Also verifies the shipped `pexe` binary runs and reports the release tag.
 #
 # Triggered:
 #   - automatically at the end of the Release workflow, which calls this as
@@ -204,6 +205,7 @@ jobs:
           patterns=(
             --pattern "dobjd-$TARGET.tar.gz"
             --pattern "dobj-$TARGET.tar.gz"
+            --pattern "pexe-$TARGET.tar.gz"
             --pattern "synchronizer-$TARGET.tar.gz"
             --pattern "relayer-$TARGET.tar.gz"
             --pattern "craft-basics*.pexe"
@@ -229,7 +231,8 @@ jobs:
           mkdir -p ~/.dobj/bin ~/.dobj/actions
           tar -xzf "artifacts/dobjd-$TARGET.tar.gz" -C ~/.dobj/bin
           tar -xzf "artifacts/dobj-$TARGET.tar.gz"  -C ~/.dobj/bin
-          chmod +x ~/.dobj/bin/dobjd ~/.dobj/bin/dobj ~/.dobj/bin/dobj-mcp-proxy
+          tar -xzf "artifacts/pexe-$TARGET.tar.gz"  -C ~/.dobj/bin
+          chmod +x ~/.dobj/bin/dobjd ~/.dobj/bin/dobj ~/.dobj/bin/dobj-mcp-proxy ~/.dobj/bin/pexe
           PEXE=$(find artifacts -maxdepth 1 -name 'craft-basics*.pexe' | head -1)
           cp "$PEXE" ~/.dobj/actions/craft-basics.pexe
 
@@ -261,6 +264,7 @@ jobs:
           New-Item -ItemType Directory -Force -Path "$DOBJ\bin", "$DOBJ\actions" | Out-Null
           tar -xzf "artifacts\dobjd-$env:TARGET.tar.gz" -C "$DOBJ\bin"
           tar -xzf "artifacts\dobj-$env:TARGET.tar.gz"  -C "$DOBJ\bin"
+          tar -xzf "artifacts\pexe-$env:TARGET.tar.gz"  -C "$DOBJ\bin"
           $pexe = Get-ChildItem artifacts -Filter 'craft-basics*.pexe' | Select-Object -First 1
           Copy-Item $pexe.FullName -Destination "$DOBJ\actions\craft-basics.pexe"
 
@@ -275,6 +279,40 @@ jobs:
             "relayerApiUrl": "http://127.0.0.1:3200"
           }
           '@ | Set-Content -Path "$DOBJ\settings.json"
+
+      # =====================================================================
+      # Verify the shipped pexe binary. Independent of the daemon and the
+      # Sepolia round-trip, so it runs right after staging and fails fast on a
+      # broken artifact instead of after the multi-minute stack bringup.
+      # =====================================================================
+
+      - name: Verify pexe (Unix)
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Same check `dobj update` makes before committing a swap: confirm the
+          # cross-compiled, signed binary actually runs on this platform (right
+          # arch, deps present, not Gatekeeper-killed) and reports the tag it
+          # shipped in. Token match (not substring) so a superstring tag like
+          # v0.1.0-rc.5 can't satisfy a v0.1.0 target.
+          out=$(~/.dobj/bin/pexe --version)
+          echo "$out"
+          echo "$out" | tr ' ' '\n' | grep -qxF "$TAG" \
+            || { echo "::error::pexe --version reported '$out', expected the tag $TAG"; exit 1; }
+
+      - name: Verify pexe (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $pexe = "$env:USERPROFILE\.dobj\bin\pexe.exe"
+          $out = (& $pexe --version) -join ' '
+          if ($LASTEXITCODE -ne 0) { throw "pexe --version failed ($LASTEXITCODE)" }
+          Write-Host $out
+          # Token match against the release tag (see the Unix step's rationale).
+          if (($out -split '\s+') -notcontains $env:TAG) {
+              throw "pexe --version reported '$out', expected the tag $env:TAG"
+          }
 
       # =====================================================================
       # Resolve a recent Sepolia slot so the synchronizer doesn't waste

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,8 @@ name: Release
 
 # Single workflow producing every Digital Objects Network release artifact: the daemon
 # (`dobjd`), CLI (`dobj`), Claude Desktop stdio bridge (`dobj-mcp-proxy`),
-# and every example plugin under `examples/` packaged as a `.pexe`.
+# plugin packaging tool (`pexe`), and every example plugin under `examples/`
+# packaged as a `.pexe`.
 # Triggered on `v*` tags or via the Actions UI with a tag name.
 #
 # On macOS, every native binary is codesigned + notarized so users get an
@@ -91,10 +92,12 @@ jobs:
 
   dobjd:
     # Builds and signs every native binary that ships in the release: the
-    # daemon (`dobjd`) is the dominant artifact, with `dobj` (the CLI) and
-    # `dobj-mcp-proxy` riding alongside. Named after dobjd because the
-    # daemon is the load-bearing piece — the others are thin wrappers
-    # around its HTTP/MCP surfaces.
+    # daemon (`dobjd`) is the dominant artifact, with `dobj` (the CLI),
+    # `dobj-mcp-proxy`, and `pexe` (the plugin packaging tool) riding
+    # alongside. Named after dobjd because the daemon is the load-bearing
+    # piece — the others are thin wrappers around its HTTP/MCP surfaces or,
+    # for pexe, an author-side companion that builds the `.pexe` plugins it
+    # loads.
     needs: validate
     strategy:
       fail-fast: false
@@ -182,6 +185,12 @@ jobs:
         # the dobj CLI.
         run: cargo build --release --locked -p dobj-mcp --bin dobj-mcp-proxy --features proxy --target ${{ matrix.target }}
 
+      - name: Build pexe
+        # Plugin packaging tool, shipped so authors can build/inspect `.pexe`
+        # archives. Pure-Rust deps only (zip + flate2's rust_backend), so it
+        # cross-compiles like the rest of the bundle.
+        run: cargo build --release --locked -p pexe --target ${{ matrix.target }}
+
       - name: Build synchronizer
         # Server binary used by the install-test workflow to spin up a
         # local stack per platform. Pulls in rocksdb — Windows needs
@@ -215,13 +224,15 @@ jobs:
           #
           DOBJD_STAGE="$GITHUB_WORKSPACE/staging/dobjd"
           DOBJ_STAGE="$GITHUB_WORKSPACE/staging/dobj"
-          mkdir -p "$DOBJD_STAGE" "$DOBJ_STAGE"
+          PEXE_STAGE="$GITHUB_WORKSPACE/staging/pexe"
+          mkdir -p "$DOBJD_STAGE" "$DOBJ_STAGE" "$PEXE_STAGE"
 
           # ${{ matrix.exe_suffix }} is `.exe` on Windows, empty everywhere
           # else, so a single set of cp lines works across all targets.
           cp "$OUT/dobjd${{ matrix.exe_suffix }}"              "$DOBJD_STAGE/"
           cp "$OUT/dobj-mcp-proxy${{ matrix.exe_suffix }}" "$DOBJD_STAGE/"
           cp "$OUT/dobj${{ matrix.exe_suffix }}"               "$DOBJ_STAGE/"
+          cp "$OUT/pexe${{ matrix.exe_suffix }}"               "$PEXE_STAGE/"
 
           # Diagnostic dump of dobjd's dynamic deps. If anyone ever bumps
           # the dep graph in a way that pulls in a C library (rocksdb,
@@ -234,11 +245,12 @@ jobs:
             *-pc-windows-*)  echo "(deps diagnostic skipped on windows: dumpbin lives in MSVC Build Tools and is awkward from Git Bash; rustls + bundled-CRT keeps Windows binaries dep-free anyway)" ;;
           esac
 
-          ls -la "$DOBJD_STAGE" "$DOBJ_STAGE"
+          ls -la "$DOBJD_STAGE" "$DOBJ_STAGE" "$PEXE_STAGE"
 
           {
             echo "DOBJD_STAGE=$DOBJD_STAGE"
             echo "DOBJ_STAGE=$DOBJ_STAGE"
+            echo "PEXE_STAGE=$PEXE_STAGE"
           } >> "$GITHUB_ENV"
 
       - name: Stage server binaries (synchronizer + relayer)
@@ -324,6 +336,8 @@ jobs:
             --options runtime --timestamp "$DOBJD_STAGE/dobj-mcp-proxy"
           codesign --force --sign "$IDENTITY" \
             --options runtime --timestamp "$DOBJ_STAGE/dobj"
+          codesign --force --sign "$IDENTITY" \
+            --options runtime --timestamp "$PEXE_STAGE/pexe"
 
           # Server binaries (used by install-test only) — sign them too
           # so notarization below doesn't reject the bundle. The archiver is
@@ -341,6 +355,7 @@ jobs:
           codesign --verify --verbose=2 "$DOBJD_STAGE/dobjd"
           codesign --verify --verbose=2 "$DOBJD_STAGE/dobj-mcp-proxy"
           codesign --verify --verbose=2 "$DOBJ_STAGE/dobj"
+          codesign --verify --verbose=2 "$PEXE_STAGE/pexe"
           codesign --verify --verbose=2 "$SYNCHRONIZER_STAGE/synchronizer"
           codesign --verify --verbose=2 "$RELAYER_STAGE/relayer"
           codesign --verify --verbose=2 "$ARCHIVER_STAGE/archiver"
@@ -374,6 +389,7 @@ jobs:
           set -euo pipefail
           tar -czf "dobjd-${{ matrix.target }}.tar.gz"        -C "$DOBJD_STAGE"        .
           tar -czf "dobj-${{ matrix.target }}.tar.gz"         -C "$DOBJ_STAGE"         .
+          tar -czf "pexe-${{ matrix.target }}.tar.gz"         -C "$PEXE_STAGE"         .
           tar -czf "synchronizer-${{ matrix.target }}.tar.gz" -C "$SYNCHRONIZER_STAGE" .
           tar -czf "relayer-${{ matrix.target }}.tar.gz"      -C "$RELAYER_STAGE"      .
           # Archiver tarball on Linux/macOS only (no archiver build on Windows).
@@ -400,6 +416,7 @@ jobs:
           files: |
             dobjd-${{ matrix.target }}.tar.gz
             dobj-${{ matrix.target }}.tar.gz
+            pexe-${{ matrix.target }}.tar.gz
             synchronizer-${{ matrix.target }}.tar.gz
             relayer-${{ matrix.target }}.tar.gz
           tag_name: ${{ env.RELEASE_TAG }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6076,7 +6076,6 @@ dependencies = [
 [[package]]
 name = "pod2"
 version = "0.1.0"
-source = "git+https://github.com/0xPARC/pod2?rev=17177e055b56595c29e2588707da324fad7f5f36#17177e055b56595c29e2588707da324fad7f5f36"
 dependencies = [
  "annotate-snippets",
  "anyhow",

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -7,6 +7,7 @@ Installing the driver gives you:
   - MCP on `http://127.0.0.1:7718/mcp` (off by default; see [Connect an agent](#connect-an-agent-mcp))
 - `~/.dobj/bin/dobj` — terminal CLI that talks to dobjd
 - `~/.dobj/bin/dobj-mcp-proxy` — stdio↔HTTP bridge for agents that only speak stdio (e.g. Claude Desktop)
+- `~/.dobj/bin/pexe` — packaging tool for building and inspecting `.pexe` plugin archives
 
 The driver installs with an **empty action catalog** — applications ship as
 plugins (`.pexe` files). See [Next steps](#next-steps) for installing one,
@@ -197,13 +198,14 @@ case "$(uname -s)-$(uname -m)" in
   *) echo "unsupported platform: $(uname -sm)"; exit 1 ;;
 esac
 
-# 2. Download and extract the two artifacts. Substitute a pinned tag for
+# 2. Download and extract the three artifacts. Substitute a pinned tag for
 #    `latest/download` -> `download/<tag>` if you don't want the newest.
 RELEASE=https://github.com/dobjlabs/digital-objects-network/releases/latest/download
 mkdir -p ~/.dobj/bin
 curl -fsSL "$RELEASE/dobjd-$TARGET.tar.gz" | tar -xz -C ~/.dobj/bin
 curl -fsSL "$RELEASE/dobj-$TARGET.tar.gz"  | tar -xz -C ~/.dobj/bin
-chmod +x ~/.dobj/bin/dobjd ~/.dobj/bin/dobj ~/.dobj/bin/dobj-mcp-proxy
+curl -fsSL "$RELEASE/pexe-$TARGET.tar.gz"  | tar -xz -C ~/.dobj/bin
+chmod +x ~/.dobj/bin/dobjd ~/.dobj/bin/dobj ~/.dobj/bin/dobj-mcp-proxy ~/.dobj/bin/pexe
 ```
 
 **Windows (PowerShell):**
@@ -213,7 +215,7 @@ $TARGET  = "x86_64-pc-windows-msvc"     # the only Windows target built
 $RELEASE = "https://github.com/dobjlabs/digital-objects-network/releases/latest/download"
 $DOBJ    = "$env:USERPROFILE\.dobj"
 New-Item -ItemType Directory -Force -Path "$DOBJ\bin" | Out-Null
-foreach ($name in @("dobjd", "dobj")) {
+foreach ($name in @("dobjd", "dobj", "pexe")) {
     $tmp = "$DOBJ\$name-$TARGET.tar.gz"
     curl.exe -fsSL "$RELEASE/$name-$TARGET.tar.gz" -o $tmp
     tar -xzf $tmp -C "$DOBJ\bin"
@@ -227,6 +229,7 @@ Then continue from [Start and verify](#start-and-verify).
 
 - **`dobjd-{target}.tar.gz`** — the daemon. Bundles `dobj-mcp-proxy` alongside.
 - **`dobj-{target}.tar.gz`** — terminal CLI for the daemon.
+- **`pexe-{target}.tar.gz`** — packaging tool for building and inspecting `.pexe` plugin archives.
 - **`craft-basics.pexe`** and **`craft-rocket.pexe`** — example plugins
   (optional; see Next steps).
 

--- a/install.ps1
+++ b/install.ps1
@@ -2,8 +2,9 @@
 #
 #   irm https://raw.githubusercontent.com/dobjlabs/digital-objects-network/main/install.ps1 | iex
 #
-# Installs dobj.exe (CLI), dobjd.exe (daemon), and dobj-mcp-proxy.exe from
-# the latest published release into %USERPROFILE%\.dobj\bin. Pin a version:
+# Installs dobj.exe (CLI), dobjd.exe (daemon), dobj-mcp-proxy.exe, and
+# pexe.exe (the plugin packaging tool) from the latest published release into
+# %USERPROFILE%\.dobj\bin. Pin a version:
 #
 #   $env:DOBJ_VERSION = "v0.1.0"; irm ... | iex
 #
@@ -51,7 +52,7 @@ $Tmp = Join-Path $env:TEMP "dobj-install-$([System.IO.Path]::GetRandomFileName()
 New-Item -ItemType Directory -Force -Path $Tmp | Out-Null
 
 try {
-    foreach ($name in @("dobjd", "dobj")) {
+    foreach ($name in @("dobjd", "dobj", "pexe")) {
         $url = "$Base/$name-$Target.tar.gz"
         Write-Host "  fetching $name-$Target.tar.gz ..."
         # curl.exe explicitly: bare `curl` is a PowerShell alias for
@@ -69,7 +70,7 @@ try {
 
     New-Item -ItemType Directory -Force -Path $BinDir | Out-Null
 
-    foreach ($name in @("dobjd", "dobj")) {
+    foreach ($name in @("dobjd", "dobj", "pexe")) {
         Get-ChildItem "$Tmp\$name" -File | ForEach-Object {
             Move-Item -Force $_.FullName (Join-Path $BinDir $_.Name)
             Write-Host "  installed $BinDir\$($_.Name)"

--- a/install.sh
+++ b/install.sh
@@ -3,8 +3,9 @@
 #
 #   curl -fsSL https://raw.githubusercontent.com/dobjlabs/digital-objects-network/main/install.sh | sh
 #
-# Installs `dobj` (CLI), `dobjd` (daemon), and `dobj-mcp-proxy` from the
-# latest published release into ~/.dobj/bin. Pin a version with:
+# Installs `dobj` (CLI), `dobjd` (daemon), `dobj-mcp-proxy`, and `pexe` (the
+# plugin packaging tool) from the latest published release into ~/.dobj/bin.
+# Pin a version with:
 #
 #   DOBJ_VERSION=v0.1.0 curl -fsSL ... | sh
 #
@@ -50,7 +51,7 @@ fi
 TMP=$(mktemp -d)
 trap 'rm -rf "$TMP"' EXIT INT TERM
 
-for name in dobjd dobj; do
+for name in dobjd dobj pexe; do
   url="$BASE/$name-$TARGET.tar.gz"
   say "  fetching $name-$TARGET.tar.gz ..."
   curl -fsSL --retry 3 -o "$TMP/$name.tar.gz" "$url" || err "download failed: $url
@@ -73,7 +74,7 @@ if [ -f "$PIDFILE" ] && kill -0 "$(cat "$PIDFILE" 2>/dev/null)" 2>/dev/null; the
   say "  note: dobjd is running; restart it afterwards to use the new version"
 fi
 
-for name in dobjd dobj; do
+for name in dobjd dobj pexe; do
   for src in "$TMP/$name"/*; do
     base=$(basename "$src")
     cp "$src" "$BIN_DIR/.$base.new"

--- a/interfaces/cli/src/main.rs
+++ b/interfaces/cli/src/main.rs
@@ -133,7 +133,7 @@ enum Cmd {
         #[arg(short = 'n', long, default_value_t = 100)]
         lines: usize,
     },
-    /// Update dobj, dobjd, and dobj-mcp-proxy to a newer release.
+    /// Update dobj, dobjd, dobj-mcp-proxy, and pexe to a newer release.
     Update {
         /// Report current and latest versions without changing anything.
         #[arg(long)]

--- a/interfaces/cli/src/update.rs
+++ b/interfaces/cli/src/update.rs
@@ -1,5 +1,5 @@
 //! `dobj update`: replace the installed bundle (dobj, dobjd,
-//! dobj-mcp-proxy) with another release from the project's GitHub releases.
+//! dobj-mcp-proxy, pexe) with another release from the project's GitHub releases.
 //!
 //! The bundle updates as a unit: every binary comes from one release tag and
 //! the swap is all-or-nothing (two-phase rename with rollback). Plugins under
@@ -33,9 +33,15 @@ const TARGET_TRIPLE: &str = env!("DOBJ_TARGET_TRIPLE");
 /// Tarballs in a release and the binaries each must contain, in swap order.
 /// `dobj` is last: the update is orchestrated by the running `dobj`, and
 /// keeping its on-disk file consistent with the executing code until
-/// everything else has landed keeps rollback reasoning simple.
-const ARTIFACTS: &[(&str, &[&str])] =
-    &[("dobjd", &["dobjd", "dobj-mcp-proxy"]), ("dobj", &["dobj"])];
+/// everything else has landed keeps rollback reasoning simple. `pexe` is
+/// swapped like the rest, but it neither drives the update nor is read during
+/// it, so where it falls in the order doesn't matter; it goes before `dobj`
+/// only to keep `dobj` last.
+const ARTIFACTS: &[(&str, &[&str])] = &[
+    ("dobjd", &["dobjd", "dobj-mcp-proxy"]),
+    ("pexe", &["pexe"]),
+    ("dobj", &["dobj"]),
+];
 
 pub async fn run(
     client: &DobjdClient,
@@ -161,7 +167,7 @@ pub async fn run(
 
     let _ = fs::remove_dir_all(&staging);
     println!(
-        "updated {CURRENT_TAG} -> {target_tag} (dobj, dobjd, dobj-mcp-proxy){}",
+        "updated {CURRENT_TAG} -> {target_tag} (dobj, dobjd, dobj-mcp-proxy, pexe){}",
         if was_running {
             ""
         } else {
@@ -716,7 +722,7 @@ fn rollback(journal: &[SwapEntry]) {
 /// Binaries whose `--version` output carries the release tag (built with the
 /// stamping build.rs). The proxy isn't stamped, so it is validated only for
 /// runnability, not for a matching tag.
-const STAMPED_BINARIES: &[&str] = &["dobj", "dobjd"];
+const STAMPED_BINARIES: &[&str] = &["dobj", "dobjd", "pexe"];
 
 /// Spawn every freshly installed binary with `--version` and require it to
 /// run; stamped binaries must also report the target tag. This catches

--- a/libs/pexe/build.rs
+++ b/libs/pexe/build.rs
@@ -1,0 +1,9 @@
+//! Stamps the release tag and target triple into the binary so `pexe
+//! --version` reports the release it shipped in, matching dobj and dobjd.
+//! The stamping logic is shared via `include!` of `../../build-stamp.rs`.
+
+include!("../../build-stamp.rs");
+
+fn main() {
+    stamp_build_version();
+}

--- a/libs/pexe/src/bin/pexe.rs
+++ b/libs/pexe/src/bin/pexe.rs
@@ -16,13 +16,24 @@ use pexe::{
 const DRIVER_DOBJ_HOME_DIR: &str = ".dobj";
 const DRIVER_ACTIONS_DIR: &str = "actions";
 
+/// Release tag + target triple, stamped by build.rs ("dev" outside a release
+/// build). pexe ships in the same release bundle as dobj/dobjd and `dobj
+/// update` validates every bundled binary reports the release tag, so its
+/// `--version` must read the same stamp.
+const VERSION: &str = concat!(
+    env!("DOBJ_RELEASE_TAG"),
+    " (",
+    env!("DOBJ_TARGET_TRIPLE"),
+    ")"
+);
+
 fn default_install_dir() -> Result<PathBuf> {
     let home = dirs::home_dir().ok_or_else(|| anyhow!("failed to resolve home directory"))?;
     Ok(home.join(DRIVER_DOBJ_HOME_DIR).join(DRIVER_ACTIONS_DIR))
 }
 
 #[derive(Parser, Debug)]
-#[command(name = "pexe", about = "plugin packaging tool")]
+#[command(name = "pexe", about = "plugin packaging tool", version = VERSION)]
 struct Cli {
     #[command(subcommand)]
     cmd: Cmd,

--- a/services/dobjd/README.md
+++ b/services/dobjd/README.md
@@ -99,8 +99,8 @@ just dobjd
 DOBJD_PORT=7727 cargo run --release -p dobjd
 ```
 
-Released binaries are signed + notarized on macOS. The tarball is just
-the three executables (`dobjd`, `dobj`, `dobj-mcp-proxy`).
+Released binaries are signed + notarized on macOS. The bundle is just
+the four executables (`dobjd`, `dobj`, `dobj-mcp-proxy`, `pexe`).
 Windows binaries are not codesigned yet — first run shows a SmartScreen warning.
 
 ## Lifecycle


### PR DESCRIPTION
Includes the `pexe` binary in the bundle of binaries released via the installer.