### PR TITLE
add invoke_prompt

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -138,6 +138,26 @@ Claude Desktop.
 **Other agents** (Cursor, Aider, Continue, …): point their MCP configuration
 at `http://127.0.0.1:7718/mcp`.
 
+#### Optional command UX
+
+After connecting MCP and starting a fresh agent session, you can open the
+Digital Objects command menu in either client:
+
+**Codex:**
+
+```text
+Call dobj invoke_prompt with: {"name":"start","arguments":{"command":"help"}} Then follow the returned messages.
+```
+
+**Claude Code:**
+
+```text
+/mcp__dobj__start
+```
+
+This command interface is optional; all Digital Objects MCP tools remain
+available without starting it.
+
 ### Add `dobj` to your PATH
 
 **macOS / Linux:**

--- a/docs/src/pages/install.mdx
+++ b/docs/src/pages/install.mdx
@@ -138,6 +138,21 @@ Every client talks to the same daemon:
 - **Claude Code / MCP agents** — `claude mcp add --transport http dobj http://127.0.0.1:7718/mcp`
 - **Stdio-only agents (e.g. Claude Desktop)** — point them at `~/.dobj/bin/dobj-mcp-proxy`
 
+:::info
+**Optional command UX:** after connecting MCP and starting a fresh agent
+session, open the Digital Objects command menu with the appropriate client:
+
+```text [Codex]
+Call dobj invoke_prompt with: {"name":"start","arguments":{"command":"help"}} Then follow the returned messages.
+```
+
+```text [Claude Code]
+/mcp__dobj__start
+```
+
+All MCP tools remain available without starting the command interface.
+:::
+
 ::::
 
 ## Manual install

--- a/interfaces/mcp/Cargo.toml
+++ b/interfaces/mcp/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 rmcp = { version = "1.2.0", features = [
     "server",
     "macros",
+    "schemars",
     "transport-io",
     "transport-streamable-http-server",
 ] }

--- a/interfaces/mcp/README.md
+++ b/interfaces/mcp/README.md
@@ -137,10 +137,10 @@ driver).
 
 A self-contained live dashboard (`dashboard/index.html`, no build step). dobjd
 writes it to `~/.dobj/dashboard/index.html` when the MCP server starts; the
-`dashboard` prompt serves it — in Claude Code, a preview pane backed by a local static
-server on `:7719`; otherwise it points the user at the file. The generated page
-polls the active dobjd REST API port for objects, the synchronizer head, and an
-action-log SSE.
+`dashboard` prompt serves it in either the Codex in-app browser or a Claude Code
+preview pane, backed by a local static server on `:7719`; otherwise it points
+the user at the file. The generated page polls the active dobjd REST API port
+for objects, the synchronizer head, and an action-log SSE.
 
 ## Setup
 

--- a/interfaces/mcp/README.md
+++ b/interfaces/mcp/README.md
@@ -79,6 +79,7 @@ production implementation lives in
 | `read_doc`                                            | Reference docs (see Resources)                                                 |
 | `define_command` / `delete_command` / `list_commands` | Manage user-authored commands                                                  |
 | `get_command`                                         | Load any command's full body (built-in or saved) to follow it                  |
+| `invoke_prompt`                                       | Invoke any prompt through a model-callable tool for clients such as Codex      |
 
 All tools return structured content (`structuredContent` + `outputSchema`)
 for clients that support it, with a text fallback for older clients.
@@ -111,6 +112,11 @@ plus any sibling scripts the command runs. The MCP server owns this directory;
 the driver is not involved. `define_command` writes the README, `create-command`
 is the guided authoring flow, and `list_commands` / `delete_command` manage them.
 Each saved command is also surfaced as its own prompt.
+
+Clients that support MCP tools but do not expose MCP prompts directly can call
+`invoke_prompt({ "name": "start" })` and follow the returned messages. Prompt
+arguments go in `arguments`, for example
+`invoke_prompt({ "name": "start", "arguments": { "command": "help" } })`.
 
 ## Resources
 

--- a/interfaces/mcp/docs/dashboard.md
+++ b/interfaces/mcp/docs/dashboard.md
@@ -15,9 +15,26 @@ else (including no argument) -> START.
 
 ### START
 
-1. Merge this configuration into the project-local `.claude/launch.json` (create
-   the file if absent; keep any existing configurations). Replace `<HOME>` with
-   the absolute home directory path:
+Use the first supported client path below.
+
+#### Codex in-app browser
+
+1. Start this command as a long-running background process, replacing `<HOME>`
+   with the absolute home directory path. If port 7719 is already serving the
+   dashboard, reuse it instead:
+
+   `python3 -m http.server 7719 --bind 127.0.0.1 --directory <HOME>/.dobj/dashboard`
+
+2. Open `http://127.0.0.1:7719/` in the Codex in-app browser, make the browser
+   visible, verify that the `Digital Objects` heading rendered, and leave the
+   dashboard tab open.
+3. Output exactly one line: `dashboard -> http://127.0.0.1:7719/  (pane open)`.
+
+#### Claude Preview
+
+1. Merge this configuration into the project-local `.claude/launch.json`
+   (create the file if absent; keep any existing configurations). Replace
+   `<HOME>` with the absolute home directory path:
 
    { "name": "dobj-dashboard", "runtimeExecutable": "python3",
    "runtimeArgs": ["-m", "http.server", "7719", "--directory", "<HOME>/.dobj/dashboard"],
@@ -25,12 +42,18 @@ else (including no argument) -> START.
 
 2. Call `preview_start` with `{name: "dobj-dashboard"}`.
 3. Output exactly one line: `dashboard -> http://127.0.0.1:7719/  (pane open)`.
-   If the Claude Preview tool is unavailable or `preview_start` errors, output
-   exactly one line instead: `dashboard -> open ~/.dobj/dashboard/index.html in your browser`.
+
+If neither client path is available, output exactly one line instead:
+`dashboard -> open ~/.dobj/dashboard/index.html in your browser`.
 
 ### STOP
 
-1. Call `preview_list`, find the entry named `dobj-dashboard`, and call
-   `preview_stop` with its `serverId`.
-2. Output exactly one line: `dashboard stopped` -- or `no dashboard to stop` if
-   there is no such entry.
+Use the active client's path:
+
+- Codex: close the in-app browser tab at `http://127.0.0.1:7719/` and stop the
+  background static server started by this command.
+- Claude Preview: call `preview_list`, find the entry named `dobj-dashboard`,
+  and call `preview_stop` with its `serverId`.
+
+Output exactly one line: `dashboard stopped` -- or `no dashboard to stop` if
+there is no open dashboard or server.

--- a/interfaces/mcp/docs/instructions.md
+++ b/interfaces/mcp/docs/instructions.md
@@ -13,8 +13,10 @@ built in, plus any the user has defined). When the user types a command's name,
 or a short phrase that clearly refers to one, call `get_command(name)` to load
 its full body and follow it exactly: the body governs which tools to call and
 the output format, and anything typed after the name is its argument. Run the
-`help` command for the list, `list_commands` for saved ones, and the `start`
-prompt for a focused command session.
+`help` command for the list and `list_commands` for saved ones. When the client
+does not expose MCP prompts directly, call `invoke_prompt({ name, arguments? })`
+and follow the returned messages; use the `start` prompt for a focused command
+session.
 
 ## Core concepts
 

--- a/interfaces/mcp/src/prompts.rs
+++ b/interfaces/mcp/src/prompts.rs
@@ -252,6 +252,14 @@ mod tests {
     }
 
     #[test]
+    fn dashboard_command_supports_codex_and_claude_previews() {
+        let dashboard = builtin_command("dashboard").unwrap();
+        assert!(dashboard.body.contains("Codex in-app browser"));
+        assert!(dashboard.body.contains("Claude Preview"));
+        assert!(dashboard.body.contains("--bind 127.0.0.1"));
+    }
+
+    #[test]
     fn is_reserved_covers_start_and_builtins() {
         assert!(is_reserved("start"));
         assert!(is_reserved("dashboard"));

--- a/interfaces/mcp/src/server.rs
+++ b/interfaces/mcp/src/server.rs
@@ -12,6 +12,7 @@ use rmcp::service::{RequestContext, RoleServer};
 use rmcp::{ServerHandler, tool, tool_handler, tool_router};
 use schemars::JsonSchema;
 use serde::Deserialize;
+use serde_json::{Map, Value};
 
 use crate::commands::{CommandList, CommandStamp, UserCommand};
 use crate::ops::DobjOps;
@@ -81,6 +82,21 @@ impl<T: DobjOps> DobjMcpService<T> {
         }
         crate::prompts::builtin_command(name)
             .or_else(|| self.command_store().ok().and_then(|store| store.get(name)))
+    }
+
+    fn resolve_prompt(
+        &self,
+        name: &str,
+        arguments: Option<&Map<String, Value>>,
+    ) -> Option<GetPromptResult> {
+        if name == crate::prompts::START {
+            return Some(crate::prompts::start_result(
+                &self.list_commands_cached(),
+                arguments,
+            ));
+        }
+        self.resolve_command(name)
+            .map(|command| crate::prompts::command_result(&command, arguments))
     }
 
     /// The saved commands, served from an in-memory cache that refreshes only
@@ -182,6 +198,16 @@ pub struct DeleteCommandParams {
 pub struct GetCommandParams {
     /// The command name to load -- a built-in or a saved command.
     pub name: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct InvokePromptParams {
+    /// Prompt name, such as "start", "help", or the name of a saved command.
+    pub name: String,
+    /// Optional prompt arguments. `start` accepts `command`; all command
+    /// prompts accept `args`.
+    #[serde(default)]
+    pub arguments: Option<Map<String, Value>>,
 }
 
 // -- Tool implementations --
@@ -464,6 +490,18 @@ impl<T: DobjOps> DobjMcpService<T> {
             .map(Json)
             .ok_or_else(|| format!("no such command: {}", params.name))
     }
+
+    #[tool(
+        description = "Invoke an MCP prompt by name and return the exact prompt messages to follow. Use this in clients such as Codex that can call MCP tools but do not expose MCP prompts directly. Supports start, built-ins, and saved commands; pass optional arguments.command for start or arguments.args for a command."
+    )]
+    fn invoke_prompt(
+        &self,
+        Parameters(params): Parameters<InvokePromptParams>,
+    ) -> Result<Json<GetPromptResult>, String> {
+        self.resolve_prompt(&params.name, params.arguments.as_ref())
+            .map(Json)
+            .ok_or_else(|| format!("unknown prompt: {}", params.name))
+    }
 }
 
 // -- Instructions --
@@ -526,14 +564,8 @@ impl<T: DobjOps> ServerHandler for DobjMcpService<T> {
         request: GetPromptRequestParams,
         _context: RequestContext<RoleServer>,
     ) -> impl std::future::Future<Output = Result<GetPromptResult, McpError>> + Send + '_ {
-        let arguments = request.arguments.as_ref();
-        if request.name == crate::prompts::START {
-            let stored = self.list_commands_cached();
-            return std::future::ready(Ok(crate::prompts::start_result(&stored, arguments)));
-        }
         let result = self
-            .resolve_command(&request.name)
-            .map(|command| crate::prompts::command_result(&command, arguments))
+            .resolve_prompt(&request.name, request.arguments.as_ref())
             .ok_or_else(|| {
                 McpError::invalid_params(format!("unknown prompt: {}", request.name), None)
             });
@@ -586,7 +618,8 @@ mod tests {
         assert!(tools.contains(&"list_commands".to_string()));
         assert!(tools.contains(&"delete_command".to_string()));
         assert!(tools.contains(&"get_command".to_string()));
-        assert_eq!(tools.len(), 19);
+        assert!(tools.contains(&"invoke_prompt".to_string()));
+        assert_eq!(tools.len(), 20);
     }
 
     #[test]
@@ -607,6 +640,67 @@ mod tests {
         let service = make_service();
         let info = service.get_info();
         assert!(info.capabilities.prompts.is_some());
+    }
+
+    #[test]
+    fn test_invoke_start_prompt_with_first_command() {
+        let service = make_service();
+        let mut arguments = Map::new();
+        arguments.insert("command".to_string(), Value::String("help".to_string()));
+        let Json(result) = service
+            .invoke_prompt(Parameters(InvokePromptParams {
+                name: "start".to_string(),
+                arguments: Some(arguments),
+            }))
+            .unwrap();
+
+        assert_eq!(result.description.as_deref(), Some("Command session"));
+        assert_eq!(result.messages.len(), 3);
+        assert!(matches!(
+            &result.messages[2].content,
+            rmcp::model::PromptMessageContent::Text { text } if text == "First command: help"
+        ));
+    }
+
+    #[test]
+    fn test_invoke_saved_command_prompt_with_arguments() {
+        let dir = tempfile::tempdir().unwrap();
+        let service = make_service().with_command_dir(dir.path());
+        service
+            .define_command(Parameters(DefineCommandParams {
+                name: "stock-up".to_string(),
+                description: "gather raw materials".to_string(),
+                body: "run the mining actions".to_string(),
+            }))
+            .unwrap();
+        let mut arguments = Map::new();
+        arguments.insert("args".to_string(), Value::String("three times".to_string()));
+        let Json(result) = service
+            .invoke_prompt(Parameters(InvokePromptParams {
+                name: "stock-up".to_string(),
+                arguments: Some(arguments),
+            }))
+            .unwrap();
+
+        assert_eq!(result.description.as_deref(), Some("gather raw materials"));
+        assert_eq!(result.messages.len(), 2);
+        assert!(matches!(
+            &result.messages[1].content,
+            rmcp::model::PromptMessageContent::Text { text } if text == "Arguments: three times"
+        ));
+    }
+
+    #[test]
+    fn test_invoke_unknown_prompt_returns_error() {
+        let service = make_service();
+        let result = service.invoke_prompt(Parameters(InvokePromptParams {
+            name: "missing".to_string(),
+            arguments: None,
+        }));
+        match result {
+            Err(error) => assert_eq!(error, "unknown prompt: missing"),
+            Ok(_) => panic!("unknown prompt should return an error"),
+        }
     }
 
     #[test]


### PR DESCRIPTION
Add an invoke_prompt MCP tool for clients like Codex that support MCP tools but do not expose MCP prompts directly.

The tool supports start, built-in prompts, saved commands, and prompt arguments while sharing the existing native prompt-resolution path.

<img width="818" height="571" alt="image" src="https://github.com/user-attachments/assets/aa8736db-f83b-47fc-9dc8-4f7d44f8bab3" />
