### PR TITLE
Bump POD2 version and add pexe build logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6076,7 +6076,7 @@ dependencies = [
 [[package]]
 name = "pod2"
 version = "0.1.0"
-source = "git+https://github.com/0xPARC/pod2?rev=73810cbd5b57cd679e25dfad0c34968faec22767#73810cbd5b57cd679e25dfad0c34968faec22767"
+source = "git+https://github.com/0xPARC/pod2?rev=7bea7db462f8410a35a84ab5f3654f961557bb19#7bea7db462f8410a35a84ab5f3654f961557bb19"
 dependencies = [
  "annotate-snippets",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = [
 resolver = "2"
 
 [workspace.dependencies]
-pod2 = { git = "https://github.com/0xPARC/pod2", rev = "73810cbd5b57cd679e25dfad0c34968faec22767", default-features = false, features = [
+pod2 = { git = "https://github.com/0xPARC/pod2", rev = "7bea7db462f8410a35a84ab5f3654f961557bb19", default-features = false, features = [
     "backend_plonky2",
     "disk_cache",
     "zk",
@@ -65,8 +65,8 @@ thiserror = "2.0.18"
 wire-types = { path = "libs/wire-types" }
 
 # Uncomment to use a local pod2 dependency
-# [patch."https://github.com/0xPARC/pod2"]
-# pod2 = { path = "../pod2" }
+#[patch."https://github.com/0xPARC/pod2"]
+#pod2 = { path = "../pod2" }
 
 # Uncomment in order to enable debug information in the release builds.  This allows getting panic backtraces with a performance similar to regular release.
 # [profile.release]

--- a/libs/sdk/src/lib.rs
+++ b/libs/sdk/src/lib.rs
@@ -2024,7 +2024,13 @@ impl Loader {
 
     fn module(self, engine: Rc<Engine>, ast: AST) -> SdkModule {
         let mut podlang_src = String::new();
+        let started = std::time::Instant::now();
         fmt_podlang::fmt(&self, &mut podlang_src).unwrap();
+        log::debug!(
+            "podlang render: {:?} ({} bytes)",
+            started.elapsed(),
+            podlang_src.len()
+        );
 
         let params = Params::default();
         let module = Arc::new(
@@ -2608,8 +2614,11 @@ impl Sdk {
         actions: &[&str],
     ) -> Result<Rc<SdkModule>, SdkError> {
         let scope = Scope::new();
+        let started = std::time::Instant::now();
         let ast = self.engine.compile_with_scope(&scope, src).unwrap();
+        log::debug!("rhai compile: {:?}", started.elapsed());
 
+        let started = std::time::Instant::now();
         let mut action_handles = Vec::new();
         for action in actions {
             let action_handle = ActionHandle::new(action.to_string(), None);
@@ -2625,8 +2634,15 @@ impl Sdk {
             )?;
             action_handles.push(action_handle);
         }
+        log::debug!(
+            "rhai load-phase runs x{}: {:?}",
+            actions.len(),
+            started.elapsed()
+        );
 
+        let started = std::time::Instant::now();
         let loader = Loader::new(action_handles)?;
+        log::debug!("loader analysis: {:?}", started.elapsed());
         Ok(Rc::new(loader.module(self.engine.clone(), ast)))
     }
 


### PR DESCRIPTION
This bumps the POD2 version to pull in the better-performing version of the Podlang parser, and adds some logging to the `pexe build` process.