### PR TITLE
Support mutating multiple objects and reading from mutated objects

### DIFF
--- a/libs/sdk/src/fmt_podlang.rs
+++ b/libs/sdk/src/fmt_podlang.rs
@@ -265,15 +265,20 @@ struct SubActionCall {
     /// `io` record
     sub_io_var: String,
     /// Script-side alias name (the `pick` in `var pick = action.subaction(...)`).
-    /// `None` if the user didn't bind via `var`. Used to skip the alias from
-    /// the parent's private wildcards list.
+    /// `None` if the user didn't bind via `var`. An alias referenced by
+    /// the parent body becomes a parent wildcard pinned to the sub's io
+    /// record; an unreferenced alias is skipped from the private
+    /// wildcards list.
     alias: Option<String>,
+    /// Name of the sub's first out entry, the one the alias refers to.
+    /// `None` if the sub produces nothing.
+    first_out_entry: Option<String>,
 }
 
 /// Walk the parent action's Insts and gather one `SubActionCall` per
 /// `Inst::SubAction`. Looks up each sub's record shape from the loader's
 /// `actions_meta`.
-fn collect_sub_action_calls(action: &ActionContext) -> Vec<SubActionCall> {
+fn collect_sub_action_calls(action: &ActionContext, loader: &Loader) -> Vec<SubActionCall> {
     let mut calls = Vec::new();
     let mut idx_counter: HashMap<String, usize> = HashMap::new();
     for inst in &action.insts {
@@ -294,11 +299,18 @@ fn collect_sub_action_calls(action: &ActionContext) -> Vec<SubActionCall> {
             } else {
                 Some(alias_name)
             };
+            let sub_meta = loader
+                .actions_meta
+                .iter()
+                .find(|m| m.name == *sub_name)
+                .expect("sub-action meta exists at fmt time");
+            let first_out_entry = sub_meta.out_entries.first().map(|e| e.varname.clone());
 
             calls.push(SubActionCall {
                 sub_name: sub_name.clone(),
                 sub_io_var,
                 alias,
+                first_out_entry,
             });
         }
     }
@@ -319,19 +331,24 @@ fn fmt_action(action: &ActionContext, loader: &Loader, w: &mut dyn fmt::Write) -
         .iter()
         .find(|m| m.name == action.name)
         .expect("ActionMeta exists at fmt time");
-    let sub_calls = collect_sub_action_calls(action);
+    let sub_calls = collect_sub_action_calls(action, loader);
 
     // ---- Signature ----
     write!(w, "{}(", action.name)?;
     write!(w, "io {}, ", schema_name_io(&action.name))?;
     write!(w, "state_header StateHeader, chain0, chain")?;
 
-    // Sub-action aliases: parent vars that hold a sub's first producing
-    // Object Ref. They're not real wildcards in the parent's predicate
-    // (the binding is structural to the script, not the proof) so we
-    // skip them from the private list.
-    let alias_names: std::collections::HashSet<String> =
-        sub_calls.iter().filter_map(|c| c.alias.clone()).collect();
+    // Sub-action aliases: parent vars that hold a sub's first out
+    // entry's Object Ref. A referenced alias becomes a real parent
+    // wildcard (pinned to the sub's io record by an ArrayContains
+    // clause below); an unreferenced alias is structural only and is
+    // skipped from the private list.
+    let referenced = crate::body_referenced_vars(&action.insts);
+    let alias_names: std::collections::HashSet<String> = sub_calls
+        .iter()
+        .filter_map(|c| c.alias.clone())
+        .filter(|alias| !referenced.contains(alias))
+        .collect();
 
     // Private wildcards: every (var, ts) except sub-action aliases, state_header, chain
     // endpoints (public chain0/chain), packed chain intermediates (anchored via the
@@ -429,6 +446,25 @@ fn fmt_action(action: &ActionContext, loader: &Loader, w: &mut dyn fmt::Write) -
                 fmt_var_at(&o.varname, max_ts, max_ts),
             )?;
         }
+    }
+    // Pin each referenced sub-action alias to its sub's first out
+    // entry.
+    for call in &sub_calls {
+        let Some(alias) = &call.alias else { continue };
+        if !referenced.contains(alias) {
+            continue;
+        }
+        let Some(entry) = &call.first_out_entry else {
+            continue;
+        };
+        writeln!(
+            w,
+            "  ArrayContains({}, {}::out_{}, {})",
+            call.sub_io_var,
+            schema_name_io(&call.sub_name),
+            entry,
+            fmt_var_at(alias, 0, meta.max_ts(alias)),
+        )?;
     }
 
     // ---- Body (Insts other than Object) ----

--- a/libs/sdk/src/lib.rs
+++ b/libs/sdk/src/lib.rs
@@ -153,11 +153,17 @@ enum Inst {
     /// statement is consumed here in the parent's post-Rhai walk.
     SubAction {
         action: String,
-        /// Aliases the sub-action's first producing object Ref so
-        /// parent scripts can bind it via `var foo = subaction(...)`.
+        /// Aliases the Ref of the sub-action's first produced object
+        /// so parent scripts can bind it via `var foo = subaction(...)`.
         obj: Ref,
         /// Sub-action's predicate statement. Some at Execute, None at Load.
         st_sub: Option<Statement>,
+        /// The sub-action's `io` record value, the aliased out entry's
+        /// slot in it, and that entry's dict, snapshotted before any
+        /// parent-side writes. Backs the ArrayContains clause that pins
+        /// the alias wildcard when the parent body references it. Some
+        /// at Execute when the sub produces an object, None otherwise.
+        sub_out: Option<(Value, i64, Dictionary)>,
     },
 }
 
@@ -578,8 +584,10 @@ impl ActionHandle {
     /// Open an action scope, run the action's rhai body, emit its
     /// txlib events, build its predicate, attach guards, and close
     /// the scope. Sub-actions invoked from the rhai body recurse here
-    /// and stack their scope on top of this one.
-    fn exe_action(&self) -> RuntimeResult<Statement> {
+    /// and stack their scope on top of this one. Returns the action's
+    /// predicate statement plus its io record, which `subaction` uses
+    /// to pin a referenced alias.
+    fn exe_action(&self) -> RuntimeResult<(Statement, Array)> {
         let (module, scope_id, action) = {
             let ctx = self.0.borrow();
             let exe_rc = ctx.exe_ctx.as_ref().expect("exe phase").clone();
@@ -754,6 +762,33 @@ impl ActionHandle {
                     }
                 }
             }
+            // Pin each referenced sub-action alias to its sub's first
+            // out entry, matching fmt_action's alias ArrayContains
+            // clause.
+            let referenced = body_referenced_vars(&ctx.insts);
+            for inst in &ctx.insts {
+                if let Inst::SubAction {
+                    obj,
+                    sub_out: Some((io_record, entry_idx, dict)),
+                    ..
+                } = inst
+                {
+                    let alias = obj.borrow().var_name().to_string();
+                    if alias == "?" || !referenced.contains(&alias) {
+                        continue;
+                    }
+                    let st = exe_ctx
+                        .bld
+                        .builder
+                        .priv_op(Operation::array_contains(
+                            io_record.clone(),
+                            *entry_idx,
+                            Value::from(dict.clone()),
+                        ))
+                        .unwrap();
+                    array_contains_sts.push(st);
+                }
+            }
         }
 
         // ---- Per-Object type guard + Tx event. Same order as
@@ -776,8 +811,13 @@ impl ActionHandle {
             post_ts: usize,
         }
         // Assign a parent_ts to each Object/SubAction inst (each one
-        // advances the parent chain by exactly 1, in inst-iteration
-        // order). Drives chain anchoring and the chain_steps record.
+        // advances the parent chain by exactly 1). Events are recorded
+        // in emission order, not declaration order: sub-actions run and
+        // emit during the parent's Rhai body, while direct Object events
+        // are emitted post-Rhai, so all SubAction insts occupy the chain
+        // ts range before all Object insts (each group in inst order).
+        // `fmt_action` renders the same order. Drives chain anchoring
+        // and the chain_steps record.
         let chain_max_ts = meta.chain_max_ts;
         // chain_step_values[ts - 1] holds the per-ts chain hash for each
         // intermediate ts in 1..chain_max_ts (the final ts is the public
@@ -789,17 +829,23 @@ impl ActionHandle {
             vec![Value::from(0_i64); chain_max_ts.saturating_sub(1)];
         let inst_chain_ts: Vec<Option<usize>> = {
             let ctx = self.0.borrow();
-            let mut chain_ts: usize = 0;
+            let num_subs = ctx
+                .insts
+                .iter()
+                .filter(|inst| matches!(inst, Inst::SubAction { .. }))
+                .count();
+            let mut sub_ts: usize = 0;
+            let mut obj_ts: usize = num_subs;
             ctx.insts
                 .iter()
                 .map(|inst| match inst {
                     Inst::Object { .. } => {
-                        chain_ts += 1;
-                        Some(chain_ts)
+                        obj_ts += 1;
+                        Some(obj_ts)
                     }
                     Inst::SubAction { st_sub, .. } => {
-                        chain_ts += 1;
-                        if let Some(slot) = fmt_podlang::chain_step_at(chain_ts, chain_max_ts) {
+                        sub_ts += 1;
+                        if let Some(slot) = fmt_podlang::chain_step_at(sub_ts, chain_max_ts) {
                             let st = st_sub
                                 .as_ref()
                                 .expect("SubAction statement captured at Rhai");
@@ -809,7 +855,7 @@ impl ActionHandle {
                             };
                             chain_step_values[slot] = post_chain;
                         }
-                        Some(chain_ts)
+                        Some(sub_ts)
                     }
                     _ => None,
                 })
@@ -1142,7 +1188,7 @@ impl ActionHandle {
             }
             exe_ctx.tx_builder.end_action(scope_id);
         }
-        Ok(st_action)
+        Ok((st_action, io_array))
     }
     //
     // Exposed methods helpers
@@ -1172,36 +1218,56 @@ impl ActionHandle {
     /// before this call returns. The sub-action's predicate statement
     /// is cached on the `Inst::SubAction` and composed into the
     /// parent's predicate during its post-Rhai body walk. The returned
-    /// `ArgHandle` aliases the sub's first producing object so parent
+    /// `ArgHandle` aliases the sub's first produced object so parent
     /// scripts can bind it via `var foo = subaction("X")`.
     fn subaction(self, action: String) -> RuntimeResult<ArgHandle> {
         let exe_rc_opt = self.0.borrow().exe_ctx.clone();
         let arg_placeholder = Rc::new(RefCell::new(VarOrValue::var(Type::Dict)));
 
-        let (arg, st_sub) = if let Some(exe_rc) = exe_rc_opt {
+        let (arg, st_sub, sub_out) = if let Some(exe_rc) = exe_rc_opt {
             let sub_handle = ActionHandle::new(action.clone(), Some(exe_rc.clone()));
-            let st_sub = sub_handle.exe_action()?;
+            let (st_sub, sub_io_array) = sub_handle.exe_action()?;
 
-            // Alias the parent's binding to the sub-action's first
-            // producing object Ref, or a fresh placeholder if the sub
+            // Alias the parent's binding to the Ref of the sub-action's
+            // first produced object, or a fresh placeholder if the sub
             // produces nothing.
-            let arg = sub_handle
-                .0
-                .borrow()
-                .insts
-                .iter()
-                .find_map(|i| match i {
-                    Inst::Object {
-                        io: ObjectIO::Output | ObjectIO::Mutate,
-                        obj,
-                        ..
-                    } => Some(obj.clone()),
+            let aliased: Option<(ObjectIO, Ref)> =
+                sub_handle.0.borrow().insts.iter().find_map(|i| match i {
+                    Inst::Object { io, obj, .. } if io.produces() => Some((*io, obj.clone())),
                     _ => None,
-                })
-                .unwrap_or_else(|| arg_placeholder.clone());
-            (arg, Some(st_sub))
+                });
+            let (arg, sub_out) = if let Some((io, obj)) = aliased {
+                let module = exe_rc.borrow().module.clone();
+                let sub_meta = module.action_by_name(&action);
+                let varname = obj.borrow().var_name().to_string();
+                let (entry_idx, _) = sub_meta
+                    .out_entry(&varname)
+                    .expect("produced object has an out entry");
+                let entry = sub_io_array
+                    .get(entry_idx)
+                    .expect("array op")
+                    .expect("sub io record has an entry per produced object");
+                // An Output's out entry is the post-identity dict, but
+                // the sub left its Ref at the pre-identity form; rebind
+                // so parent reads see the recorded form.
+                if io == ObjectIO::Output {
+                    obj.borrow_mut().set_value(entry.clone());
+                }
+                // The shared Ref still carries the sub's script-side
+                // var name; reset it so only a parent `var` binding
+                // names it (matching the Load-phase placeholder).
+                obj.borrow_mut().set_var_name("?".to_string())?;
+                let dict = entry.as_dictionary().expect("out entry is a dict");
+                (
+                    obj,
+                    Some((Value::from(sub_io_array), entry_idx as i64, dict)),
+                )
+            } else {
+                (arg_placeholder.clone(), None)
+            };
+            (arg, Some(st_sub), sub_out)
         } else {
-            (arg_placeholder, None)
+            (arg_placeholder, None, None)
         };
 
         let mut ctx = self.0.borrow_mut();
@@ -1209,6 +1275,7 @@ impl ActionHandle {
             action,
             obj: arg.clone(),
             st_sub,
+            sub_out,
         });
         ctx.inc_t_var("chain").expect("chain exists");
         Ok(ArgHandle::new(self.clone(), arg))
@@ -1732,6 +1799,7 @@ impl ActionMeta {
             var_max_ts: ctx.max_ts_per_var(),
             ..Self::default()
         };
+        let referenced = body_referenced_vars(&ctx.insts);
         for inst in &ctx.insts {
             match inst {
                 Inst::Object { io, obj, class, .. } => {
@@ -1748,11 +1816,17 @@ impl ActionMeta {
                     }
                     meta.object_refs.push(r);
                 }
-                Inst::SubAction { action, .. } => {
+                Inst::SubAction { action, obj, .. } => {
                     let sub = prior
                         .iter()
                         .find(|a| &a.name == action)
                         .ok_or_else(|| anyhow!("subaction {action} not defined"))?;
+                    let alias = obj.borrow().var_name().to_string();
+                    if alias != "?" && referenced.contains(&alias) && sub.out_entries.is_empty() {
+                        return Err(anyhow!(
+                            "subaction {action} produces no object; `{alias}` cannot be referenced in the parent body"
+                        ));
+                    }
                     meta.total_inputs.extend(sub.total_inputs.iter().cloned());
                     meta.total_outputs.extend(sub.total_outputs.iter().cloned());
                 }
@@ -1789,6 +1863,41 @@ impl ActionMeta {
         meta.initials_entries = (!output_names.is_empty() && !any_blocked).then_some(output_names);
         Ok(meta)
     }
+}
+
+/// Var names referenced by the action's body Insts: as a Statement or
+/// Intro arg, as a Set/Update value, or as a Set/Update target. Drives
+/// whether a sub-action alias must materialize as a parent wildcard
+/// pinned to the sub's out record; unreferenced aliases stay purely
+/// structural.
+pub(crate) fn body_referenced_vars(insts: &[Inst]) -> HashSet<String> {
+    fn add(referenced: &mut HashSet<String>, r: &Ref) {
+        if let VarOrValue::Var(var) = &*r.borrow() {
+            referenced.insert(var.name.clone());
+        }
+    }
+    let mut referenced = HashSet::new();
+    for inst in insts {
+        match inst {
+            Inst::Object { .. } | Inst::SubAction { .. } => {}
+            Inst::Update { obj, value, .. } => {
+                referenced.insert(obj.clone());
+                add(&mut referenced, value);
+            }
+            Inst::Set { obj, kvs, .. } => {
+                referenced.insert(obj.clone());
+                for (_key, value) in kvs {
+                    add(&mut referenced, value);
+                }
+            }
+            Inst::Statement { args, .. } | Inst::Intro { args, .. } => {
+                for arg in args {
+                    add(&mut referenced, arg);
+                }
+            }
+        }
+    }
+    referenced
 }
 
 /// An Object's in/out/initials form normally collapses into the matching

--- a/libs/sdk/src/tests.rs
+++ b/libs/sdk/src/tests.rs
@@ -518,6 +518,263 @@ IsFoo(state, state_header StateHeader, chain0, chain) = OR(
     );
 }
 
+/// Parent reads a value off the object mutated by a sub-action: the
+/// referenced alias becomes a parent wildcard pinned to the sub's
+/// first out entry.
+#[allow(clippy::cloned_ref_to_slice_refs)]
+#[test]
+fn test_subaction_alias_read_mutate() {
+    let _ = env_logger::builder().is_test(true).try_init();
+    let craft_src = r#"
+        fn LaunchProbe(action) {
+            var probe = action.output("Probe");
+            probe.set([["depth", 0]]);
+        }
+
+        fn Descend(action) {
+            var probe = action.mutate("Probe");
+            var depth = action.random();
+            probe.update("depth", depth);
+        }
+
+        fn SampleRock(action) {
+            var probe = action.subaction("Descend");
+            var rock = action.output("Rock");
+            rock.set([["found_at_depth", probe.depth]]);
+        }
+    "#;
+    let sdk = Sdk::default();
+    let module = sdk
+        .load_module_from_src_actions(craft_src, &["LaunchProbe", "Descend", "SampleRock"])
+        .unwrap();
+    println!("{}", module.podlang_src);
+
+    let mut state = TestState::default();
+
+    let executor = module.executor(true, grounding_witness(&state, &[]));
+    let res = executor.action("LaunchProbe", vec![]).unwrap();
+    let probe_tx = res.tx.clone();
+    let [probe] = res.objs();
+    apply_tx(&mut state, &probe_tx);
+
+    let executor = module.executor(true, grounding_witness(&state, &[probe.obj.commitment()]));
+    let res = executor.action("SampleRock", vec![probe]).unwrap();
+    let [_probe2, _rock] = res.objs();
+}
+
+/// Entry reads written into another object via set(): `fuel_before`
+/// reads the pre-mutation form (forces the in-side wildcard) and
+/// `fuel_after` the post-mutation form (forces the out-side wildcard).
+/// Both must be emitted as Contains-backed args, not literals, to
+/// match the rendered anchored-key templates.
+#[allow(clippy::cloned_ref_to_slice_refs)]
+#[test]
+fn test_cross_read_into_set() {
+    let _ = env_logger::builder().is_test(true).try_init();
+    let craft_src = r#"
+        fn SpawnTank(action) {
+            var tank = action.output("Tank");
+            tank.set([["fuel", 10]]);
+        }
+
+        fn DrawFuel(action) {
+            var tank = action.mutate("Tank");
+            var receipt = action.output("Receipt");
+            receipt.set([["fuel_before", tank.fuel]]);
+            var fuel = unsafe { tank.fuel - 1 };
+            action.st_sum(fuel, 1, tank.fuel);
+            tank.update("fuel", fuel);
+            receipt.set([["fuel_after", tank.fuel]]);
+        }
+    "#;
+    let sdk = Sdk::default();
+    let module = sdk
+        .load_module_from_src_actions(craft_src, &["SpawnTank", "DrawFuel"])
+        .unwrap();
+    println!("{}", module.podlang_src);
+
+    let mut state = TestState::default();
+
+    let executor = module.executor(true, grounding_witness(&state, &[]));
+    let res = executor.action("SpawnTank", vec![]).unwrap();
+    let tank_tx = res.tx.clone();
+    let [tank] = res.objs();
+    apply_tx(&mut state, &tank_tx);
+
+    let executor = module.executor(true, grounding_witness(&state, &[tank.obj.commitment()]));
+    let res = executor.action("DrawFuel", vec![tank]).unwrap();
+    let [_tank2, _receipt] = res.objs();
+}
+
+/// Direct objects declared before a subaction call, with enough events
+/// to pack the parent's chain record. Events are recorded sub-actions
+/// first (they run during Rhai; direct events are emitted post-Rhai),
+/// so chain-ts numbering must follow emission order, not declaration
+/// order.
+#[allow(clippy::cloned_ref_to_slice_refs)]
+#[test]
+fn test_packed_chain_objects_before_subaction() {
+    let _ = env_logger::builder().is_test(true).try_init();
+    let craft_src = r#"
+        fn SpawnShip(action) {
+            var ship = action.output("Ship");
+            ship.set([["fuel", 10]]);
+        }
+
+        fn BurnFuel(action) {
+            var ship = action.mutate("Ship");
+            var fuel = action.random();
+            ship.update("fuel", fuel);
+        }
+
+        fn MineTwoRocks(action) {
+            var rock_a = action.output("Rock");
+            var rock_b = action.output("Rock");
+            var ship = action.subaction("BurnFuel");
+        }
+    "#;
+    let sdk = Sdk::default();
+    let module = sdk
+        .load_module_from_src_actions(craft_src, &["SpawnShip", "BurnFuel", "MineTwoRocks"])
+        .unwrap();
+    println!("{}", module.podlang_src);
+
+    let mut state = TestState::default();
+
+    let executor = module.executor(true, grounding_witness(&state, &[]));
+    let res = executor.action("SpawnShip", vec![]).unwrap();
+    let ship_tx = res.tx.clone();
+    let [ship] = res.objs();
+    apply_tx(&mut state, &ship_tx);
+
+    let executor = module.executor(true, grounding_witness(&state, &[ship.obj.commitment()]));
+    let res = executor.action("MineTwoRocks", vec![ship]).unwrap();
+    let [_ship2, _rock_a, _rock_b] = res.objs();
+}
+
+/// Two mutations in one action where the second object's update()
+/// takes a value read off the first object, exercising the
+/// Contains-backed value arg on the DictUpdate path.
+#[allow(clippy::cloned_ref_to_slice_refs)]
+#[test]
+fn test_cross_read_into_update() {
+    let _ = env_logger::builder().is_test(true).try_init();
+    let craft_src = r#"
+        fn SpawnShip(action) {
+            var ship = action.output("Ship");
+            ship.set([["fuel", 10]]);
+        }
+
+        fn SpawnSector(action) {
+            var sector = action.output("Sector");
+            sector.set([["ship_fuel", 0]]);
+        }
+
+        fn EnterSector(action) {
+            var ship = action.mutate("Ship");
+            var sector = action.mutate("Sector");
+            var fuel = unsafe { ship.fuel - 1 };
+            action.st_sum(fuel, 1, ship.fuel);
+            ship.update("fuel", fuel);
+            sector.update("ship_fuel", ship.fuel);
+        }
+    "#;
+    let sdk = Sdk::default();
+    let module = sdk
+        .load_module_from_src_actions(craft_src, &["SpawnShip", "SpawnSector", "EnterSector"])
+        .unwrap();
+    println!("{}", module.podlang_src);
+
+    let mut state = TestState::default();
+
+    let executor = module.executor(true, grounding_witness(&state, &[]));
+    let res = executor.action("SpawnShip", vec![]).unwrap();
+    let ship_tx = res.tx.clone();
+    let [ship] = res.objs();
+    apply_tx(&mut state, &ship_tx);
+
+    let executor = module.executor(true, grounding_witness(&state, &[]));
+    let res = executor.action("SpawnSector", vec![]).unwrap();
+    let sector_tx = res.tx.clone();
+    let [sector] = res.objs();
+    apply_tx(&mut state, &sector_tx);
+
+    let executor = module.executor(
+        true,
+        grounding_witness(&state, &[ship.obj.commitment(), sector.obj.commitment()]),
+    );
+    let res = executor.action("EnterSector", vec![ship, sector]).unwrap();
+    let [_ship2, _sector2] = res.objs();
+}
+
+/// Parent reads values off an object created (not mutated) by a
+/// sub-action, exercising the post-identity rebinding of the alias.
+#[allow(clippy::cloned_ref_to_slice_refs)]
+#[test]
+fn test_subaction_alias_read_output() {
+    let _ = env_logger::builder().is_test(true).try_init();
+    let craft_src = r#"
+        fn SpawnShip(action) {
+            var ship = action.output("Ship");
+            ship.set([["fuel", 10]]);
+        }
+
+        fn ChristenShip(action) {
+            var ship = action.subaction("SpawnShip");
+            var plaque = action.output("Plaque");
+            plaque.set([["ship_fuel", ship.fuel], ["ship_id", ship.stable_identifier]]);
+        }
+    "#;
+    let sdk = Sdk::default();
+    let module = sdk
+        .load_module_from_src_actions(craft_src, &["SpawnShip", "ChristenShip"])
+        .unwrap();
+    println!("{}", module.podlang_src);
+
+    let state = TestState::default();
+
+    let executor = module.executor(true, grounding_witness(&state, &[]));
+    let res = executor.action("ChristenShip", vec![]).unwrap();
+    let [ship, plaque] = res.objs();
+    let ship_id = ship
+        .obj
+        .get(&StrKey::from("stable_identifier"))
+        .unwrap()
+        .unwrap();
+    let plaque_ship_id = plaque.obj.get(&StrKey::from("ship_id")).unwrap().unwrap();
+    assert_eq!(ship_id, plaque_ship_id);
+}
+
+/// A sub-action that produces no object has no out entry to pin an
+/// alias to, so a parent body that reads the alias must be rejected at
+/// module load.
+#[test]
+fn test_subaction_alias_no_output_rejected() {
+    let craft_src = r#"
+        fn BurnLog(action) {
+            var log = action.input("Log");
+        }
+
+        fn MineRock(action) {
+            var burned = action.subaction("BurnLog");
+            var rock = action.output("Rock");
+            rock.set([["seen", burned.kind]]);
+        }
+    "#;
+    let sdk = Sdk::default();
+    let result = sdk.load_module_from_src_actions(craft_src, &["BurnLog", "MineRock"]);
+    match result {
+        Ok(_) => panic!("expected load to reject referencing a no-output sub-action alias"),
+        Err(err) => {
+            let msg = err.to_string();
+            assert!(
+                msg.contains("cannot be referenced"),
+                "unexpected error: {msg}"
+            );
+        }
+    }
+}
+
 /// Class names go straight into qualified ids (`<plugin>::<class>`) and
 /// `.dobj` filename prefixes. The SDK refuses to compile a script that
 /// declares a class name outside the `[A-Za-z0-9_-]` allowlist so a


### PR DESCRIPTION
This adds SDK support for actions which mutate multiple objects, and for reading from mutated objects in sub-actions.

This does _not_ add support for reading from multiple objects, which seems likely to be needed in future but is not a current requirement (as far as we know).