### PR TITLE
fix gui after recent pod2 change broke the object display

### DIFF
--- a/interfaces/gui/src/shared/pod2utils.ts
+++ b/interfaces/gui/src/shared/pod2utils.ts
@@ -113,7 +113,10 @@ function normalizePod2Value(value: unknown): unknown {
       );
     }
 
-    if (key === "inner") {
+    // `_raw` is the daemon's fallback wrapper for an object dictionary that
+    // serialized as a pod2 container sequence ([key, value] entries) rather
+    // than a plain object; unwrap it the same way as `inner`.
+    if (key === "inner" || key === "_raw") {
       return normalizePod2ContainerInner(inner);
     }
   }


### PR DESCRIPTION
I think the object display is fragile, but I'm not sure what a more robust way to display the object fields would be. Given this is a dev-ui, I'm just patching it for now

Before:
<img width="418" height="330" alt="image" src="https://github.com/user-attachments/assets/2ba11820-b2cf-4611-af9e-9101b0d4c82a" />

After:
<img width="412" height="292" alt="Screenshot 2026-06-17 at 12 35 18 PM" src="https://github.com/user-attachments/assets/e6a681e2-da8e-497a-8634-ee2d6a5a5752" />

