### PR TITLE
fix archiver reorg off-by-one

### DIFF
--- a/services/archiver/src/main.rs
+++ b/services/archiver/src/main.rs
@@ -92,8 +92,18 @@ async fn main() -> Result<()> {
                     "reorg: slot {} ({}) has different parent than us",
                     beacon_block_header.slot, beacon_block_header.root
                 );
-                node.store.delete_block_data(&node.store.slot_dir(slot))?;
-                prev_beacon_block_header = node.store.last_header()?;
+                // `slot` has not been stored yet.  We delete the parent and retry
+                // from there
+                loop {
+                    slot -= 1;
+                    let deleted = node.store.delete_block_data(&node.store.slot_dir(slot))?;
+                    prev_beacon_block_header = node.store.last_header()?;
+                    // Make sure we either deleted a parent slot or our store is empty.  This
+                    // handles the case of reorgs with slots that have no blocks
+                    if deleted || prev_beacon_block_header.is_none() {
+                        break;
+                    }
+                }
                 slot = prev_beacon_block_header
                     .as_ref()
                     .map(|h| h.slot + 1)

--- a/services/archiver/src/node.rs
+++ b/services/archiver/src/node.rs
@@ -86,10 +86,11 @@ pub struct Store {
 }
 
 impl Store {
-    pub(crate) fn delete_block_data(&self, slot_path: &Path) -> Result<()> {
+    /// Returns true if a slot path was deleted
+    pub(crate) fn delete_block_data(&self, slot_path: &Path) -> Result<bool> {
         match fs::symlink_metadata(slot_path) {
             Ok(_) => {}
-            Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(()),
+            Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(false),
             Err(e) => return Err(e.into()),
         }
         // `slot_path` points to `../../../by_root/{root_hi}/{root_med}/{root_lo}`, so we remove
@@ -117,7 +118,7 @@ impl Store {
         }
         info!("Removing stale symlink at {:?}", slot_path);
         fs::remove_file(slot_path)?;
-        Ok(())
+        Ok(true)
     }
 
     // Find the latest valid processed block header (and deleting stale ones if found)


### PR DESCRIPTION
The basic fix was an off-by one error.  We were deleting the slot yet to be stored, and not the previous one!
Since not all slots have blocks, there's a chance that in a reorg at slot n, slot n-1 has no block, so we're not deleting anything and we'd be stuck again.  So I've made a few changes to make sure we delete the previous slot, which may not be n-1 but lower.